### PR TITLE
fix(Windows): Debug settings are not persisted across sessions

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,23 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/example/node_modules/.generated/windows/ReactTestApp/Generated Files",
+                "${workspaceFolder}/example/node_modules/react-native-windows/build/x64/Debug/Microsoft.ReactNative/Generated Files",
+                "${workspaceFolder}/example/windows/packages/nlohmann.json.3.9.1/build/native/include"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "windowsSdkVersion": "10.0.18362.0",
+            "compilerPath": "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "files.associations": {
+        "any": "cpp",
+        "fstream": "cpp",
+        "iostream": "cpp",
+        "map": "cpp",
+        "optional": "cpp",
+        "string": "cpp",
+        "vector": "cpp"
+    }
+}

--- a/test/getPackageVersion.test.js
+++ b/test/getPackageVersion.test.js
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// @ts-check
+
+describe("getPackageVersion", () => {
+  const path = require("path");
+  const { getPackageVersion } = require("../windows/test-app");
+
+  const nodeModulesPath = path.join(
+    __dirname,
+    "__fixtures__",
+    "test_app",
+    "node_modules"
+  );
+
+  test("returns version number for specified package", () => {
+    const rnPath = path.join(nodeModulesPath, "react-native");
+    expect(getPackageVersion(rnPath)).toBe("1000.0.0");
+
+    const rnCliPath = path.join(
+      nodeModulesPath,
+      "@react-native-community",
+      "cli-platform-ios"
+    );
+    expect(getPackageVersion(rnCliPath)).toBe("4.10.1");
+  });
+});

--- a/test/getVersionNumber.test.js
+++ b/test/getVersionNumber.test.js
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// @ts-check
+
+describe("getVersionNumber", () => {
+  const { getVersionNumber } = require("../windows/test-app");
+
+  test("handles arbitrary version number formats", () => {
+    expect(getVersionNumber("0")).toBe(0);
+    expect(getVersionNumber("1")).toBe(1);
+    expect(getVersionNumber("11")).toBe(11);
+
+    expect(getVersionNumber("0.0")).toBe(0);
+    expect(getVersionNumber("0.1")).toBe(1);
+    expect(getVersionNumber("1.0")).toBe(100);
+    expect(getVersionNumber("1.1")).toBe(101);
+
+    expect(getVersionNumber("0.0.0")).toBe(0);
+    expect(getVersionNumber("0.0.1")).toBe(1);
+    expect(getVersionNumber("0.1.0")).toBe(100);
+    expect(getVersionNumber("0.1.1")).toBe(101);
+    expect(getVersionNumber("1.0.0")).toBe(10000);
+    expect(getVersionNumber("1.0.1")).toBe(10001);
+    expect(getVersionNumber("1.1.0")).toBe(10100);
+    expect(getVersionNumber("1.1.1")).toBe(10101);
+
+    expect(getVersionNumber("0.0.0.0")).toBe(0);
+    expect(getVersionNumber("0.0.0.1")).toBe(1);
+    expect(getVersionNumber("0.0.1.0")).toBe(100);
+    expect(getVersionNumber("0.0.1.1")).toBe(101);
+    expect(getVersionNumber("0.1.0.0")).toBe(10000);
+    expect(getVersionNumber("0.1.0.1")).toBe(10001);
+    expect(getVersionNumber("0.1.1.0")).toBe(10100);
+    expect(getVersionNumber("0.1.1.1")).toBe(10101);
+    expect(getVersionNumber("1.0.0.0")).toBe(1000000);
+    expect(getVersionNumber("1.0.0.1")).toBe(1000001);
+    expect(getVersionNumber("1.0.1.0")).toBe(1000100);
+    expect(getVersionNumber("1.0.1.1")).toBe(1000101);
+    expect(getVersionNumber("1.1.0.0")).toBe(1010000);
+    expect(getVersionNumber("1.1.0.1")).toBe(1010001);
+    expect(getVersionNumber("1.1.1.0")).toBe(1010100);
+    expect(getVersionNumber("1.1.1.1")).toBe(1010101);
+  });
+});

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -26,23 +26,35 @@ namespace winrt::ReactTestApp::implementation
                                Windows::UI::Xaml::RoutedEventArgs);
         void LoadFromJSBundle(Windows::Foundation::IInspectable const &,
                               Windows::UI::Xaml::RoutedEventArgs);
-        void OpenDebugMenu(Windows::Foundation::IInspectable const &,
-                           Windows::UI::Xaml::RoutedEventArgs);
+
+        void Reload(Windows::Foundation::IInspectable const &, Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleBreakOnFirstLine(Windows::Foundation::IInspectable const &,
+                                    Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleDirectDebugger(Windows::Foundation::IInspectable const &,
+                                  Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleFastRefresh(Windows::Foundation::IInspectable const &,
+                               Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleInspector(Windows::Foundation::IInspectable const &,
+                             Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleWebDebugger(Windows::Foundation::IInspectable const &,
+                               Windows::UI::Xaml::RoutedEventArgs);
 
         Windows::Foundation::IAsyncAction
-        OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs const &e);
+        OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs const &);
 
     private:
         using Base = MainPageT;
 
         ::ReactTestApp::ReactInstance reactInstance_;
 
-        void LoadReactComponent(::ReactTestApp::Component const &component);
+        void InitializeDebugMenu();
+        void InitializeReactMenu();
+        void InitializeTitleBar();
 
-        void SetUpTitleBar();
+        void LoadReactComponent(::ReactTestApp::Component const &);
 
         void OnCoreTitleBarLayoutMetricsChanged(
-            Windows::ApplicationModel::Core::CoreApplicationViewTitleBar const &sender,
+            Windows::ApplicationModel::Core::CoreApplicationViewTitleBar const &,
             Windows::Foundation::IInspectable const &);
     };
 }  // namespace winrt::ReactTestApp::implementation

--- a/windows/ReactTestApp/MainPage.xaml
+++ b/windows/ReactTestApp/MainPage.xaml
@@ -2,7 +2,6 @@
     x:Class="ReactTestApp.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:ReactTestApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -19,11 +18,21 @@
                 <TextBlock x:Name="AppTitle" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </Grid>
             <MenuBar x:Name="AppMenuBar" HorizontalAlignment="Left" VerticalContentAlignment="Stretch" Width="Auto">
-                <MenuBarItem x:Name="ReactMenuBarItem" Title="React">
-                    <MenuFlyoutItem Text="Load from JS bundle" Click="LoadFromJSBundle"/>
-                    <MenuFlyoutItem Text="Load from dev server" Click="LoadFromDevServer"/>
-                    <MenuFlyoutItem Text="Open debug menu" Click="OpenDebugMenu" KeyboardAcceleratorTextOverride="Ctrl+Shift+D" x:Name="OpenDebugMenuButton" IsEnabled="false"/>
+                <MenuBarItem x:Name="ReactMenuBarItem" Title="React" AccessKey="R">
+                    <MenuFlyoutItem Text="Load from JS bundle" Click="LoadFromJSBundle" AccessKey="E"/>
+                    <MenuFlyoutItem Text="Load from dev server" Click="LoadFromDevServer" AccessKey="D"/>
                     <MenuFlyoutSeparator/>
+                </MenuBarItem>
+                <MenuBarItem x:Name="DebugMenuBarItem" IsEnabled="false" Title="Debug" AccessKey="D">
+                    <MenuBarItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="D" Modifiers="Control,Shift"/>
+                    </MenuBarItem.KeyboardAccelerators>
+                    <MenuFlyoutItem Text="Reload JavaScript" Click="Reload" AccessKey="R"/>
+                    <MenuFlyoutItem x:Name="WebDebuggerMenuItem" Click="ToggleWebDebugger" AccessKey="W"/>
+                    <MenuFlyoutItem x:Name="DirectDebuggingMenuItem" Click="ToggleDirectDebugger" AccessKey="D"/>
+                    <MenuFlyoutItem x:Name="BreakOnFirstLineMenuItem" Click="ToggleBreakOnFirstLine" AccessKey="B"/>
+                    <MenuFlyoutItem x:Name="FastRefreshMenuItem" Click="ToggleFastRefresh" AccessKey="F"/>
+                    <MenuFlyoutItem Text="Toggle Inspector" Click="ToggleInspector" AccessKey="I"/>
                 </MenuBarItem>
             </MenuBar>
         </Grid>

--- a/windows/ReactTestApp/Package.appxmanifest
+++ b/windows/ReactTestApp/Package.appxmanifest
@@ -2,8 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
          xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-         IgnorableNamespaces="mp uap rescap">
+         IgnorableNamespaces="mp uap">
   <Identity Name="40411fc5-8e92-4d46-b68d-b62df44b1366"
             Publisher="CN=AnastasiaOrishchenko"
             Version="1.0.0.0" />
@@ -34,6 +33,5 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
-    <rescap:Capability Name="inputInjectionBrokered" />
   </Capabilities>
 </Package>

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -9,8 +9,10 @@
 
 #include "ReactInstance.h"
 
+#include <NativeModules.h>
 #include <filesystem>
 
+#include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 
 #include "AutolinkedNativeModules.g.h"
@@ -19,8 +21,61 @@
 using ReactTestApp::ReactInstance;
 using winrt::ReactTestApp::implementation::ReactPackageProvider;
 using winrt::Windows::Foundation::IAsyncOperation;
+using winrt::Windows::Foundation::PropertyValue;
 using winrt::Windows::Foundation::Uri;
+using winrt::Windows::Storage::ApplicationData;
 using winrt::Windows::Web::Http::HttpClient;
+
+namespace
+{
+    // The `DevSettings` module override used to get the `ReactContext` was
+    // introduced in 0.63. `ReactContext` is needed to toggle element inspector.
+    // We also need to be on a version with the fix for re-initializing native
+    // modules when reloading.
+#if REACT_NATIVE_VERSION >= 6305
+    constexpr bool kUseCustomDeveloperMenu = true;
+#else
+    constexpr bool kUseCustomDeveloperMenu = false;
+#endif
+
+    winrt::hstring const kBreakOnFirstLine = L"breakOnFirstLine";
+    winrt::hstring const kUseDirectDebugger = L"useDirectDebugger";
+    winrt::hstring const kUseFastRefresh = L"useFastRefresh";
+    winrt::hstring const kUseWebDebugger = L"useWebDebugger";
+
+    bool RetrieveLocalSetting(winrt::hstring const &key, bool defaultValue)
+    {
+        auto localSettings = ApplicationData::Current().LocalSettings();
+        auto values = localSettings.Values();
+        return winrt::unbox_value_or<bool>(values.Lookup(key), defaultValue);
+    }
+
+    void StoreLocalSetting(winrt::hstring const &key, bool value)
+    {
+        auto localSettings = ApplicationData::Current().LocalSettings();
+        auto values = localSettings.Values();
+        values.Insert(key, PropertyValue::CreateBoolean(value));
+    }
+
+    REACT_MODULE(DevSettings)
+    struct DevSettings {
+        REACT_INIT(Initialize)
+        void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept
+        {
+            context_ = reactContext;
+        }
+
+        static void ToggleElementInspector() noexcept
+        {
+            context_.CallJSFunction(L"RCTDeviceEventEmitter", L"emit", L"toggleElementInspector");
+        }
+
+    private:
+        static winrt::Microsoft::ReactNative::ReactContext context_;
+    };
+
+    winrt::Microsoft::ReactNative::ReactContext DevSettings::context_ = nullptr;
+}  // namespace
 
 ReactInstance::ReactInstance()
 {
@@ -32,22 +87,95 @@ ReactInstance::ReactInstance()
 void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
 {
     auto instanceSettings = reactNativeHost_.InstanceSettings();
-    instanceSettings.UseLiveReload(source == JSBundleSource::DevServer);
-    instanceSettings.UseWebDebugger(source == JSBundleSource::DevServer);
-    instanceSettings.UseFastRefresh(source == JSBundleSource::DevServer);
-
     switch (source) {
         case JSBundleSource::DevServer:
             instanceSettings.JavaScriptMainModuleName(L"index");
             instanceSettings.JavaScriptBundleFile(L"");
             break;
         case JSBundleSource::Embedded:
-            winrt::hstring bundleFileName = winrt::to_hstring(GetBundleName());
-            instanceSettings.JavaScriptBundleFile(bundleFileName);
+            instanceSettings.JavaScriptBundleFile(winrt::to_hstring(GetBundleName()));
             break;
     }
 
+    Reload();
+}
+
+void ReactInstance::Reload()
+{
+    auto instanceSettings = reactNativeHost_.InstanceSettings();
+
+    instanceSettings.UseWebDebugger(UseWebDebugger());
+    instanceSettings.UseDirectDebugger(UseDirectDebugger());
+
+    auto useFastRefresh = UseFastRefresh();
+    instanceSettings.UseFastRefresh(useFastRefresh);
+    instanceSettings.UseLiveReload(useFastRefresh);
+
+    instanceSettings.EnableDeveloperMenu(!kUseCustomDeveloperMenu);
+
     reactNativeHost_.ReloadInstance();
+}
+
+bool ReactInstance::BreakOnFirstLine() const
+{
+    return RetrieveLocalSetting(kBreakOnFirstLine, false);
+}
+
+void ReactInstance::BreakOnFirstLine(bool breakOnFirstLine)
+{
+    StoreLocalSetting(kBreakOnFirstLine, breakOnFirstLine);
+    Reload();
+}
+
+void ReactInstance::ToggleElementInspector() const
+{
+    DevSettings::ToggleElementInspector();
+}
+
+bool ReactInstance::UseCustomDeveloperMenu() const
+{
+    return kUseCustomDeveloperMenu;
+}
+
+bool ReactInstance::UseDirectDebugger() const
+{
+    return RetrieveLocalSetting(kUseDirectDebugger, false);
+}
+
+void ReactInstance::UseDirectDebugger(bool useDirectDebugger)
+{
+    if (useDirectDebugger) {
+        // Remote debugging is incompatible with direct debugging
+        StoreLocalSetting(kUseWebDebugger, false);
+    }
+    StoreLocalSetting(kUseDirectDebugger, useDirectDebugger);
+    Reload();
+}
+
+bool ReactInstance::UseFastRefresh() const
+{
+    return RetrieveLocalSetting(kUseFastRefresh, true);
+}
+
+void ReactInstance::UseFastRefresh(bool useFastRefresh)
+{
+    StoreLocalSetting(kUseFastRefresh, useFastRefresh);
+    Reload();
+}
+
+bool ReactInstance::UseWebDebugger() const
+{
+    return RetrieveLocalSetting(kUseWebDebugger, false);
+}
+
+void ReactInstance::UseWebDebugger(bool useWebDebugger)
+{
+    if (useWebDebugger) {
+        // Remote debugging is incompatible with direct debugging
+        StoreLocalSetting(kUseDirectDebugger, false);
+    }
+    StoreLocalSetting(kUseWebDebugger, useWebDebugger);
+    Reload();
 }
 
 std::string ReactTestApp::GetBundleName()

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -28,16 +28,6 @@ using winrt::Windows::Web::Http::HttpClient;
 
 namespace
 {
-    // The `DevSettings` module override used to get the `ReactContext` was
-    // introduced in 0.63. `ReactContext` is needed to toggle element inspector.
-    // We also need to be on a version with the fix for re-initializing native
-    // modules when reloading.
-#if REACT_NATIVE_VERSION >= 6305
-    constexpr bool kUseCustomDeveloperMenu = true;
-#else
-    constexpr bool kUseCustomDeveloperMenu = false;
-#endif
-
     winrt::hstring const kBreakOnFirstLine = L"breakOnFirstLine";
     winrt::hstring const kUseDirectDebugger = L"useDirectDebugger";
     winrt::hstring const kUseFastRefresh = L"useFastRefresh";
@@ -57,7 +47,17 @@ namespace
         values.Insert(key, PropertyValue::CreateBoolean(value));
     }
 
+    // The `DevSettings` module override used to get the `ReactContext` was
+    // introduced in 0.63. `ReactContext` is needed to toggle element inspector.
+    // We also need to be on a version with the fix for re-initializing native
+    // modules when reloading.
+#if REACT_NATIVE_VERSION < 6305
+    constexpr bool kUseCustomDeveloperMenu = false;
+#else
+    constexpr bool kUseCustomDeveloperMenu = true;
+
     REACT_MODULE(DevSettings)
+#endif
     struct DevSettings {
         REACT_INIT(Initialize)
         void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -24,12 +24,29 @@ namespace ReactTestApp
     public:
         ReactInstance();
 
-        auto &ReactHost()
+        auto const &ReactHost() const
         {
             return reactNativeHost_;
         }
 
-        void LoadJSBundleFrom(JSBundleSource source);
+        void LoadJSBundleFrom(JSBundleSource);
+        void Reload();
+
+        bool BreakOnFirstLine() const;
+        void BreakOnFirstLine(bool);
+
+        void ToggleElementInspector() const;
+
+        bool UseCustomDeveloperMenu() const;
+
+        bool UseDirectDebugger() const;
+        void UseDirectDebugger(bool);
+
+        bool UseFastRefresh() const;
+        void UseFastRefresh(bool);
+
+        bool UseWebDebugger() const;
+        void UseWebDebugger(bool);
 
     private:
         winrt::Microsoft::ReactNative::ReactNativeHost reactNativeHost_;

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -121,7 +121,7 @@
             <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
             <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
             <DisableSpecificWarnings></DisableSpecificWarnings>
-            <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+            <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;REACT_NATIVE_VERSION=10000000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
         </ClCompile>
     </ItemDefinitionGroup>
     <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
| Normal | With Access Keys |
|-|-|
| ![image](https://user-images.githubusercontent.com/4123478/95022067-219fe780-0675-11eb-8c6c-e1228ff52593.png) | ![image](https://user-images.githubusercontent.com/4123478/95022077-311f3080-0675-11eb-83bb-e9f9afa3aa29.png) |
| ![image](https://user-images.githubusercontent.com/4123478/95021668-a806fa00-0672-11eb-94d0-c3beeb798aae.png) | ![image](https://user-images.githubusercontent.com/4123478/95021711-f0261c80-0672-11eb-9c12-f64f5fc76f82.png) |

#### To Do

- [x] Figure out how to toggle inspector
- [x] Figure out why custom `DevSettings` module is not initialized after reload (https://github.com/microsoft/react-native-windows/pull/6159)

#### Test Plan

1. Build and run Windows test app
2. The debug menu should be **disabled**
    - `Ctrl`+`Shift`+`D` should open `react-native-windows`' developer menu
3. Run `git clean -dfqx` to restore state
4. Bump `react-native` to ^0.63 and `react-native-windows` to ^0.63.5 (see diff below)
5. Build and run Windows test app
6. The debug menu should be **enabled**
    - `Ctrl`+`Shift`+`D` should open it instead of `react-native-windows`' developer menu
    - The state of each item in the debug menu should be restored when the app is restarted
    - `Toggle Inspector` should always work, even after a JS reload

```diff
diff --git a/example/package.json b/example/package.json
index 5bde75f..2d7104d 100644
--- a/example/package.json
+++ b/example/package.json
@@ -25,10 +25,9 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "react": "16.11.0",
-    "react-native": "0.62.2",
-    "react-native-macos": "0.62.14",
+    "react": "16.13.1",
+    "react-native": "0.63.3",
     "react-native-test-app": "../",
-    "react-native-windows": "0.62.12"
+    "react-native-windows": "0.63.5"
   }
 }

```