### PR TITLE
Revert "ci: Update and commit `Podfile.lock` [skip ci] (#85)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,12 +202,6 @@ jobs:
           node-version: 12
       - name: Install
         run: |
-          yarn link
-          pushd example 1> /dev/null
-          yarn
-          yarn link react-native-test-app
-          pod install --project-directory=ios
-          popd 1> /dev/null
           yarn
       - name: Release
         env:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
           "assets": [
             "example/ios/Podfile.lock",
+            "example/yarn.lock",
             "package.json"
           ]
         }


### PR DESCRIPTION
Version bump happens at a later stage so running `pod install` before
release only makes the job slower.

This reverts commit b79fcb773f8fa20d32fffafd6d6c09ce6037fc37.