### PR TITLE
fix(iOS): Add URI schemes to support MSAL

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -353,7 +353,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactTestApp-DevSupport: 1aee56d5c69fe4a4f4d5be0cbd3f22f5326d70fd
-  ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
+  ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/ios/ReactTestApp/Info.plist
+++ b/ios/ReactTestApp/Info.plist
@@ -16,6 +16,15 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>msauth.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -24,6 +33,7 @@
 		<string>ms-outlook</string>
 		<string>ms-sfb</string>
 		<string>msauth</string>
+		<string>msauthv2</string>
 		<string>msauthv3</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -91,9 +91,7 @@ def resources_pod(project_root, target_platform)
   app_manifest = find_file('app.json', project_root)
   return if app_manifest.nil?
 
-  manifest_resources = resolve_resources(JSON.parse(File.read(app_manifest)), target_platform)
-  resources = ['app.json'] + (manifest_resources.instance_of?(Array) ? manifest_resources : [])
-
+  resources = resolve_resources(JSON.parse(File.read(app_manifest)), target_platform)
   spec = {
     'name' => 'ReactTestApp-Resources',
     'version' => '1.0.0-dev',
@@ -106,7 +104,7 @@ def resources_pod(project_root, target_platform)
       'ios' => '12.0',
       'osx' => '10.14',
     },
-    'resources' => resources,
+    'resources' => ['app.json', *resources],
   }
 
   app_dir = File.dirname(app_manifest)


### PR DESCRIPTION
As documented here: https://github.com/AzureAD/microsoft-authentication-library-for-objc#ios-only-steps