### PR TITLE
Handling cases when dist/res folder is not provided

### DIFF
--- a/android/app/src/main/java/com/sample/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/sample/react/TestAppReactNativeHost.kt
@@ -13,9 +13,10 @@ class TestAppReactNativeHost @Inject constructor(
     private val reactBundleNameProvider: ReactBundleNameProvider
 ) : ReactNativeHost(application) {
 
-    override fun getBundleAssetName() = reactBundleNameProvider.bundleName
+    override fun getBundleAssetName() =
+        reactBundleNameProvider.bundleName ?: super.getBundleAssetName()
 
-    override fun getUseDeveloperSupport() = bundleAssetName != null
+    override fun getUseDeveloperSupport() = reactBundleNameProvider.bundleName == null
 
     override fun getPackages(): List<ReactPackage> = PackageList(application).packages
 }

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -22,7 +22,7 @@ ext.applyTestAppSettings = { DefaultSettings defaultSettings ->
 ext.applyTestAppModule = { Project project, String packageName ->
     applyNativeModulesAppBuildGradle(project, packageName)
 
-    def manifestFile = findFile("app.json")
+    def manifestFile = file("$rootDir/app.json")
     def manifest = new JsonSlurper().parseText(manifestFile.text)
 
     def resources = manifest["resources"]
@@ -37,9 +37,8 @@ ext.applyTestAppModule = { Project project, String packageName ->
             "to be either a list of paths, or must contain a nested list with the \"android\" key")
     }
 
-    def projectRoot = manifestFile.getParent()
     def androidResourceFiles = androidResources
-        .collect { file("$projectRoot/$it") }
+        .collect { file("$rootDir/$it") }
 
     def androidResDir = androidResourceFiles
         .find { it.isDirectory() && it.name == "res" }
@@ -62,12 +61,20 @@ ext.applyTestAppModule = { Project project, String packageName ->
 
     task copyResources(type: Copy) {
         if (androidResDir == null) {
-            throw new IllegalArgumentException(
-                "The res path for android must be present")
-        }
+            // If no resources are present in the path specified in the manifest, 
+            // the plugin has to fallback to copying at least the manifest itself 
+            // for the test-app to function. The resources, in this case, can be 
+            // served through the dev server. 
 
-        from androidResDir
-        into generatedResDir
+            def generatedRawDir = file("$generatedResDir/raw")
+            generatedRawDir.mkdirs()
+
+            from manifestFile
+            into generatedRawDir
+        } else {
+            from androidResDir
+            into generatedResDir
+        }        
     }
 
     preBuild.dependsOn(copyAssets)

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -22,7 +22,7 @@ ext.applyTestAppSettings = { DefaultSettings defaultSettings ->
 ext.applyTestAppModule = { Project project, String packageName ->
     applyNativeModulesAppBuildGradle(project, packageName)
 
-    def manifestFile = file("$rootDir/app.json")
+    def manifestFile = findFile("app.json")
     def manifest = new JsonSlurper().parseText(manifestFile.text)
 
     def resources = manifest["resources"]
@@ -37,8 +37,9 @@ ext.applyTestAppModule = { Project project, String packageName ->
             "to be either a list of paths, or must contain a nested list with the \"android\" key")
     }
 
+    def projectRoot = manifestFile.getParent()
     def androidResourceFiles = androidResources
-        .collect { file("$rootDir/$it") }
+        .collect { file("$projectRoot/$it") }
 
     def androidResDir = androidResourceFiles
         .find { it.isDirectory() && it.name == "res" }
@@ -61,10 +62,10 @@ ext.applyTestAppModule = { Project project, String packageName ->
 
     task copyResources(type: Copy) {
         if (androidResDir == null) {
-            // If no resources are present in the path specified in the manifest, 
-            // the plugin has to fallback to copying at least the manifest itself 
-            // for the test-app to function. The resources, in this case, can be 
-            // served through the dev server. 
+            // If no resources are present in the path specified in the manifest,
+            // the plugin has to fallback to copying at least the manifest itself
+            // for the test-app to function. The resources, in this case, can be
+            // served through the dev server.
 
             def generatedRawDir = file("$generatedResDir/raw")
             generatedRawDir.mkdirs()
@@ -74,7 +75,7 @@ ext.applyTestAppModule = { Project project, String packageName ->
         } else {
             from androidResDir
             into generatedResDir
-        }        
+        }
     }
 
     preBuild.dependsOn(copyAssets)


### PR DESCRIPTION
When serving assets only through the dev server, resource folders are not generated. This PR enables the dev server flow by making the resource folder to be optional, and copying the manifest file directly from the library root where it is defined to the test app. 