### PR TITLE
fix(Apple): Fix tests depending on ReactTestApp-DevSupport not building

### DIFF
--- a/ReactTestApp-DevSupport.podspec
+++ b/ReactTestApp-DevSupport.podspec
@@ -15,6 +15,9 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
 
-  s.source_files         = 'ios/ReactTestApp/Public/*.h'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
+  s.source_files         = 'ios/ReactTestApp/Public/*.h',
+                           'ios/ReactTestApp/ReactTestApp-DevSupport.m'
   s.public_header_files  = 'ios/ReactTestApp/Public/*.h'
 end

--- a/example/Example-Tests.podspec
+++ b/example/Example-Tests.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.14'
 
   s.dependency 'React'
+  s.dependency 'ReactTestApp-DevSupport'
 
   s.framework             = 'XCTest'
   s.user_target_xcconfig  = { 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => '$(inherited)' }

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -1,0 +1,23 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <ReactTestApp-DevSupport/ReactTestApp-DevSupport.h>
+
+@interface DevSupportTests : XCTestCase
+@end
+
+@implementation DevSupportTests
+
+- (void)testDevSupportIsLinked
+{
+    XCTAssertNotNil(ReactTestAppDidInitializeNotification);
+    XCTAssertNotNil(ReactTestAppSceneDidOpenURLNotification);
+}
+
+@end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,6 +3,7 @@ PODS:
   - DoubleConversion (1.1.6)
   - Example-Tests (0.0.1-dev):
     - React
+    - ReactTestApp-DevSupport
   - FBLazyVector (0.61.5)
   - FBReactNativeSpec (0.61.5):
     - Folly (= 2018.10.22.00)
@@ -327,7 +328,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  Example-Tests: 1605ab8a9f15c3394c656e5e673470a40eb41561
+  Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
   FBLazyVector: aaeaf388755e4f29cd74acbc9e3b8da6d807c37f
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
@@ -352,7 +353,7 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  ReactTestApp-DevSupport: 1aee56d5c69fe4a4f4d5be0cbd3f22f5326d70fd
+  ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -350,7 +350,7 @@ SPEC CHECKSUMS:
   React-RCTText: e81f5065516561545ae40f2c5b84d7b14fe6baec
   React-RCTVibration: 2ab29818330374b02167caac117d609159f360ab
   ReactCommon: e24f8c0d974cdb872d73cbd87cdfea9d72cfae26
-  ReactTestApp-DevSupport: 1aee56d5c69fe4a4f4d5be0cbd3f22f5326d70fd
+  ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   Yoga: 9cc54b8ca13d6fa87f8214c6eac97745e1df8092

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -1,0 +1,13 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#import <Foundation/Foundation.h>
+
+NSNotificationName const ReactTestAppDidInitializeNotification =
+    @"ReactTestAppDidInitializeNotification";
+NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
+    @"ReactTestAppSceneDidOpenURLNotification";

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.m
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.m
@@ -1,16 +1,11 @@
 //
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 #import "UIViewController+ReactTestApp.h"
-
-NSNotificationName const ReactTestAppDidInitializeNotification =
-    @"ReactTestAppDidInitializeNotification";
-NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
-    @"ReactTestAppSceneDidOpenURLNotification";
 
 @protocol RTAViewController <NSObject>
 - (instancetype)initWithBridge:(RCTBridge *)bridge;


### PR DESCRIPTION
The symbols declared in ReactTestApp-DevSupport aren't compiled in the same module, but in the main ReactTestApp module. This causes tests to fail building because the linker cannot find the symbols, e.g.:

```
Undefined symbols for architecture x86_64:
  "_ReactTestAppSceneDidOpenURLNotification", referenced from:
      -[ADALTokenBroker init] in libReactTestApp-Contoso.a(ADALTokenBroker.o)
  "_ReactTestAppDidInitializeNotification", referenced from:
      +[ADALTokenBroker load] in libReactTestApp-Contoso.a(ADALTokenBroker.o)
      +[ReactBootstrapper load] in libReactTestApp-Contoso.a(ReactBootstrapper.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```