### PR TITLE
fix(macOS): Enumerate components starting from 1

### DIFF
--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -40,7 +40,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let item = reactMenu.addItem(
                 withTitle: title,
                 action: #selector(onComponentSelected),
-                keyEquivalent: index < 10 ? String(index) : ""
+                keyEquivalent: index < 9 ? String(index + 1) : ""
             )
             item.keyEquivalentModifierMask = [.shift, .command]
             item.isEnabled = false


### PR DESCRIPTION
Ctrl+Shift+0 is used to switch between input languages on Windows. We
change the macOS implementation so they are aligned.