### PR TITLE
Don't run ESLint on YAML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "format:c": "clang-format -i $(git ls-files '*.h' '*.m' '*.mm')",
     "format:js": "prettier --write $(git ls-files '*.js' '*.yml')",
-    "lint:js": "eslint $(git ls-files '*.js' '*.yml')"
+    "lint:js": "eslint $(git ls-files '*.js')"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Even though Prettier supports YAML files, ESLint doesn't. This simply
generates warnings during CI builds.