### PR TITLE
ci: Use Node 12 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: CocoaPods
         run: |
           bundle install
@@ -34,6 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install
         run: |
           yarn
@@ -59,6 +67,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install
         run: scripts/install-test-template.sh ${{ matrix.template }}
       - name: Build
@@ -150,6 +162,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install
         run: |
           yarn
@@ -171,6 +187,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install
         run: scripts/install-test-template.sh ${{ matrix.template }}
       - name: Build


### PR DESCRIPTION
This should fix builds randomly failing with `Assertion failed:
(!uv__is_closing(handle)), function uv_close, file
../deps/uv/src/unix/core.c, line 113.`