### PR TITLE
fix(macOS): `pod install` fails when `react-native` version differs

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -64,6 +64,15 @@ def project_path(file, target_platform)
   File.expand_path(file, File.join(__dir__, '..', target_platform.to_s))
 end
 
+def react_native_path(target_platform)
+  react_native = case target_platform
+                 when :ios then 'react-native'
+                 when :macos then 'react-native-macos'
+                 else raise "Unsupported target platform: #{target_platform}"
+                 end
+  Pathname.new(resolve_module(react_native))
+end
+
 def react_native_pods(version)
   v = version.release
   if v >= Gem::Version.new('0.63')
@@ -134,7 +143,7 @@ def use_flipper!(versions = {})
 end
 
 def use_react_native!(project_root, target_platform)
-  react_native = Pathname.new(resolve_module('react-native'))
+  react_native = react_native_path(target_platform)
   version = package_version(react_native.to_s)
 
   require_relative(react_native_pods(version))
@@ -166,7 +175,7 @@ def make_project!(xcodeproj, project_root, target_platform)
     FileUtils.ln_sf(source, File.join(destination, 'ReactTestAppShared'))
   end
 
-  react_native = Pathname.new(resolve_module('react-native'))
+  react_native = react_native_path(target_platform)
   version = package_version(react_native.to_s).segments
   version = version[0] * 10_000 + version[1] * 100 + version[2]
   version_macro = "REACT_NATIVE_VERSION=#{version}"

--- a/ios/use_react_native-0.60.rb
+++ b/ios/use_react_native-0.60.rb
@@ -7,8 +7,6 @@
 # rubocop:disable Layout/LineLength
 
 def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
-  react_native = "#{react_native}-macos" if target_platform == :macos
-
   pod 'React', :path => react_native
   pod 'React-Core', :path => "#{react_native}/React", :inhibit_warnings => true
   pod 'React-DevSupport', :path => "#{react_native}/React"

--- a/ios/use_react_native-0.61.rb
+++ b/ios/use_react_native-0.61.rb
@@ -7,8 +7,6 @@
 # rubocop:disable Layout/LineLength
 
 def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
-  react_native = "#{react_native}-macos" if target_platform == :macos
-
   pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "#{react_native}/Libraries/FBReactNativeSpec"
   pod 'RCTRequired', :path => "#{react_native}/Libraries/RCTRequired"


### PR DESCRIPTION
`react-native-macos` does not depend on `react-native` so their version numbers need not be in sync.

The issue manifests itself when you have a project like below:

```
project
├── ios
├── macos
└── node_modules
    ├── react-native@0.62
    └── react-native-macos@0.61
```

In this case, `test_app.rb` will import `use_react_native-0.62.rb` for both iOS and macOS targets. In the latter case, it will fail since 0.61 is installed.