### PR TITLE
fix: Align with Expo's way to set applicationId/bundleIdentifier

### DIFF
--- a/android/react-native-build.gradle
+++ b/android/react-native-build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath 'de.undercouch:gradle-download-task:4.0.4'
     }
 }

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 import java.nio.file.Paths
 
 ext.buildReactNativeFromSource = { baseDir ->
@@ -49,7 +51,7 @@ ext.findNodeModulesPath = { baseDir, packageName ->
     // Node's module resolution algorithm searches up to the root directory,
     // after which the base path will be null
     while (basePath) {
-        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
+        def candidatePath = Paths.get(basePath.toString(), 'node_modules', packageName)
         if (candidatePath.toFile().exists()) {
             return candidatePath.toString()
         }
@@ -60,9 +62,31 @@ ext.findNodeModulesPath = { baseDir, packageName ->
     return null
 }
 
-ext.getApplicationId = {
+ext.getApplicationId = { baseDir ->
+    def manifestFile = findFile('app.json')
+    if (manifestFile != null) {
+        def manifest = new JsonSlurper().parseText(manifestFile.text)
+        def config = manifest['android']
+        if (config instanceof Object && config.containsKey('package')) {
+            return config['package']
+        }
+    }
+
     if (project.hasProperty('TEST_APP_IDENTIFIER')) {
-        return project.getProperty('TEST_APP_IDENTIFIER')
+        def applicationId = project.getProperty('TEST_APP_IDENTIFIER')
+        logger.warn('WARNING: Setting TEST_APP_IDENTIFIER in `gradle.properties` is deprecated')
+        logger.warn('WARNING: Please set the application identifier in `app.json`, e.g.')
+        logger.warn('WARNING:')
+        logger.warn('WARNING:     {')
+        logger.warn('WARNING:       "name": "Example",')
+        logger.warn('WARNING:       "displayName": "Example",')
+        logger.warn('WARNING:       "components": [],')
+        logger.warn('WARNING:       "resources": {},')
+        logger.warn('WARNING:       "android": {')
+        logger.warn("WARNING:         \"package\": \"${applicationId}\"")
+        logger.warn('WARNING:       }')
+        logger.warn('WARNING:     }')
+        return applicationId
     }
 
     return 'com.react.testapp'
@@ -84,7 +108,7 @@ ext.getFlipperVersion = { baseDir ->
     // Prefer user specified Flipper version
     if (project.hasProperty('FLIPPER_VERSION')) {
         def flipperVersion = project.getProperty('FLIPPER_VERSION')
-        return flipperVersion == "false" ? null : flipperVersion
+        return flipperVersion == 'false' ? null : flipperVersion
     }
 
     // Use the recommended Flipper version

--- a/test/__fixtures__/with_platform_resources/app.json
+++ b/test/__fixtures__/with_platform_resources/app.json
@@ -16,5 +16,11 @@
       "dist-macos/assets",
       "dist-macos/main.jsbundle"
     ]
+  },
+  "ios": {
+    "bundleIdentifier": "com.react.ReactTestApp-ios"
+  },
+  "macos": {
+    "bundleIdentifier": "com.react.ReactTestApp-macos"
   }
 }

--- a/test/__fixtures__/without_platform_resources/app.json
+++ b/test/__fixtures__/without_platform_resources/app.json
@@ -7,6 +7,7 @@
       "displayName": "Test"
     }
   ],
-  "resources": {
-  }
+  "resources": {},
+  "ios": {},
+  "macos": {}
 }

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -108,6 +108,15 @@ class TestTestApp < Minitest::Test
   end
 
   %i[ios macos].each do |target|
+    define_method("test_#{target}_bundle_identifier") do
+      assert_equal("com.react.ReactTestApp-#{target}",
+                   bundle_identifier(fixture_path('with_platform_resources'), target))
+      assert_nil(bundle_identifier(fixture_path('without_platform_resources'), target))
+      assert_nil(bundle_identifier(fixture_path('without_resources'), target))
+    end
+  end
+
+  %i[ios macos].each do |target|
     define_method("test_#{target}_resources_pod_returns_spec_path") do
       assert_nil(resources_pod(Pathname.new('/'), target))
       assert_nil(resources_pod(Pathname.new('.'), target))


### PR DESCRIPTION
From Expo's documentation:
- [android.package](https://docs.expo.io/versions/v39.0.0/config/app/#package)
- [ios.bundleIdentifier](https://docs.expo.io/versions/v39.0.0/config/app/#bundleidentifier)

#### Test Plan

- **Android:**
  1. Setting `TEST_APP_IDENTIFIER` in `gradle.properties` should output a deprecation warning, but still set `applicationId` correctly
  2. Setting `android.package` in `app.json` should correctly set `applicationId`
  3. If both are set, the one in `app.json` should take precedence
- **iOS:**
  1. Calling `test_app_bundle_identifier()` should output output a deprecation warning, but still set `bundleIdentifier` correctly
  2. Setting `ios.bundleIdentifier` in `app.json` should correctly set `bundleIdentifier`
  3. If both are set, the one in `app.json` should take precedence
- **macOS:** See iOS steps.
