### PR TITLE
fix(Android): Let JS component handle back button first

### DIFF
--- a/android/app/src/main/java/com/react/testapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/react/testapp/component/ComponentActivity.kt
@@ -80,15 +80,6 @@ class ComponentActivity : ReactActivity() {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (android.R.id.home == item.itemId) {
-            onBackPressed()
-            return true
-        }
-
-        return super.onOptionsItemSelected(item)
-    }
-
     override fun getSystemService(name: String): Any? {
         if (name == "service:reactNativeHostService") {
             return reactNativeHost
@@ -98,16 +89,20 @@ class ComponentActivity : ReactActivity() {
     }
 
     // TODO: https://github.com/microsoft/react-native-test-app/issues/51
-    override fun onBackPressed() {
-        super.invokeDefaultOnBackPressed()
-    }
-
-    // TODO: https://github.com/microsoft/react-native-test-app/issues/51
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
         supportFragmentManager.fragments.forEach {
             it.onActivityResult(requestCode, resultCode, data)
         }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (android.R.id.home == item.itemId) {
+            onBackPressed()
+            return true
+        }
+
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/android/app/src/main/java/com/react/testapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/react/testapp/react/TestAppReactNativeHost.kt
@@ -136,21 +136,6 @@ class TestAppReactNativeHost @Inject constructor(
 
     override fun getPackages(): List<ReactPackage> = PackageList(application).packages
 
-    private fun isPackagerRunning(context: Context): Boolean {
-        val latch = CountDownLatch(1)
-        var packagerIsRunning = false
-        DevServerHelper(
-            DevInternalSettings(context) {},
-            context.packageName,
-            BundleStatusProvider { BundleStatus() }
-        ).isPackagerRunning {
-            packagerIsRunning = it
-            latch.countDown()
-        }
-        latch.await()
-        return packagerIsRunning
-    }
-
     private fun addCustomDevOptions(devSupportManager: DevSupportManager) {
         val bundleOption = application.resources.getString(
             if (source == BundleSource.Disk) {
@@ -171,5 +156,20 @@ class TestAppReactNativeHost @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun isPackagerRunning(context: Context): Boolean {
+        val latch = CountDownLatch(1)
+        var packagerIsRunning = false
+        DevServerHelper(
+            DevInternalSettings(context) {},
+            context.packageName,
+            BundleStatusProvider { BundleStatus() }
+        ).isPackagerRunning {
+            packagerIsRunning = it
+            latch.countDown()
+        }
+        latch.await()
+        return packagerIsRunning
     }
 }


### PR DESCRIPTION
It doesn't seem like it's necessary to override `ReactActivity#onBackPressed()` any longer. `DefaultHardwareBackBtnHandler#invokeDefaultOnBackPressed()` is called after JS has had its chance to handle the back button event.