### PR TITLE
chore(deps): `adoptopenjdk8` has been moved to `homebrew/cask-versions`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-tap 'AdoptOpenJDK/openjdk'
+tap 'homebrew/cask-versions'
 brew 'clang-format'
 brew 'node'
 brew 'swiftlint'


### PR DESCRIPTION
If you've added both taps, you'll now get this error:

```
% brew bundle
Tapping adoptopenjdk/openjdk
Using clang-format
Using node
Using swiftlint
Using yarn
Error: Cask adoptopenjdk8 exists in multiple taps:
  homebrew/cask-versions/adoptopenjdk8
  adoptopenjdk/openjdk/adoptopenjdk8
Installing adoptopenjdk8 has failed!
Homebrew Bundle failed! 1 Brewfile dependency failed to install.
```

Replacing `adoptopenjdk/openjdk` with `homebrew/cask-versions` fixes the
issue for future contributors. Existing contributors need to also run
`brew untap adoptopenjdk/openjdk`.