### PR TITLE
fix(Windows): Don't hard-code paths to project files

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -260,9 +260,17 @@ function generateSolution(destPath, noAutolink) {
     projectFilesDestPath
   );
 
+  const { version: rnWindowsVersion } = JSON.parse(
+    fs.readFileSync(path.join(rnWindowsPath, "package.json"), {
+      encoding: "utf8",
+    })
+  );
+
   const projectFilesReplacements = {
     "\\$\\(BundleDirContentPaths\\)": bundleDirContent,
     "\\$\\(BundleFileContentPaths\\)": bundleFileContent,
+    "packages\\\\Microsoft\\.ReactNative\\.0\\.63\\.2\\\\build\\\\native\\\\Microsoft\\.ReactNative\\.targets": `packages\\Microsoft.ReactNative.${rnWindowsVersion}\\build\\native\\Microsoft.ReactNative.targets`,
+    "packages\\\\Microsoft\\.ReactNative\\.Cxx\\.0\\.63\\.2\\\\build\\\\native\\\\Microsoft\\.ReactNative\\.Cxx\\.targets": `packages\\Microsoft.ReactNative.Cxx.${rnWindowsVersion}\\build\\native\\Microsoft.ReactNative.Cxx.targets`,
   };
 
   const copyTasks = [


### PR DESCRIPTION
Of all 0.63 versions, only 0.63.2 currently works as the project file has hard-coded paths to `.targets` files.

#### Test Plan

1. Bump `react-native` and `react-native-windows` to latest 0.63 (see patch)
2. Build Example app

```diff
diff --git a/example/package.json b/example/package.json
index 5bde75f..c7d8ce9 100644
--- a/example/package.json
+++ b/example/package.json
@@ -25,10 +25,9 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "react": "16.11.0",
-    "react-native": "0.62.2",
-    "react-native-macos": "0.62.14",
+    "react": "16.13.1",
+    "react-native": "0.63.3",
     "react-native-test-app": "../",
-    "react-native-windows": "0.62.12"
+    "react-native-windows": "0.63.3"
   }
 }
```