### PR TITLE
fix: Enable Flipper by default when on 0.62+

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ apply from: file("${testAppDir}/test-app.gradle")
 applyTestAppModule(project, "com.sample")
 
 project.ext.react = [
-  enableFlipper: hasProperty('FLIPPER_VERSION'),
+  enableFlipper: getFlipperVersion(rootDir),
   enableHermes: true,
 ]
 
@@ -104,13 +104,14 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
 
     if (project.ext.react.enableFlipper) {
-        debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+        def flipperVersion = project.ext.react.enableFlipper
+        debugImplementation("com.facebook.flipper:flipper:${flipperVersion}") {
             exclude group:'com.facebook.fbjni'
         }
-        debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${flipperVersion}") {
             exclude group:'com.facebook.flipper'
         }
-        debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        debugImplementation("com.facebook.flipper:flipper-network-plugin:${flipperVersion}") {
             exclude group:'com.facebook.flipper'
         }
     }

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -51,3 +51,25 @@ ext.findNodeModulesPath = { baseDir, packageName ->
 
     return null
 }
+
+ext.getFlipperVersion = { baseDir ->
+    def reactNativePath = findNodeModulesPath(baseDir, 'react-native')
+    def props = new Properties()
+    file("${reactNativePath}/template/android/gradle.properties").withInputStream {
+        props.load(it)
+    }
+
+    def recommendedFlipperVersion = props.getProperty('FLIPPER_VERSION')
+    if (recommendedFlipperVersion == null) {
+        // Current React Native version doesn't support Flipper
+        return null
+    }
+
+    // Prefer user specified Flipper version
+    if (project.hasProperty('FLIPPER_VERSION')) {
+        return project.getProperty('FLIPPER_VERSION')
+    }
+
+    // Use the recommended Flipper version
+    return recommendedFlipperVersion
+}

--- a/ios/use_react_native-0.60.rb
+++ b/ios/use_react_native-0.60.rb
@@ -6,7 +6,7 @@
 #
 # rubocop:disable Layout/LineLength
 
-def include_react_native!(react_native:, target_platform:, project_root:, use_flipper:)
+def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
   react_native = "#{react_native}-macos" if target_platform == :macos
 
   pod 'React', :path => react_native

--- a/ios/use_react_native-0.61.rb
+++ b/ios/use_react_native-0.61.rb
@@ -6,7 +6,7 @@
 #
 # rubocop:disable Layout/LineLength
 
-def include_react_native!(react_native:, target_platform:, project_root:, use_flipper:)
+def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
   react_native = "#{react_native}-macos" if target_platform == :macos
 
   pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"

--- a/ios/use_react_native-0.62.rb
+++ b/ios/use_react_native-0.62.rb
@@ -38,8 +38,8 @@ def add_flipper_pods!(versions = {})
   pod 'FlipperKit/FlipperKitNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
 end
 
-def include_react_native!(react_native:, target_platform:, project_root:, use_flipper:)
-  add_flipper_pods!(use_flipper) if use_flipper
+def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
+  add_flipper_pods!(flipper_versions) if target_platform == :ios && flipper_versions
 
   pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "#{react_native}/Libraries/FBReactNativeSpec"


### PR DESCRIPTION
Resolves #124

### Test Plan

1. On React Native 0.60 and 0.61, Flipper should remain off even if it's been explicitly turned on
2. On React Native 0.62, Flipper should be enabled with the recommended versions if unspecified
3. On React Native 0.62, enabling Flipper with specific versions should override the recommended versions
4. On React Native 0.62, it is possible to disable Flipper by specifying `false`, i.e. `FLIPPER_VERSION=false` or `use_flipper!(false)`