### PR TITLE
ci: Workaround for random assertion failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          yarn build:ios
+          yarn build:ios || yarn build:ios
           pod install --project-directory=ios
           ../scripts/xcodebuild.sh ios/Example.xcworkspace build-for-testing
         working-directory: example
@@ -114,7 +114,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          yarn build:ios
+          yarn build:ios || yarn build:ios
           if [[ ${{ matrix.template }} == ios ]]; then
             pod install
             ../scripts/xcodebuild.sh TemplateExample.xcworkspace build
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          yarn build:android
+          yarn build:android || yarn build:android
           pushd android 1> /dev/null
           ./gradlew clean build check test
         working-directory: example
@@ -205,7 +205,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          yarn build:android
+          yarn build:android || yarn build:android
           [[ -d android ]] && pushd android 1> /dev/null
           ./gradlew clean build check test
         shell: bash
@@ -233,7 +233,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          yarn build:macos
+          yarn build:macos || yarn build:macos
           pod install --project-directory=macos
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build-for-testing
         working-directory: example
@@ -272,7 +272,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          yarn build:macos
+          yarn build:macos || yarn build:macos
           if [[ ${{ matrix.template }} == macos ]]; then
             pod install
             ../scripts/xcodebuild.sh TemplateExample.xcworkspace build


### PR DESCRIPTION
CI builds randomly fail with `Assertion failed: (!uv__is_closing(handle)), function uv_close, ...`. Adding simple retry logic to work around the issue.

Resolves #156

### Test Plan

I don't know what triggers the assertion so I just re-ran the jobs until one failed:

![image](https://user-images.githubusercontent.com/4123478/89471035-6abee280-d77d-11ea-82c5-f0ca20b251ef.png)
