### PR TITLE
ci: Cache node_modules folder to reduce hitting ESOCKETTIMEDOUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: project-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: CocoaPods
         run: |
           bundle install
@@ -42,6 +47,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: example/node_modules
+          key: example-${{ runner.os }}-${{ hashFiles('example/yarn.lock') }}
       - name: Install
         run: |
           yarn
@@ -107,6 +117,11 @@ jobs:
           # Node version helps to workaround this problem:
           # https://github.com/facebook/react-native/issues/26598
           node-version: 12.9.1
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: example/node_modules
+          key: example-${{ runner.os }}-${{ hashFiles('example/yarn.lock') }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Install
@@ -166,6 +181,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: example/node_modules
+          key: example-${{ runner.os }}-${{ hashFiles('example/yarn.lock') }}
       - name: Install
         run: |
           yarn
@@ -229,6 +249,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: project-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: |
           yarn


### PR DESCRIPTION
It's not enabled on _template_ builds (yet), but will at least ensure that the last build job doesn't fail on some random network failure during install.

**Bonus:** It's actually faster in some cases too. Compared to a  [random build](https://github.com/microsoft/react-native-test-app/runs/841420113?check_suite_focus=true):
| Build | Before | After |
|:-|-:|-:|
| lint + test | 3m 26s | 52s |
| iOS | 9m 8s | 6m 19s |
| Android (macos-latest) | 6m 9s | 4m 59s |
| Android (windows-latest) | 8m 28s | 7m 27s |
| macOS | 8m 20s | 6m 47ms |
| release | 1m 26s | 27s |