### PR TITLE
Android: Set the back button behaviour to default

### DIFF
--- a/android/app/src/main/java/com/sample/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/sample/component/ComponentActivity.kt
@@ -74,6 +74,10 @@ class ComponentActivity : ReactActivity() {
         return super.getSystemService(name)
     }
 
+    override fun onBackPressed() {
+        super.invokeDefaultOnBackPressed()
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 

--- a/android/app/src/main/java/com/sample/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/sample/component/ComponentActivity.kt
@@ -74,10 +74,12 @@ class ComponentActivity : ReactActivity() {
         return super.getSystemService(name)
     }
 
+    // TODO: https://github.com/microsoft/react-native-test-app/issues/51
     override fun onBackPressed() {
         super.invokeDefaultOnBackPressed()
     }
 
+    // TODO: https://github.com/microsoft/react-native-test-app/issues/51
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 


### PR DESCRIPTION
Override the default behaviour of the `ReactActivity` to support `onBackPressed` events within fragments. This is a temporary solution that will be followed by a proper fix described in: https://github.com/microsoft/react-native-test-app/issues/51