### PR TITLE
fix(Windows): Support for 0.63

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1",
     "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || 1000.0.0",
     "react-native-macos": "^0.60.0 || ^0.61.0 || ^0.62.0",
-    "react-native-windows": "^0.62.0"
+    "react-native-windows": "^0.62.0 || ^0.63.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/example/windows/ReactTestAppTests/ManifestTests.cpp
+++ b/example/windows/ReactTestAppTests/ManifestTests.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"
 
 #include <CppUnitTest.h>

--- a/package.json
+++ b/package.json
@@ -46,12 +46,16 @@
     "yargs": "^16.0.0"
   },
   "peerDependencies": {
+    "mustache": "^4.0.0",
     "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1",
     "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || 1000.0.0",
     "react-native-macos": "^0.60.0 || ^0.61.0 || ^0.62.0",
-    "react-native-windows": "^0.62.0"
+    "react-native-windows": "^0.62.0 || ^0.63.0"
   },
   "peerDependenciesMeta": {
+    "mustache": {
+      "optional": true
+    },
     "react-native-macos": {
       "optional": true
     },
@@ -62,9 +66,10 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@types/jest": "^26.0.0",
+    "@types/mustache": "^4.0.0",
     "@types/node": "^12.0.0",
     "eslint": "^7.9.0",
-    "eslint-plugin-jest": "^24.0.1",
+    "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
     "jest": "^26.4.2",

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,11 +1,9 @@
-/**
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-const chalk = require("chalk");
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 /**
  * Returns whether the specified package is installed.
@@ -70,6 +68,7 @@ module.exports = (plop) => {
         return [];
       }
 
+      const chalk = require("chalk");
       const path = require("path");
 
       const { name, platforms } = answers;
@@ -347,8 +346,9 @@ module.exports = (plop) => {
           }
         } else {
           console.warn(
-            chalk.yellow("[WARN] ") +
-              "Cannot find module 'react-native-macos'; skipping macOS target"
+            `${chalk.yellow(
+              "[WARN]"
+            )} Cannot find module 'react-native-macos'; skipping macOS target`
           );
         }
       }
@@ -378,8 +378,9 @@ module.exports = (plop) => {
           }
         } else {
           console.warn(
-            chalk.yellow("[WARN] ") +
-              "Cannot find module 'react-native-windows'; skipping Windows target"
+            `${chalk.yellow(
+              "[WARN]"
+            )} Cannot find module 'react-native-windows'; skipping Windows target`
           );
         }
       }

--- a/windows/ReactTestApp/App.cpp
+++ b/windows/ReactTestApp/App.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"
 
 #include "App.h"

--- a/windows/ReactTestApp/App.h
+++ b/windows/ReactTestApp/App.h
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #pragma once
 
 #include "App.xaml.g.h"

--- a/windows/ReactTestApp/App.xaml
+++ b/windows/ReactTestApp/App.xaml
@@ -3,5 +3,4 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:ReactTestApp">
-
 </Application>

--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"
 
 #include "MainPage.h"

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #pragma once
 
 #include <any>

--- a/windows/ReactTestApp/MainPage.idl
+++ b/windows/ReactTestApp/MainPage.idl
@@ -1,4 +1,3 @@
-
 namespace ReactTestApp
 {
     [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page

--- a/windows/ReactTestApp/Manifest.cpp
+++ b/windows/ReactTestApp/Manifest.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"
 
 #include "Manifest.h"

--- a/windows/ReactTestApp/Manifest.h
+++ b/windows/ReactTestApp/Manifest.h
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #pragma once
 
 #include <any>

--- a/windows/ReactTestApp/Package.appxmanifest
+++ b/windows/ReactTestApp/Package.appxmanifest
@@ -4,10 +4,9 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="mp uap rescap">
-  <Identity
-    Name="40411fc5-8e92-4d46-b68d-b62df44b1366"
-    Publisher="CN=AnastasiaOrishchenko"
-    Version="1.0.0.0" />
+  <Identity Name="40411fc5-8e92-4d46-b68d-b62df44b1366"
+            Publisher="CN=AnastasiaOrishchenko"
+            Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="40411fc5-8e92-4d46-b68d-b62df44b1366" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
   <Properties>
     <DisplayName>ReactTestApp</DisplayName>
@@ -22,8 +21,11 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="ReactTestApp.App">
-      <uap:VisualElements DisplayName="ReactTestApp" Description="Project for a single page C++/WinRT Universal Windows Platform (UWP) app with no predefined layout"
-        Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="ReactTestApp"
+                          Description="React Native test app for C++/WinRT Universal Windows Platform (UWP)"
+                          Square150x150Logo="Assets\Square150x150Logo.png"
+                          Square44x44Logo="Assets\Square44x44Logo.png"
+                          BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"
 
 #include "ReactInstance.h"
@@ -6,62 +13,67 @@
 
 #include <winrt/Windows.Web.Http.Headers.h>
 
+#include "ReactPackageProvider.h"
+
+using ReactTestApp::ReactInstance;
+using winrt::ReactTestApp::implementation::ReactPackageProvider;
 using winrt::Windows::Foundation::IAsyncOperation;
 using winrt::Windows::Foundation::Uri;
 using winrt::Windows::Web::Http::HttpClient;
 
-namespace ReactTestApp
+ReactInstance::ReactInstance()
 {
-    void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
-    {
-        auto instanceSettings = reactNativeHost_.InstanceSettings();
-        instanceSettings.UseLiveReload(source == JSBundleSource::DevServer);
-        instanceSettings.UseWebDebugger(source == JSBundleSource::DevServer);
-        instanceSettings.UseFastRefresh(source == JSBundleSource::DevServer);
+    reactNativeHost_.PackageProviders().Append(winrt::make<ReactPackageProvider>());
+}
 
-        switch (source) {
-            case JSBundleSource::DevServer:
-                instanceSettings.JavaScriptMainModuleName(L"index");
-                instanceSettings.JavaScriptBundleFile(L"");
-                break;
-            case JSBundleSource::Embedded:
-                winrt::hstring bundleFileName = winrt::to_hstring(GetBundleName());
-                instanceSettings.JavaScriptBundleFile(bundleFileName);
-                break;
-        }
+void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
+{
+    auto instanceSettings = reactNativeHost_.InstanceSettings();
+    instanceSettings.UseLiveReload(source == JSBundleSource::DevServer);
+    instanceSettings.UseWebDebugger(source == JSBundleSource::DevServer);
+    instanceSettings.UseFastRefresh(source == JSBundleSource::DevServer);
 
-        reactNativeHost_.ReloadInstance();
+    switch (source) {
+        case JSBundleSource::DevServer:
+            instanceSettings.JavaScriptMainModuleName(L"index");
+            instanceSettings.JavaScriptBundleFile(L"");
+            break;
+        case JSBundleSource::Embedded:
+            winrt::hstring bundleFileName = winrt::to_hstring(GetBundleName());
+            instanceSettings.JavaScriptBundleFile(bundleFileName);
+            break;
     }
 
-    std::string GetBundleName()
-    {
-        std::vector entryFileNames = {"index.windows",
-                                      "main.windows",
-                                      "index.native",
-                                      "main.native",
-                                      "index"
-                                      "main"};
+    reactNativeHost_.ReloadInstance();
+}
 
-        for (std::string &&n : entryFileNames) {
-            std::string path = "Bundle\\" + n + ".bundle";
-            if (std::filesystem::exists(path)) {
-                return n;
-            }
-        }
+std::string ReactTestApp::GetBundleName()
+{
+    auto entryFileNames = {"index.windows",
+                           "main.windows",
+                           "index.native",
+                           "main.native",
+                           "index"
+                           "main"};
 
-        return "";
-    }
-
-    IAsyncOperation<bool> IsDevServerRunning()
-    {
-        Uri uri(L"http://localhost:8081/status");
-        HttpClient httpClient;
-        try {
-            auto r = co_await httpClient.GetAsync(uri);
-            co_return r.IsSuccessStatusCode();
-        } catch (winrt::hresult_error &) {
-            co_return false;
+    for (std::string main : entryFileNames) {
+        std::string path = "Bundle\\" + main + ".bundle";
+        if (std::filesystem::exists(path)) {
+            return main;
         }
     }
 
-}  // namespace ReactTestApp
+    return "";
+}
+
+IAsyncOperation<bool> ReactTestApp::IsDevServerRunning()
+{
+    Uri uri(L"http://localhost:8081/status");
+    HttpClient httpClient;
+    try {
+        auto r = co_await httpClient.GetAsync(uri);
+        co_return r.IsSuccessStatusCode();
+    } catch (winrt::hresult_error &) {
+        co_return false;
+    }
+}

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -1,3 +1,10 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #pragma once
 
 #include <string>
@@ -15,6 +22,8 @@ namespace ReactTestApp
     class ReactInstance
     {
     public:
+        ReactInstance();
+
         auto &ReactHost()
         {
             return reactNativeHost_;

--- a/windows/ReactTestApp/ReactPackageProvider.cpp
+++ b/windows/ReactTestApp/ReactPackageProvider.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#include "pch.h"
+
+#include "ReactPackageProvider.h"
+
+#include <NativeModules.h>
+
+using winrt::Microsoft::ReactNative::IReactPackageBuilder;
+using winrt::ReactTestApp::implementation::ReactPackageProvider;
+
+void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
+{
+    AddAttributedModules(packageBuilder);
+}

--- a/windows/ReactTestApp/ReactPackageProvider.h
+++ b/windows/ReactTestApp/ReactPackageProvider.h
@@ -1,0 +1,19 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::ReactTestApp::implementation
+{
+    struct ReactPackageProvider
+        : implements<ReactPackageProvider, Microsoft::ReactNative::IReactPackageProvider> {
+    public:
+        void CreatePackage(Microsoft::ReactNative::IReactPackageBuilder const &) noexcept;
+    };
+}  // namespace winrt::ReactTestApp::implementation

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
     <PropertyGroup Label="Globals">
         <CppWinRTOptimized>true</CppWinRTOptimized>
         <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -10,7 +10,7 @@
         <ProjectName>ReactTestApp</ProjectName>
         <RootNamespace>ReactTestApp</RootNamespace>
         <DefaultLanguage>en-US</DefaultLanguage>
-        <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
         <AppContainerApplication>true</AppContainerApplication>
         <ApplicationType>Windows Store</ApplicationType>
         <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
@@ -18,6 +18,11 @@
         <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     </PropertyGroup>
     <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="ReactNativeWindowsProps">
+        <ProjectRootDir Condition="'$(ProjectRootDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'app.json'))</ProjectRootDir>
+        <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+        <ReactTestAppDir Condition="'$(ReactTestAppDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows\ReactTestApp\</ReactTestAppDir>
+    </PropertyGroup>
     <ItemGroup Label="ProjectConfigurations">
         <ProjectConfiguration Include="Debug|ARM">
             <Configuration>Debug</Configuration>
@@ -54,13 +59,11 @@
     </ItemGroup>
     <PropertyGroup Label="Configuration">
         <ConfigurationType>Application</ConfigurationType>
-        <PlatformToolset>v140</PlatformToolset>
-        <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-        <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+        <PlatformToolset>v142</PlatformToolset>
         <CharacterSet>Unicode</CharacterSet>
         <BundleDirAssets>$(BundleDirContentPaths)</BundleDirAssets>
         <BundleFileAssets>$(BundleFileContentPaths)</BundleFileAssets>
-        <AssetsContentRoot>$(SourceFilesPath)\Assets</AssetsContentRoot>
+        <AssetsContentRoot>$(ReactTestAppDir)\Assets</AssetsContentRoot>
         <AssetsContent>$(AssetsContentRoot)\**\*</AssetsContent>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -73,40 +76,40 @@
         <LinkIncremental>false</LinkIncremental>
     </PropertyGroup>
     <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings">
-    </ImportGroup>
-    <ImportGroup Label="Shared">
-        <Import Project="$(ReactNativeModulePath)\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
-    </ImportGroup>
+    <ImportGroup Label="ExtensionSettings"></ImportGroup>
     <ImportGroup Label="PropertySheets">
         <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     </ImportGroup>
     <ImportGroup Label="PropertySheets">
         <Import Project="PropertySheet.props" />
     </ImportGroup>
+    <ImportGroup Label="ReactNativeWindowsPropertySheets">
+        <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" />
+        <Import Project="$(SolutionDir)packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)' != '' And Exists('$(SolutionDir)packages\$(WinUIPackageProps)')" />
+    </ImportGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SourceFilesPath)</IncludePath>
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
     </PropertyGroup>
     <ItemDefinitionGroup>
         <ClCompile>
@@ -117,88 +120,49 @@
             <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
             <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
             <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
-            <DisableSpecificWarnings>
-            </DisableSpecificWarnings>
+            <DisableSpecificWarnings></DisableSpecificWarnings>
             <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
         </ClCompile>
     </ItemDefinitionGroup>
     <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
         <ClCompile>
             <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
+            <TreatWarningAsError>true</TreatWarningAsError>
         </ClCompile>
     </ItemDefinitionGroup>
     <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
         <ClCompile>
             <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</TreatWarningAsError>
-            <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatWarningAsError>
+            <TreatWarningAsError>true</TreatWarningAsError>
         </ClCompile>
     </ItemDefinitionGroup>
     <ItemGroup>
-        <ClInclude Include="$(SourceFilesPath)\pch.h" />
-        <ClInclude Include="$(SourceFilesPath)\Manifest.h" />
-        <ClInclude Include="$(SourceFilesPath)\App.h">
-            <DependentUpon>$(SourceFilesPath)\App.xaml</DependentUpon>
+        <ClInclude Include="$(ReactTestAppDir)\pch.h" />
+        <ClInclude Include="$(ReactTestAppDir)\App.h">
+            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
         </ClInclude>
-        <ClInclude Include="$(SourceFilesPath)\MainPage.h">
-            <DependentUpon>$(SourceFilesPath)\MainPage.xaml</DependentUpon>
+        <ClInclude Include="$(ReactTestAppDir)\MainPage.h">
+            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
         </ClInclude>
-        <ClInclude Include="$(SourceFilesPath)\ReactInstance.h" />
+        <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
+        <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
+        <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
     </ItemGroup>
     <ItemGroup>
-        <ApplicationDefinition Include="$(SourceFilesPath)\App.xaml">
+        <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml">
             <SubType>Designer</SubType>
         </ApplicationDefinition>
-        <Page Include="$(SourceFilesPath)\MainPage.xaml">
+        <Page Include="$(ReactTestAppDir)\MainPage.xaml">
             <SubType>Designer</SubType>
         </Page>
     </ItemGroup>
     <ItemGroup>
-        <AppxManifest Include="$(SourceFilesPath)\Package.appxmanifest">
+        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest">
             <SubType>Designer</SubType>
         </AppxManifest>
     </ItemGroup>
     <ItemGroup>
-        <AssetsToBePackaged Include="$(AssetsContent)" />
-        <None Include="@(AssetsToBePackaged)">
-            <Link>$([MSBuild]::MakeRelative($(ProjectDir),'Assets\%(RecursiveDir)%(Filename)%(Extension)'))</Link>
-            <DeploymentContent>true</DeploymentContent>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <Text Include="$(ManifestRootPath)\app.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="$(SourceFilesPath)\pch.cpp">
-            <PrecompiledHeader>Create</PrecompiledHeader>
-        </ClCompile>
-        <ClCompile Include="$(SourceFilesPath)\App.cpp">
-            <DependentUpon>$(SourceFilesPath)\App.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="$(SourceFilesPath)\MainPage.cpp">
-            <DependentUpon>$(SourceFilesPath)\MainPage.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\Manifest.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\ReactInstance.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Midl Include="$(SourceFilesPath)\App.idl">
-            <DependentUpon>$(SourceFilesPath)\App.xaml</DependentUpon>
-        </Midl>
-        <Midl Include="$(SourceFilesPath)\MainPage.idl">
-            <DependentUpon>$(SourceFilesPath)\MainPage.xaml</DependentUpon>
-        </Midl>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-        <None Include="PropertySheet.props" />
+        <Text Include="$(ProjectRootDir)\app.json" />
     </ItemGroup>
     <ItemGroup>
         <BundleDirContentToBePackaged Include="$(BundleDirAssets)"/>
@@ -217,37 +181,63 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(ReactNativeModulePath)\Common\Common.vcxproj">
-            <Project>{fca38f3c-7c73-4c47-be4e-32f77fa8538d}</Project>
-        </ProjectReference>
-        <ProjectReference Include="$(ReactNativeModulePath)\Folly\Folly.vcxproj">
-            <Project>{a990658c-ce31-4bcc-976f-0fc6b1af693d}</Project>
-        </ProjectReference>
-        <ProjectReference Include="$(ReactNativeModulePath)\JSI\Universal\JSI.Universal.vcxproj">
-            <Project>{a62d504a-16b8-41d2-9f19-e2e86019e5e4}</Project>
-        </ProjectReference>
-        <ProjectReference Include="$(ReactNativeModulePath)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
-            <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
-            <Private>false</Private>
-        </ProjectReference>
-        <ProjectReference Include="$(ReactNativeModulePath)\ReactCommon\ReactCommon.vcxproj">
-            <Project>{a9d95a91-4db7-4f72-beb6-fe8a5c89bfbd}</Project>
-        </ProjectReference>
-        <ProjectReference Include="$(ReactNativeModulePath)\ReactWindowsCore\ReactWindowsCore.vcxproj">
-            <Project>{11c084a3-a57c-4296-a679-cac17b603144}</Project>
-        </ProjectReference>
+        <AssetsToBePackaged Include="$(AssetsContent)" />
+        <None Include="@(AssetsToBePackaged)">
+            <Link>$([MSBuild]::MakeRelative($(ProjectDir),'Assets\%(RecursiveDir)%(Filename)%(Extension)'))</Link>
+            <DeploymentContent>true</DeploymentContent>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+        <ClCompile Include="$(ReactTestAppDir)\pch.cpp">
+            <PrecompiledHeader>Create</PrecompiledHeader>
+        </ClCompile>
+        <ClCompile Include="$(ReactTestAppDir)\App.cpp">
+            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
+        </ClCompile>
+        <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp">
+            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
+        </ClCompile>
+        <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\ReactPackageProvider.cpp" />
+    </ItemGroup>
+    <ItemGroup>
+        <Midl Include="$(ReactTestAppDir)\App.idl">
+            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
+        </Midl>
+        <Midl Include="$(ReactTestAppDir)\MainPage.idl">
+            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
+        </Midl>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="packages.config" />
+        <None Include="PropertySheet.props" />
     </ItemGroup>
     <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    <ImportGroup Label="ReactNativeWindowsTargets">
+        <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
+    </ImportGroup>
+    <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references targets in your node_modules\react-native-windows folder. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props'))" />
+        <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
+    </Target>
     <ImportGroup Label="ExtensionTargets">
-        <Import Project="$(SolutionDir)packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" />
-        <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.0.63.2\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.0.63.2\build\native\Microsoft.ReactNative.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.0.63.2\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.0.63.2\build\native\Microsoft.ReactNative.Cxx.targets')" />
+        <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
+        <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
     </ImportGroup>
     <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
         <PropertyGroup>
             <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
         </PropertyGroup>
-        <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.7.3\build\native\nlohmann.json.targets'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
+        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+        <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets'))" />
     </Target>
 </Project>

--- a/windows/ReactTestApp/ReactTestApp.vcxproj.filters
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj.filters
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <ApplicationDefinition Include="$(SourceFilesPath)\App.xaml" />
+        <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml" />
     </ItemGroup>
     <ItemGroup>
-        <Page Include="$(SourceFilesPath)\MainPage.xaml" />
+        <Page Include="$(ReactTestAppDir)\MainPage.xaml" />
     </ItemGroup>
     <ItemGroup>
-        <Midl Include="$(SourceFilesPath)\App.idl" />
-        <Midl Include="$(SourceFilesPath)\MainPage.idl" />
+        <Midl Include="$(ReactTestAppDir)\App.idl" />
+        <Midl Include="$(ReactTestAppDir)\MainPage.idl" />
     </ItemGroup>
     <ItemGroup>
-        <ClCompile Include="$(SourceFilesPath)\pch.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\App.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\MainPage.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\pch.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\App.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
+        <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
         <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\Manifest.cpp" />
-        <ClCompile Include="$(SourceFilesPath)\ReactInstance.cpp" />
     </ItemGroup>
     <ItemGroup>
-        <ClInclude Include="$(SourceFilesPath)\pch.h" />
-        <ClInclude Include="$(SourceFilesPath)\Manifest.h" />
-        <ClInclude Include="$(SourceFilesPath)\ReactInstance.h" />
+        <ClInclude Include="$(ReactTestAppDir)\pch.h" />
+        <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
+        <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
     </ItemGroup>
     <ItemGroup>
-        <Text Include="$(ManifestRootPath)\app.json">
+        <Text Include="$(ProjectRootDir)\app.json">
             <Filter>Assets</Filter>
         </Text>
     </ItemGroup>
     <ItemGroup>
-        <AppxManifest Include="$(SourceFilesPath)\Package.appxmanifest" />
+        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" />
     </ItemGroup>
     <ItemGroup>
         <Filter Include="Assets">

--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200630.5" targetFramework="native" />
-  <package id="nlohmann.json" version="3.7.3" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.4.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="nlohmann.json" version="3.9.1" targetFramework="native" />
 </packages>

--- a/windows/ReactTestApp/pch.cpp
+++ b/windows/ReactTestApp/pch.cpp
@@ -1,1 +1,8 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #include "pch.h"

--- a/windows/ReactTestApp/pch.h
+++ b/windows/ReactTestApp/pch.h
@@ -1,4 +1,13 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 #pragma once
+
+#define NOMINMAX
 
 #include <hstring.h>
 #include <restrictederrorinfo.h>
@@ -6,6 +15,14 @@
 #include <windows.h>
 
 #include <winrt/Microsoft.ReactNative.h>
+
+#if __has_include(<winrt/Microsoft.UI.Xaml.Controls.h>)
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#endif
+#if __has_include(<winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>)
+#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
+#endif
+
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,6 +1494,11 @@
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/mustache@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz#e4d421ed2d06d463b120621774185a5cd1b92d77"
+  integrity sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==
+
 "@types/node@*", "@types/node@>= 8":
   version "14.10.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
@@ -3527,7 +3532,7 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-jest@^24.0.1:
+eslint-plugin-jest@^24.0.0:
   version "24.0.1"
   resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.0.1.tgz#ad5e091d47cf895e15dc115e18f98471135a334f"
   integrity sha512-8tYFDqOHGr7vVfdVYspmlV4sRBTylrM4gSLgkGKlO6F+djDOEJ+tEU7I50smUs7AIvFnNZutXUQAMgI9s9N6xQ==


### PR DESCRIPTION
#### Test Plan

1. Bump react-native and react-native-windows to 0.63 (see patch below)
2. Build Windows test app

```diff
diff --git a/example/package.json b/example/package.json
index 14029ce..4971467 100644
--- a/example/package.json
+++ b/example/package.json
@@ -20,10 +20,9 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "react": "16.11.0",
-    "react-native": "0.62.2",
-    "react-native-macos": "0.62.1",
+    "react": "16.13.1",
+    "react-native": "0.63.2",
     "react-native-test-app": "../",
-    "react-native-windows": "0.62.7"
+    "react-native-windows": "0.63.1"
   }
 }
```