### PR TITLE
fix(iOS): Tests fail to compile when Flipper is enabled

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -271,14 +271,14 @@ class ReactTestAppTargets
 
   def tests
     @podfile.target 'ReactTestAppTests' do
-      @podfile.inherit! :search_paths
+      @podfile.inherit! :complete
       yield if block_given?
     end
   end
 
   def ui_tests
     @podfile.target 'ReactTestAppUITests' do
-      @podfile.inherit! :search_paths
+      @podfile.inherit! :complete
       yield if block_given?
     end
   end


### PR DESCRIPTION
Changed from `:search_paths` to `:complete` so React binaries are also linked with the test targets. Otherwise, tests targets will fail to link due to missing symbols.