### PR TITLE
iOS: Fix test action picking the wrong scheme

### DIFF
--- a/ReactTestApp-DevSupport.podspec
+++ b/ReactTestApp-DevSupport.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 version = package['version']
 
 Pod::Spec.new do |s|
-  s.name      = 'ReactTestApp'
+  s.name      = 'ReactTestApp-DevSupport'
   s.version   = version
   s.author    = { package['author']['name'] => package['author']['email'] }
   s.license   = package['license']


### PR DESCRIPTION
Xcode picks the wrong scheme because there are two ReactTestApp schemes:
One is the test app itself (which we want), and the other is the Pod
that only contains public interfaces. The latter will eventually be
superseded by using native modules but for now, we will rename it to
avoid confusing Xcode.