### PR TITLE
fix(Android): RedBox is dismissed on app start

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,14 +101,14 @@ dependencies {
     implementation "androidx.core:core-ktx:1.3.1"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation "com.google.android.material:material:1.2.0"
+    implementation "com.google.android.material:material:1.2.1"
 
     implementation("com.squareup.moshi:moshi-kotlin:1.9.2")
     kapt("com.squareup.moshi:moshi-kotlin-codegen:1.9.2")
 
     testImplementation "junit:junit:4.13"
-    androidTestImplementation "androidx.test.ext:junit:1.1.1"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.2"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
 
     if (project.ext.react.enableFlipper) {
         def flipperVersion = project.ext.react.enableFlipper

--- a/android/app/src/main/java/com/react/testapp/MainActivity.kt
+++ b/android/app/src/main/java/com/react/testapp/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.react.ReactActivity
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.systeminfo.ReactNativeVersion
 import com.google.android.material.appbar.MaterialToolbar
 import com.react.testapp.component.ComponentActivity
@@ -51,11 +52,15 @@ class MainActivity : ReactActivity() {
     }
 
     private val startComponentActivity = { component: ComponentViewModel ->
+        didInitialNavigation = true;
         startActivity(newComponentActivityIntent(component))
     }
 
+    private var didInitialNavigation = false;
+
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
+        didInitialNavigation = savedInstanceState?.getBoolean("didInitialNavigation", false) == true
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -65,11 +70,20 @@ class MainActivity : ReactActivity() {
 
         if (manifest.components.count() == 1) {
             val component = newComponentViewModel(manifest.components[0])
-            startComponentActivity(component)
+            testAppReactNativeHost.addReactInstanceEventListener { _: ReactContext  ->
+                if (!didInitialNavigation) {
+                    startComponentActivity(component)
+                }
+            }
         }
 
         setupToolbar(manifest.displayName)
         setupRecyclerView(manifest.components)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean("didInitialNavigation", didInitialNavigation);
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupToolbar(displayName: String) {

--- a/android/app/src/main/java/com/react/testapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/react/testapp/react/TestAppReactNativeHost.kt
@@ -8,6 +8,7 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
 import com.facebook.react.common.LifecycleState
@@ -79,6 +80,10 @@ class TestAppReactNativeHost @Inject constructor(
                 )
             }
         }
+    }
+
+    fun addReactInstanceEventListener(listener: (ReactContext) -> Unit) {
+        reactInstanceManager.addReactInstanceEventListener(listener)
     }
 
     fun reload(activity: Activity?, newSource: BundleSource) {


### PR DESCRIPTION
If there is only one component, we navigate to it regardless of whether React Native was successfully initialized. This dismisses any RedBox instances, making it hard to debug errors.