### PR TITLE
fix(Android): Android build artifacts pollute installation folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,11 @@
 .DS_Store
 .gradle/
 .idea/
+.vs/
 Pods/
-build/
 clang-format-diff.py
 dist/
+example/android/build/
 local.properties
 node_modules/
 !test/fixtures/**/node_modules/
@@ -15,4 +16,3 @@ package-lock.json
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 xcuserdata/
 yarn-error.log*
-.vs/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,5 @@
+buildDir = "$rootDir/build"
+
 buildscript {
     ext.kotlinVersion = "1.3.72"
 
@@ -11,7 +13,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.android.tools.build:gradle:3.6.2"
+        classpath "com.android.tools.build:gradle:3.6.4"
     }
 }
 
@@ -96,9 +98,9 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.core:core-ktx:1.2.0"
+    implementation "androidx.core:core-ktx:1.3.1"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "com.google.android.material:material:1.1.0"
 
     implementation("com.squareup.moshi:moshi-kotlin:1.9.2")


### PR DESCRIPTION
Android build artifacts are currently output under `node_modules/react-native-test-app/android`. In a
[monorepo](https://github.com/microsoft/react-native-test-app/wiki#folder-structures), multiple packages can share the same installation if it was hoisted, e.g.:

```
my-monorepo
├── node_modules
│   └── react-native-test-app
│       └── android  # Used by both packages
├── package.json
└── packages
    ├── my-awesome-component-android
    │   ├── build.gradle
    │   ├── package.json
    │   ├── settings.gradle
    │   └── src
    └── my-second-awesome-component-android
        ├── build.gradle
        ├── package.json
        ├── settings.gradle
        └── src
```

In this example, `node_modules/react-native-test-app/android` may contain build artifacts from both `my-awesome-component-android` and `my-second-awesome-component-android`.

Resolves #158