### PR TITLE
Add preliminary support for 0.62

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,8 +10,8 @@
     "start:macos": "react-native start --config=metro.config.macos.js"
   },
   "peerDependencies": {
-    "react": "~16.8.6 || ~16.9.0",
-    "react-native": "^0.60.6 || ^0.61.5",
+    "react": "~16.8.6 || ~16.9.0 || ~16.11.0",
+    "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2",
     "react-native-macos": "^0.60 || ^0.61.39"
   },
   "devDependencies": {

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -93,6 +93,7 @@ def resources_pod(project_root, target_platform)
   Pathname.new(app_dir).relative_path_from(project_root).to_s
 end
 
+# rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 def use_react_native!(project_root, target_platform)
   react_native = Pathname.new(resolve_module('react-native'))
   version = package_version(react_native.to_s)
@@ -101,6 +102,8 @@ def use_react_native!(project_root, target_platform)
     require_relative('use_react_native-0.60')
   elsif version[:major] == '0' && version[:minor] == '61'
     require_relative('use_react_native-0.61')
+  elsif version[:major] == '0' && version[:minor] == '62'
+    require_relative('use_react_native-0.62')
   else
     raise "Unsupported React Native version: #{version[0]}"
   end
@@ -109,6 +112,7 @@ def use_react_native!(project_root, target_platform)
                         target_platform,
                         project_root)
 end
+# rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 
 def make_project!(xcodeproj, project_root, target_platform)
   src_xcodeproj = File.join(__dir__, '..', target_platform.to_s, xcodeproj)

--- a/ios/use_react_native-0.62.rb
+++ b/ios/use_react_native-0.62.rb
@@ -1,0 +1,42 @@
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# rubocop:disable Layout/LineLength
+
+def include_react_native!(react_native, _target_platform, _project_root)
+  pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "#{react_native}/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "#{react_native}/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "#{react_native}/Libraries/TypeSafety"
+  pod 'React', :path => "#{react_native}/"
+  pod 'React-Core', :path => "#{react_native}/", :inhibit_warnings => true
+  pod 'React-CoreModules', :path => "#{react_native}/React/CoreModules"
+  pod 'React-Core/DevSupport', :path => "#{react_native}/"
+  pod 'React-RCTActionSheet', :path => "#{react_native}/Libraries/ActionSheetIOS"
+  pod 'React-RCTAnimation', :path => "#{react_native}/Libraries/NativeAnimation"
+  pod 'React-RCTBlob', :path => "#{react_native}/Libraries/Blob"
+  pod 'React-RCTImage', :path => "#{react_native}/Libraries/Image"
+  pod 'React-RCTLinking', :path => "#{react_native}/Libraries/LinkingIOS"
+  pod 'React-RCTNetwork', :path => "#{react_native}/Libraries/Network"
+  pod 'React-RCTSettings', :path => "#{react_native}/Libraries/Settings"
+  pod 'React-RCTText', :path => "#{react_native}/Libraries/Text", :inhibit_warnings => true
+  pod 'React-RCTVibration', :path => "#{react_native}/Libraries/Vibration"
+  pod 'React-Core/RCTWebSocket', :path => "#{react_native}/"
+
+  pod 'React-cxxreact', :path => "#{react_native}/ReactCommon/cxxreact", :inhibit_warnings => true
+  pod 'React-jsi', :path => "#{react_native}/ReactCommon/jsi"
+  pod 'React-jsiexecutor', :path => "#{react_native}/ReactCommon/jsiexecutor"
+  pod 'React-jsinspector', :path => "#{react_native}/ReactCommon/jsinspector"
+  pod 'ReactCommon/callinvoker', :path => "#{react_native}/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "#{react_native}/ReactCommon"
+  pod 'Yoga', :path => "#{react_native}/ReactCommon/yoga", :modular_headers => true
+
+  pod 'DoubleConversion', :podspec => "#{react_native}/third-party-podspecs/DoubleConversion.podspec"
+  pod 'glog', :podspec => "#{react_native}/third-party-podspecs/glog.podspec"
+  pod 'Folly', :podspec => "#{react_native}/third-party-podspecs/Folly.podspec"
+end
+
+# rubocop:enable Layout/LineLength

--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
     "plop": "^2.6.0"
   },
   "peerDependencies": {
-    "react": "~16.8.6 || ~16.9.0",
-    "react-native": "^0.60.6 || ^0.61.5",
+    "react": "~16.8.6 || ~16.9.0 || ~16.11.0",
+    "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2",
     "react-native-macos": "^0.60 || ^0.61.39"
   },
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",
     "eslint": "^6.8.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "2.0.4",
+    "eslint-plugin-prettier": "^3.1.3",
+    "prettier": "2.0.5",
     "react": "16.9.0",
     "react-native": "0.61.5",
     "react-native-macos": "0.61.39",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,10 +2856,10 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-plugin-prettier@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
-  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+eslint-plugin-prettier@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz#ae116a0fc0e598fdae48743a4430903de5b4e6ca"
+  integrity sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -6715,10 +6715,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
-  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
+prettier@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
@@ -7498,9 +7498,9 @@ scheduler@0.15.0:
     object-assign "^4.1.1"
 
 semantic-release@^17.0.0:
-  version "17.0.7"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-17.0.7.tgz#03792bf6e1a9ad2353dfd0da6a5d5511fa672b06"
-  integrity sha512-F6FzJI1yiGavzCTXir4yPthK/iozZPJ4myUYndiHhSHbmOcCSJ2m7V+P6sFwVpDpQKQp1Q31M68sTJ/Q/27Bow==
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-17.0.8.tgz#68b80461fdd8eb445228ae23fd9e85857a50ae3f"
+  integrity sha512-9KcdidiJ4xchrJXxPdaDQVlybgX0xTeKyVjRySYk5u9GpjibXD7E5F8cB0BvFLMDmMyrkCwcem0kFiaLD2VNPg==
   dependencies:
     "@semantic-release/commit-analyzer" "^8.0.0"
     "@semantic-release/error" "^2.2.0"


### PR DESCRIPTION
Android and iOS on React Native 0.62 both work after this commit. We're
still missing a way for people to enable Flipper (#112) and we're
waiting on RN for macOS to release 0.62.

Resolves #110