### PR TITLE
refactor: Reuse result element when parsing manifest

### DIFF
--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -6,8 +6,7 @@
 #include "MainPage.g.cpp"
 #include "Manifest.h"
 
-using namespace winrt;
-using namespace Windows::UI::Xaml;
+using winrt::Windows::Foundation::Collections::IVector;
 
 namespace winrt::ReactTestApp::implementation
 {
@@ -16,16 +15,15 @@ namespace winrt::ReactTestApp::implementation
         InitializeComponent();
     }
 
-    Windows::Foundation::Collections::IVector<ReactTestApp::ComponentViewModel>
-    MainPage::Components()
+    IVector<ReactTestApp::ComponentViewModel> MainPage::Components()
     {
-        Windows::Foundation::Collections::IVector<ReactTestApp::ComponentViewModel> components =
+        IVector<ReactTestApp::ComponentViewModel> components =
             winrt::single_threaded_observable_vector<ReactTestApp::ComponentViewModel>();
 
-        for (auto &&c : GetManifest().components) {
+        for (auto &&c : ::ReactTestApp::GetManifest().components) {
             hstring componentName = to_hstring(c.displayName.value_or(c.appKey));
             ReactTestApp::ComponentViewModel newComponent =
-                winrt::make<ReactTestApp::implementation::ComponentViewModel>((componentName));
+                winrt::make<ComponentViewModel>(componentName);
             components.Append(newComponent);
         }
 

--- a/windows/ReactTestApp/Manifest.cpp
+++ b/windows/ReactTestApp/Manifest.cpp
@@ -4,21 +4,26 @@
 
 #include <fstream>
 #include <iostream>
+
 #include <nlohmann/json.hpp>
 
-namespace winrt::ReactTestApp::implementation
+namespace
 {
     template <typename T>
     std::optional<T> get_optional(const nlohmann::json &j, const std::string &key)
     {
-        if (j.find(key) != j.end()) {
-            return j.at(key).get<T>();
+        auto element = j.find(key);
+        if (element != j.end()) {
+            return element->get<T>();
         } else {
             return std::nullopt;
         }
     }
+}  // namespace
 
-    inline void from_json(const nlohmann::json &j, Component &c)
+namespace ReactTestApp
+{
+    void from_json(const nlohmann::json &j, Component &c)
     {
         c.appKey = j.at("appKey");
         c.displayName = get_optional<std::string>(j, "displayName");
@@ -26,7 +31,7 @@ namespace winrt::ReactTestApp::implementation
             get_optional<std::map<std::string, std::string>>(j, "initialProperties");
     }
 
-    inline void from_json(const nlohmann::json &j, Manifest &m)
+    void from_json(const nlohmann::json &j, Manifest &m)
     {
         m.name = j.at("name");
         m.displayName = j.at("displayName");
@@ -41,4 +46,4 @@ namespace winrt::ReactTestApp::implementation
         Manifest m = j.get<Manifest>();
         return m;
     }
-}  // namespace winrt::ReactTestApp::implementation
+}  // namespace ReactTestApp

--- a/windows/ReactTestApp/Manifest.h
+++ b/windows/ReactTestApp/Manifest.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace winrt::ReactTestApp::implementation
+namespace ReactTestApp
 {
     struct Component {
         std::string appKey;
@@ -21,4 +21,4 @@ namespace winrt::ReactTestApp::implementation
 
     Manifest GetManifest();
 
-}  // namespace winrt::ReactTestApp::implementation
+}  // namespace ReactTestApp

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -1,194 +1,194 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" />
-    <PropertyGroup Label="Globals">
-        <CppWinRTOptimized>true</CppWinRTOptimized>
-        <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-        <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
-        <MinimalCoreWin>true</MinimalCoreWin>
-        <ProjectGuid>{b44cead7-fbff-4a17-95ea-ff5434bbd79d}</ProjectGuid>
-        <ProjectName>ReactTestApp</ProjectName>
-        <RootNamespace>ReactTestApp</RootNamespace>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
-        <AppContainerApplication>true</AppContainerApplication>
-        <ApplicationType>Windows Store</ApplicationType>
-        <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-        <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
-        <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{b44cead7-fbff-4a17-95ea-ff5434bbd79d}</ProjectGuid>
+    <ProjectName>ReactTestApp</ProjectName>
+    <RootNamespace>ReactTestApp</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
+      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="ComponentViewModel.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="Manifest.h" />
+    <ClInclude Include="App.h">
+      <DependentUpon>App.xaml</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MainPage.h">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Assets\LockScreenLogo.scale-200.png" />
+    <Image Include="Assets\SplashScreen.scale-200.png" />
+    <Image Include="Assets\Square150x150Logo.scale-200.png" />
+    <Image Include="Assets\Square44x44Logo.scale-200.png" />
+    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+    <Image Include="Assets\StoreLogo.png" />
+    <Image Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Text Include="..\..\example\app.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ComponentViewModel.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="App.cpp">
+      <DependentUpon>App.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MainPage.cpp">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="Manifest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="App.idl">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="MainPage.idl">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="ComponentViewModel.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets" Condition="Exists('..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|ARM">
-            <Configuration>Debug</Configuration>
-            <Platform>ARM</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|ARM64">
-            <Configuration>Debug</Configuration>
-            <Platform>ARM64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|Win32">
-            <Configuration>Debug</Configuration>
-            <Platform>Win32</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|ARM">
-            <Configuration>Release</Configuration>
-            <Platform>ARM</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|ARM64">
-            <Configuration>Release</Configuration>
-            <Platform>ARM64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|Win32">
-            <Configuration>Release</Configuration>
-            <Platform>Win32</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>Application</ConfigurationType>
-        <PlatformToolset>v140</PlatformToolset>
-        <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-        <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-        <UseDebugLibraries>true</UseDebugLibraries>
-        <LinkIncremental>true</LinkIncremental>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
-        <UseDebugLibraries>false</UseDebugLibraries>
-        <WholeProgramOptimization>true</WholeProgramOptimization>
-        <LinkIncremental>false</LinkIncremental>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings">
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets">
-        <Import Project="PropertySheet.props" />
-    </ImportGroup>
-    <PropertyGroup Label="UserMacros" />
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PrecompiledHeader>Use</PrecompiledHeader>
-            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-            <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
-            <WarningLevel>Level4</WarningLevel>
-            <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-            <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-            <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
-            <DisableSpecificWarnings>
-            </DisableSpecificWarnings>
-            <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        </ClCompile>
-        <Link>
-            <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-        </Link>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
-        <ClCompile>
-            <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
-        <ClCompile>
-            <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
-        </ClCompile>
-        <Link>
-            <EnableCOMDATFolding>true</EnableCOMDATFolding>
-            <OptimizeReferences>true</OptimizeReferences>
-        </Link>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <ClInclude Include="ComponentViewModel.h" />
-        <ClInclude Include="pch.h" />
-        <ClInclude Include="Manifest.h" />
-        <ClInclude Include="App.h">
-            <DependentUpon>App.xaml</DependentUpon>
-        </ClInclude>
-        <ClInclude Include="MainPage.h">
-            <DependentUpon>MainPage.xaml</DependentUpon>
-        </ClInclude>
-    </ItemGroup>
-    <ItemGroup>
-        <ApplicationDefinition Include="App.xaml">
-            <SubType>Designer</SubType>
-        </ApplicationDefinition>
-        <Page Include="MainPage.xaml">
-            <SubType>Designer</SubType>
-        </Page>
-    </ItemGroup>
-    <ItemGroup>
-        <AppxManifest Include="Package.appxmanifest">
-            <SubType>Designer</SubType>
-        </AppxManifest>
-    </ItemGroup>
-    <ItemGroup>
-        <Image Include="Assets\LockScreenLogo.scale-200.png" />
-        <Image Include="Assets\SplashScreen.scale-200.png" />
-        <Image Include="Assets\Square150x150Logo.scale-200.png" />
-        <Image Include="Assets\Square44x44Logo.scale-200.png" />
-        <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
-        <Image Include="Assets\StoreLogo.png" />
-        <Image Include="Assets\Wide310x150Logo.scale-200.png" />
-        <Text Include="..\..\example\app.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="ComponentViewModel.cpp" />
-        <ClCompile Include="pch.cpp">
-            <PrecompiledHeader>Create</PrecompiledHeader>
-        </ClCompile>
-        <ClCompile Include="App.cpp">
-            <DependentUpon>App.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="MainPage.cpp">
-            <DependentUpon>MainPage.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-        <ClCompile Include="Manifest.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Midl Include="App.idl">
-            <DependentUpon>App.xaml</DependentUpon>
-        </Midl>
-        <Midl Include="MainPage.idl">
-            <DependentUpon>MainPage.xaml</DependentUpon>
-        </Midl>
-        <Midl Include="ComponentViewModel.idl" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-        <None Include="PropertySheet.props" />
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-    <ImportGroup Label="ExtensionTargets">
-        <Import Project="..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets" Condition="Exists('..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" />
-        <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets'))" />
-        <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
-        <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    </Target>
+    <Error Condition="!Exists('..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
 </Project>


### PR DESCRIPTION
Reuse the iterator returned by `nlohmann::json::find()` and avoid
performing another lookup.

Also bump target platform minimum version to 10.0.17763.0 so we don't
get warnings on `MenuBar` and `MenuBarItem`.