### PR TITLE
fix(android): copy the manifest file on android regardless of the res folder

### DIFF
--- a/test-app.gradle
+++ b/test-app.gradle
@@ -60,24 +60,20 @@ ext.applyTestAppModule = { Project project, String packageName ->
         into generatedAssetsDir
     }
 
-    task copyResources(type: Copy) {
-        if (androidResDir == null) {
-            // If no resources are present in the path specified in the manifest,
-            // the plugin has to fallback to copying at least the manifest itself
-            // for the test-app to function. The resources, in this case, can be
-            // served through the dev server.
+    task copyManifest(type: Copy) {
+        def generatedRawDir = file("$generatedResDir/raw")
+        generatedRawDir.mkdirs()
 
-            def generatedRawDir = file("$generatedResDir/raw")
-            generatedRawDir.mkdirs()
-
-            from manifestFile
-            into generatedRawDir
-        } else {
-            from androidResDir
-            into generatedResDir
-        }
+        from manifestFile
+        into generatedRawDir
     }
 
+    task copyResources(type: Copy) {
+        from androidResDir
+        into generatedResDir
+    }
+
+    preBuild.dependsOn(copyManifest)
     preBuild.dependsOn(copyAssets)
     preBuild.dependsOn(copyResources)
 


### PR DESCRIPTION
Copy the manifest from the project root folder to the generated resources regardless of the res folder generated by bundler. 