### PR TITLE
chore: Bump suggestion-bot to 1.0.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 64
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 64
       - name: Cache /node_modules
         uses: actions/cache@v2
         with:
@@ -57,12 +57,12 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /example/node_modules
         uses: actions/cache@v2
         with:
@@ -91,12 +91,12 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /node_modules
         uses: actions/cache@v2
         with:
@@ -131,8 +131,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -145,6 +143,8 @@ jobs:
           # Node version helps to workaround this problem:
           # https://github.com/facebook/react-native/issues/26598
           node-version: 12.9.1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Cache /example/node_modules
@@ -173,8 +173,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -187,6 +185,8 @@ jobs:
           # Node version helps to workaround this problem:
           # https://github.com/facebook/react-native/issues/26598
           node-version: 12.9.1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /node_modules
         uses: actions/cache@v2
         with:
@@ -215,12 +215,12 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /example/node_modules
         uses: actions/cache@v2
         with:
@@ -249,12 +249,12 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /node_modules
         uses: actions/cache@v2
         with:
@@ -295,12 +295,12 @@ jobs:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache /node_modules
         uses: actions/cache@v2
         with:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8253,9 +8253,9 @@ sudo-prompt@^9.0.0:
   integrity sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==
 
 suggestion-bot@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/suggestion-bot/-/suggestion-bot-1.0.3.tgz#19f2466df32a66f6f1ff9271692dc1d56d1d28c8"
-  integrity sha512-EnsLFCa6li+0hkEcJH0Cr+VjZ+DtwVFPNbGoANewQjC3YEgRIKBZBQJwryyA6cj5gjL/LJx+hFvLNSGTwSkGbw==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/suggestion-bot/-/suggestion-bot-1.0.8.tgz#63eeea71455543eb19cac5a14236091af575e4c9"
+  integrity sha512-V4nijicUqZI8bDBRU9uHr/5DyNFzFcWz9WPwCaeEr/Uy98OamD839yXdAYkLTlfEn+Ob0ogVCdp33syknkosKw==
   dependencies:
     "@octokit/rest" "^17.0.0"
     parse-diff "^0.7.0"


### PR DESCRIPTION
Bug Fixes
* Handle diffs that were piped to `diff` ([1ecb8a0](https://github.com/tido64/suggestion-bot/commit/1ecb8a09f2f7f097d89204c68b3062200e6bbc80))
* Convert Windows paths to POSIX ([5b711ab](https://github.com/tido64/suggestion-bot/commit/5b711abb05183d99270348048dda37085eea4f1c))
* Don't pack mocks and coverage files ([bcd4915](https://github.com/tido64/suggestion-bot/commit/bcd4915aff70c6d1d2685e089602d82ab10d0c5e))
* Add support for piped input ([16c7a2e](https://github.com/tido64/suggestion-bot/commit/16c7a2ed5a0c3e4253a43b9ab8d489300b4fbd87))
* Add usage message ([f3ddadc](https://github.com/tido64/suggestion-bot/commit/f3ddadcc488fe0d4ac650a0b3a5aeb72a8cb30cb))