### PR TITLE
fix: unmet peer dependency warning when react-native-macos is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
     "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63 || 1000.0.0",
     "react-native-macos": "^0.60 || ^0.61.39"
   },
+  "peerDependenciesMeta": {
+    "react-native-macos": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "eslint": "^7.4.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
It's perfectly fine to not have `react-native-macos` installed when one is only concerned with Android and iOS. This change makes `react-native-macos` optional.

See also [peerDependenciesMeta](https://classic.yarnpkg.com/en/docs/package-json#toc-peerdependenciesmeta).

### Test Plan

Apply the patch and run `yarn`:

```diff
diff --git a/example/package.json b/example/package.json
index 29f2c78..e2ffb97 100644
--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,6 @@
     "mkdirp": "^0.5.1",
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-macos": "0.61.39",
     "react-native-test-app": "../"
   }
 }
```

#### Before:

```
% yarn
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > react-native-test-app@0.0.1-dev" has unmet peer dependency "react-native-macos@^0.60 || ^0.61.39".
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 19.78s.
```

#### After:

```
% yarn
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 21.67s.
```