### PR TITLE
fix(macOS): Enable Hermes if hermes-engine-darwin is installed

### DIFF
--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -13,7 +13,7 @@
 
 // `RCTReloadCommand.h` is excluded from `react-native-macos`
 // See https://github.com/microsoft/react-native-macos/blob/v0.61.39/React-Core.podspec#L66
-#if !TARGET_OS_OSX
+#if REACT_NATIVE_VERSION >= 6200
 #import <React/RCTReloadCommand.h>
 #endif
 

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+def resolve_module(request)
+  script = "console.log(path.dirname(require.resolve('#{request}/package.json')));"
+  Pod::Executable.execute_command('node', ['-e', script], true).strip
+end
+
 def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end

--- a/ios/use_react_native-0.62.rb
+++ b/ios/use_react_native-0.62.rb
@@ -81,6 +81,18 @@ def include_react_native!(react_native:, target_platform:, project_root:, flippe
   try_pod('boost-for-react-native',
           "#{react_native}/third-party-podspecs/boost-for-react-native.podspec",
           project_root)
+
+  return unless target_platform == :macos
+
+  # Hermes
+  begin
+    hermes_engine_darwin = resolve_module('hermes-engine-darwin')
+    pod 'React-Core/Hermes', :path => "#{react_native}/"
+    pod 'hermes', :path => Pathname.new(hermes_engine_darwin).relative_path_from(project_root).to_s
+    pod 'libevent', :podspec => "#{react_native}/third-party-podspecs/libevent.podspec"
+  rescue StandardError
+    # Use JavaScriptCore
+  end
 end
 
 # rubocop:enable Layout/LineLength


### PR DESCRIPTION
<img width="861" alt="Screenshot 2020-08-26 at 22 48 30" src="https://user-images.githubusercontent.com/4123478/91356191-9159c180-e7ef-11ea-92cc-6cb2e7ba13ef.png">

#### Test Plan

1. Apply the patch below
2. Build the macOS test app
3. Observe that it says "Engine: Hermes" in the upper right corner

```diff
diff --git a/example/package.json b/example/package.json
index d6e372a..3cf758b 100644
--- a/example/package.json
+++ b/example/package.json
@@ -16,10 +16,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "hermes-engine-darwin": "^0.4.3",
     "mkdirp": "^0.5.1",
-    "react": "16.9.0",
-    "react-native": "0.61.5",
-    "react-native-macos": "0.61.39",
+    "react": "16.11.0",
+    "react-native": "0.62.2",
+    "react-native-macos": "0.62.1",
     "react-native-test-app": "../"
   }
 }
diff --git a/package.json b/package.json
index ff3b258..e2e0c11 100644
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime": "^7.0.0",
-    "@react-native-community/cli": "^3.0.0",
-    "@react-native-community/cli-platform-android": "^3.0.0",
-    "@react-native-community/cli-platform-ios": "^3.0.0",
+    "@react-native-community/cli": "^4.0.0",
+    "@react-native-community/cli-platform-android": "^4.0.0",
+    "@react-native-community/cli-platform-ios": "^4.0.0",
     "chalk": "^1.1.3",
     "plop": "^2.6.0"
   },
```