### PR TITLE
fix(macOS): macOS target should be optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@react-native-community/cli": "^3.0.0",
     "@react-native-community/cli-platform-android": "^3.0.0",
     "@react-native-community/cli-platform-ios": "^3.0.0",
+    "chalk":"^1.1.3",
     "plop": "^2.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Projects that don't care for `react-native-macos` shouldn't have to install it just to run `plop`. Now we should get a warning instead, and none of the macOS specific commands/files:

```
% yarn plop --dest template-example TemplateExample all
yarn run v1.22.4
⠋ [WARN] Cannot find module 'react-native-macos'; skipping macOS target
✔  ++ /.watchmanconfig
✔  ++ /App.js
✔  ++ /app.json
✔  ++ /babel.config.js
✔  ++ /index.js
✔  ++ /metro.config.js
✔  ++ /package.json
✔  ++ /react-native.config.js
✔  ++ /android/gradle/wrapper/gradle-wrapper.jar
✔  ++ /android/gradle/wrapper/gradle-wrapper.properties
✔  ++ /android/gradle.properties
✔  ++ /android/gradlew
✔  ++ /android/gradlew.bat
✔  ++ /android/settings.gradle
✔  ++ /ios/Podfile
```