### PR TITLE
fix: Support custom application identifier

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,6 +35,7 @@ apply from: file("${testAppDir}/test-app.gradle")
 applyTestAppModule(project, "com.react.testapp")
 
 project.ext.react = [
+    applicationId: getApplicationId(),
     enableFlipper: getFlipperVersion(rootDir),
     enableHermes: true,
 ]
@@ -51,7 +52,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.react.testapp"
+        applicationId project.ext.react.applicationId
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -57,6 +57,14 @@ ext.findNodeModulesPath = { baseDir, packageName ->
     return null
 }
 
+ext.getApplicationId = {
+    if (project.hasProperty('TEST_APP_IDENTIFIER')) {
+        return project.getProperty('TEST_APP_IDENTIFIER')
+    }
+
+    return 'com.react.testapp'
+}
+
 ext.getFlipperVersion = { baseDir ->
     def reactNativePath = findNodeModulesPath(baseDir, 'react-native')
     def props = new Properties()

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -123,6 +123,12 @@ def resources_pod(project_root, target_platform)
   Pathname.new(app_dir).relative_path_from(project_root).to_s
 end
 
+# rubocop:disable Style/TrivialAccessors
+def test_app_bundle_identifier(identifier)
+  @test_app_bundle_identifier = identifier
+end
+# rubocop:enable Style/TrivialAccessors
+
 def use_flipper!(versions = {})
   @flipper_versions = versions
 end
@@ -178,6 +184,10 @@ def make_project!(xcodeproj, project_root, target_platform)
         'FB_SONARKIT_ENABLED=' + (use_flipper ? '1' : '0'),
         'USE_FLIPPER=' + (use_flipper ? '1' : '0'),
       ]
+
+      if @test_app_bundle_identifier.is_a? String
+        config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = @test_app_bundle_identifier
+      end
 
       next unless use_flipper
 


### PR DESCRIPTION
Resolves #140 

### Test Plan

1. Apply the patch below
2. Build Android/iOS/macOS apps
3. Verify that the application/bundle id is set to `com.contoso.MyTestApp`

```diff
diff --git a/example/android/gradle.properties b/example/android/gradle.properties
index 08bd26e..02b8080 100644
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,5 @@
 # These properties are required to enable AndroidX for the test app.
 android.useAndroidX=true
 android.enableJetifier=true
+
+TEST_APP_IDENTIFIER=com.contoso.MyTestApp
diff --git a/example/ios/Podfile b/example/ios/Podfile
index 59f8153..72aec64 100644
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,6 +1,7 @@
 require_relative '../node_modules/react-native-test-app/test_app.rb'

 workspace 'Example.xcworkspace'
+test_app_bundle_identifier 'com.contoso.MyTestApp'

 use_test_app! do |target|
   target.tests do
diff --git a/example/macos/Podfile b/example/macos/Podfile
index 91a46da..abec4b8 100644
--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -1,6 +1,7 @@
 require_relative '../node_modules/react-native-test-app/macos/test_app.rb'

 workspace 'Example.xcworkspace'
+test_app_bundle_identifier 'com.contoso.MyTestApp'

 use_test_app! do |target|
   target.tests do
```

#### Android

```
% adb shell 'pm list packages -f' | grep contoso
package:/data/app/com.contoso.MyTestApp-lGagASJYZMeA8zqIMXmKvA==/base.apk=com.contoso.MyTestApp
```

#### iOS/macOS

<img width="874" alt="image" src="https://user-images.githubusercontent.com/4123478/86757901-c2b1de80-c043-11ea-8fb5-82e219ef5aba.png">
