### PR TITLE
fix(iOS): Flipper is still built when disabled

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -118,7 +118,7 @@ def use_react_native!(project_root, target_platform)
   include_react_native!(react_native: react_native.relative_path_from(project_root).to_s,
                         target_platform: target_platform,
                         project_root: project_root,
-                        flipper_versions: @flipper_versions || {})
+                        flipper_versions: @flipper_versions != false && (@flipper_versions || {}))
 end
 
 def make_project!(xcodeproj, project_root, target_platform)


### PR DESCRIPTION
### Test Plan

1. Bump to 0.62
    ```diff
    diff --git a/example/package.json b/example/package.json
    index f245bf9..80824e0 100644
    --- a/example/package.json
    +++ b/example/package.json
    @@ -17,9 +17,8 @@
       "devDependencies": {
         "@babel/core": "^7.0.0",
         "mkdirp": "^0.5.1",
    -    "react": "16.9.0",
    -    "react-native": "0.61.5",
    -    "react-native-macos": "0.61.39",
    +    "react": "16.11.0",
    +    "react-native": "0.62.2",
         "react-native-test-app": "../"
       }
     }
    ```
2. Run `yarn && pod install --project-directory=ios`
3. Observe that Flipper gets included
4. Disable Flipper
    ```diff
    diff --git a/example/ios/Podfile b/example/ios/Podfile
    index 59f8153..953899c 100644
    --- a/example/ios/Podfile
    +++ b/example/ios/Podfile
    @@ -2,6 +2,7 @@ require_relative '../node_modules/react-native-test-app/test_app.rb'

     workspace 'Example.xcworkspace'

    +use_flipper!(false)
     use_test_app! do |target|
       target.tests do
         pod 'Example-Tests', :path => '..'
    ```
5. `pod install --project-directory=ios`
6. Observe that Flipper is removed