### PR TITLE
fix(Android): Wrong version of Hermes is bundled in APK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,11 @@
 buildDir = "$rootDir/build"
 
+def reactNativeDir = findNodeModulesPath(rootDir, "react-native")
+def hermesEngineDir =
+    findNodeModulesPath(file(reactNativeDir), "hermes-engine")
+        ?: findNodeModulesPath(file(reactNativeDir), "hermesvm")
+def hermesAndroidDir = "$hermesEngineDir/android"
+
 buildscript {
     ext.kotlinVersion = "1.3.72"
 
@@ -19,7 +25,7 @@ buildscript {
 
 repositories {
     maven {
-        url("${findNodeModulesPath(rootDir, "react-native")}/android")
+        url("${reactNativeDir}/android")
     }
 
     google()
@@ -76,9 +82,6 @@ android {
     }
 }
 
-def hermesEnginePath = findNodeModulesPath(projectDir, "hermes-engine") ?: findNodeModulesPath(projectDir, "hermesvm")
-def hermesPath = "$hermesEnginePath/android"
-
 dependencies {
     implementation "com.google.dagger:dagger:2.28.3"
     implementation "com.google.dagger:dagger-android:2.28.3"
@@ -87,8 +90,8 @@ dependencies {
     kapt("com.google.dagger:dagger-compiler:2.28.3")
     kapt("com.google.dagger:dagger-android-processor:2.28.3")
 
-    releaseImplementation files("$hermesPath/hermes-release.aar")
-    debugImplementation files("$hermesPath/hermes-debug.aar")
+    releaseImplementation files("$hermesAndroidDir/hermes-release.aar")
+    debugImplementation files("$hermesAndroidDir/hermes-debug.aar")
 
     if (buildReactNativeFromSource(rootDir)) {
         implementation project(':ReactAndroid')


### PR DESCRIPTION
The wrong version of Hermes can be bundled in the APK if multiple versions are installed and the wrong version is being hoisted. For instance, bumping `react-native` to ^0.63 and keeping `react-native-macos` at ^0.62, will install both `hermes-engine@0.5.1` and `hermes-engine@0.4.3`, where the latter is hoisted. We fix this by using `react-native`'s `node_modules` folder as starting point when looking for `hermes-engine`.

Resolves #207

#### Test Plan

1. Bump`react-native` to ^0.63 and remove `react-native-windows`
    ```diff
    diff --git a/example/package.json b/example/package.json
    index b0c89af..99f65f6 100644
    --- a/example/package.json
    +++ b/example/package.json
    @@ -21,10 +21,9 @@
       "devDependencies": {
         "@babel/core": "^7.0.0",
         "mkdirp": "^0.5.1",
    -    "react": "16.11.0",
    -    "react-native": "0.62.2",
    +    "react": "16.13.1",
    +    "react-native": "0.63.2",
         "react-native-macos": "0.62.10",
    -    "react-native-test-app": "../",
    -    "react-native-windows": "0.62.9"
    +    "react-native-test-app": "../"
       }
     }
    ```
2. Observe that two versions of `hermes-engine` are installed
    ```
    % yarn why hermes-engine
    yarn why v1.22.5
    [1/4] 🤔  Why do we have the module "hermes-engine"...?
    [2/4] 🚚  Initialising dependency graph...
    [3/4] 🔍  Finding dependency...
    [4/4] 🚡  Calculating file sizes...
    => Found "hermes-engine@0.4.3"
    info Reasons this module exists
    - "react-native-macos" depends on it
    - Hoisted from "react-native-macos#hermes-engine"
    info Disk size without dependencies: "140.31MB"
    info Disk size with unique dependencies: "140.31MB"
    info Disk size with transitive dependencies: "140.31MB"
    info Number of shared dependencies: 0
    => Found "react-native#hermes-engine@0.5.1"
    info This module exists because "react-native" depends on it.
    info Disk size without dependencies: "17.72MB"
    info Disk size with unique dependencies: "17.72MB"
    info Disk size with transitive dependencies: "17.72MB"
    info Number of shared dependencies: 0
    ✨  Done in 0.72s.
    ```
3. Observe that the 0.4.3 is hoisted
    ```
    % head node_modules/hermes-engine/package.json
    {
      "name": "hermes-engine",
      "version": "0.4.3",
      "private": false,
      "description": "A JavaScript engine optimized for running React Native on Android",
      "license": "MIT",
      "repository": {
        "type": "git",
        "url": "git@github.com:facebook/hermes.git"
      },
    ```
4. Build and run Android test app
