### PR TITLE
React Native Path from Manifest

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.62.1)
-  - FBReactNativeSpec (0.62.1):
+  - FBLazyVector (0.62.14)
+  - FBReactNativeSpec (0.62.14):
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.1)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
+    - RCTRequired (= 0.62.14)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
   - glog (0.3.5)
   - RCT-Folly (2018.10.22.00):
     - boost-for-react-native
@@ -22,231 +22,231 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.62.1)
-  - RCTTypeSafety (0.62.1):
-    - FBLazyVector (= 0.62.1)
+  - RCTRequired (0.62.14)
+  - RCTTypeSafety (0.62.14):
+    - FBLazyVector (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.1)
-    - React-Core (= 0.62.1)
-  - React (0.62.1):
-    - React-Core (= 0.62.1)
-    - React-Core/DevSupport (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-RCTActionSheet (= 0.62.1)
-    - React-RCTAnimation (= 0.62.1)
-    - React-RCTBlob (= 0.62.1)
-    - React-RCTImage (= 0.62.1)
-    - React-RCTLinking (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - React-RCTSettings (= 0.62.1)
-    - React-RCTText (= 0.62.1)
-    - React-RCTVibration (= 0.62.1)
-  - React-Core (0.62.1):
+    - RCTRequired (= 0.62.14)
+    - React-Core (= 0.62.14)
+  - React (0.62.14):
+    - React-Core (= 0.62.14)
+    - React-Core/DevSupport (= 0.62.14)
+    - React-Core/RCTWebSocket (= 0.62.14)
+    - React-RCTActionSheet (= 0.62.14)
+    - React-RCTAnimation (= 0.62.14)
+    - React-RCTBlob (= 0.62.14)
+    - React-RCTImage (= 0.62.14)
+    - React-RCTLinking (= 0.62.14)
+    - React-RCTNetwork (= 0.62.14)
+    - React-RCTSettings (= 0.62.14)
+    - React-RCTText (= 0.62.14)
+    - React-RCTVibration (= 0.62.14)
+  - React-Core (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-Core/Default (= 0.62.14)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - Yoga
-  - React-Core/Default (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - Yoga
-  - React-Core/DevSupport (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - React-jsinspector (= 0.62.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.62.1):
+  - React-Core/CoreModulesHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.62.1):
+  - React-Core/Default (0.62.14):
+    - glog
+    - RCT-Folly (= 2018.10.22.00)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
+    - Yoga
+  - React-Core/DevSupport (0.62.14):
+    - glog
+    - RCT-Folly (= 2018.10.22.00)
+    - React-Core/Default (= 0.62.14)
+    - React-Core/RCTWebSocket (= 0.62.14)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
+    - React-jsinspector (= 0.62.14)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.62.1):
+  - React-Core/RCTAnimationHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTImageHeaders (0.62.1):
+  - React-Core/RCTBlobHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.62.1):
+  - React-Core/RCTImageHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.62.1):
+  - React-Core/RCTLinkingHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.62.1):
+  - React-Core/RCTNetworkHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTTextHeaders (0.62.1):
+  - React-Core/RCTSettingsHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.62.1):
+  - React-Core/RCTTextHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-Core/RCTWebSocket (0.62.1):
+  - React-Core/RCTVibrationHeaders (0.62.14):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-Core/Default
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
     - Yoga
-  - React-CoreModules (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+  - React-Core/RCTWebSocket (0.62.14):
+    - glog
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/CoreModulesHeaders (= 0.62.1)
-    - React-RCTImage (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-cxxreact (0.62.1):
+    - React-Core/Default (= 0.62.14)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-jsiexecutor (= 0.62.14)
+    - Yoga
+  - React-CoreModules (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
+    - RCT-Folly (= 2018.10.22.00)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core/CoreModulesHeaders (= 0.62.14)
+    - React-RCTImage (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-cxxreact (0.62.14):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsinspector (= 0.62.1)
-  - React-jsi (0.62.1):
+    - React-jsinspector (= 0.62.14)
+  - React-jsi (0.62.14):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsi/Default (= 0.62.1)
-  - React-jsi/Default (0.62.1):
+    - React-jsi/Default (= 0.62.14)
+  - React-jsi/Default (0.62.14):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-  - React-jsiexecutor (0.62.1):
+  - React-jsiexecutor (0.62.14):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-  - React-jsinspector (0.62.1)
-  - React-RCTActionSheet (0.62.1):
-    - React-Core/RCTActionSheetHeaders (= 0.62.1)
-  - React-RCTAnimation (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+  - React-jsinspector (0.62.14)
+  - React-RCTActionSheet (0.62.14):
+    - React-Core/RCTActionSheetHeaders (= 0.62.14)
+  - React-RCTAnimation (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTAnimationHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTBlob (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core/RCTAnimationHeaders (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTBlob (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTBlobHeaders (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTImage (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - React-Core/RCTBlobHeaders (= 0.62.14)
+    - React-Core/RCTWebSocket (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - React-RCTNetwork (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTImage (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTImageHeaders (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTLinking (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
-    - React-Core/RCTLinkingHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTNetwork (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core/RCTImageHeaders (= 0.62.14)
+    - React-RCTNetwork (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTLinking (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
+    - React-Core/RCTLinkingHeaders (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTNetwork (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTNetworkHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTSettings (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core/RCTNetworkHeaders (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTSettings (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTSettingsHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTText (0.62.1):
-    - React-Core/RCTTextHeaders (= 0.62.1)
-  - React-RCTVibration (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.14)
+    - React-Core/RCTSettingsHeaders (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - React-RCTText (0.62.14):
+    - React-Core/RCTTextHeaders (= 0.62.14)
+  - React-RCTVibration (0.62.14):
+    - FBReactNativeSpec (= 0.62.14)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTVibrationHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - ReactCommon/callinvoker (0.62.1):
+    - React-Core/RCTVibrationHeaders (= 0.62.14)
+    - ReactCommon/turbomodule/core (= 0.62.14)
+  - ReactCommon/callinvoker (0.62.14):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-  - ReactCommon/turbomodule/core (0.62.1):
+    - React-cxxreact (= 0.62.14)
+  - ReactCommon/turbomodule/core (0.62.14):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - ReactCommon/callinvoker (= 0.62.1)
+    - React-Core (= 0.62.14)
+    - React-cxxreact (= 0.62.14)
+    - React-jsi (= 0.62.14)
+    - ReactCommon/callinvoker (= 0.62.14)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.40.0)
+  - SwiftLint (0.40.2)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -279,7 +279,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native-macos/Libraries/Vibration`)
   - ReactCommon/callinvoker (from `../node_modules/react-native-macos/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
-  - ReactTestApp-DevSupport (from `../..`)
+  - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - ReactTestApp-Resources (from `..`)
   - SwiftLint
   - Yoga (from `../node_modules/react-native-macos/ReactCommon/yoga`)
@@ -342,7 +342,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native-macos/ReactCommon"
   ReactTestApp-DevSupport:
-    :path: "../.."
+    :path: "../node_modules/react-native-test-app"
   ReactTestApp-Resources:
     :path: ".."
   Yoga:
@@ -352,33 +352,33 @@ SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 681b789128e5512811c81706e9b361209f40d21e
   Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
-  FBLazyVector: 4cccc4ac9816ce336701763ca24877286d8b681a
-  FBReactNativeSpec: 150543c16ce5c258d5aaf12ae2ae994a1237d615
+  FBLazyVector: 64af00ac48ff254b9f04ed8676666290d647878f
+  FBReactNativeSpec: ac3acb7b5521e817980813975dacd9b4d96fd4bb
   glog: d86cb3634e15ec6d8cd9a1c7c1b9d6fa295beb37
   RCT-Folly: 71ece0166f9c96c1ec9279eeb0317baf533c020f
-  RCTRequired: e183b4ec3b3651e83c81568b918a274b8bc099db
-  RCTTypeSafety: f1b73ad47c3bda0695695188254708b20856d5b7
-  React: 3c009f39e0dca4c26386bbac7af671cab8c98f5b
-  React-Core: a78e0e78dc7798cfddfe07da4beae854de7bcb00
-  React-CoreModules: 2e8e91fe4d4af1b492c0806068ef570eac678c34
-  React-cxxreact: f4e3c0a083c1c97a665f9770367100eacc9dde24
-  React-jsi: 75dcebdd14a57bc052b46d316a56617faffb518b
-  React-jsiexecutor: 42cfdf5c3d2664c08ad6f66358fa83ffb1f734e0
-  React-jsinspector: 490839681e1c43c7c0e38dbcb2e581d76e509b72
-  React-RCTActionSheet: de9959e2ea34242108e5a51d79b0f10a67245363
-  React-RCTAnimation: d6347f13c2543e19b2abdd97bd2cb183d5668a70
-  React-RCTBlob: 78ec255b47dc176f7cba94a0c9eba5d9749a2bdc
-  React-RCTImage: e63bdfd21005fe1aea7f13677873260579c6c891
-  React-RCTLinking: 0668870012eeb661b1c48b30cd4027b901971fa2
-  React-RCTNetwork: 719f35fad1d03d8c1d945c587dd7fd7476f66b24
-  React-RCTSettings: 67aff9438c39896150cc63c07d36aa46ccd8c815
-  React-RCTText: 74947882a3d7632add1490f29f5be0aba6cc2587
-  React-RCTVibration: 2bb1044cc49aba5810d09fcb658b18f4df69aec9
-  ReactCommon: 5832dcdbcccc6bdc11f99181df74ed5f2b47789a
+  RCTRequired: 5bcfa563978fc37a5443dcfbc8acaa7136161841
+  RCTTypeSafety: f252cb22d0cc4d1b22eedce462b8384094e854ae
+  React: c3b1aa0716f061b32503c6f2d7b9ba30ff5ea4df
+  React-Core: b3ebb2e0952f67e615db7f1873b107610286fd30
+  React-CoreModules: 4707ba8729b34203389824da451630fa755b6d3f
+  React-cxxreact: 5621b91c130a495912e9992c972a42e8f336be66
+  React-jsi: 0f67f38c9417ebc2395f28e19f9c7e73fc5e004e
+  React-jsiexecutor: 51ee120f3042947e385d62dd5a20d7feabbb5b55
+  React-jsinspector: d6f22dca7a6c4fea888f6314aeed609b1d078813
+  React-RCTActionSheet: c3508a9795a797aa7713f3b7322fafa7c0c7eaf4
+  React-RCTAnimation: a03dc8f92bb7efd3163fc159acdfddae2d6896c7
+  React-RCTBlob: c3c3e9966c73a506a63cc58c92a2446fd4938889
+  React-RCTImage: 02ec162522faac9d7d2dc1d2a0893c070526ec76
+  React-RCTLinking: 67051057845f14e443b0736b18067146aa543490
+  React-RCTNetwork: 52514a8e58b2aca7833ec67f6aac9e03742db177
+  React-RCTSettings: 61ecea1046995a97d3ab7682dd8201ddb59c0bc5
+  React-RCTText: dd94cf282282ba6ef6ab649df85938b71554efa0
+  React-RCTVibration: 92273da15320bfd26c1526b9a8dfb8e49f2953c6
+  ReactCommon: f809132fbaae5c69015cbec7090ad180eacf81bc
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
-  SwiftLint: 4154893c73a4c52d6240195507eb7a3e3c64087e
-  Yoga: af4be6a73a3dfa9f8108031e617610931101b809
+  SwiftLint: 1216c910d27c2633ade33b4f071bb6b930982e62
+  Yoga: 2f7b6d55f1cd5cc888a45cfe927f9d7eb2521a78
 
 PODFILE CHECKSUM: 46118b2425d29bf77d0f229aa6514b3efa6510fa
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -48,7 +48,7 @@ def react_native_path_from_manifest(project_root, target_platform)
   return if config.nil?
 
   react_native_path = config['reactNativePath']
-  return Pathname.new(resolve_module(react_native_path)) if react_native_path.is_a? String
+  return react_native_path if react_native_path.is_a? String
 end
 
 def find_file(file_name, current_dir)
@@ -95,7 +95,7 @@ end
 
 def react_native_path(project_root, target_platform)
   react_native_from_manifest = react_native_path_from_manifest(project_root, target_platform)
-  return react_native_from_manifest unless react_native_from_manifest.nil?
+  return Pathname.new(resolve_module(react_native_from_manifest)) unless react_native_from_manifest.nil?
 
   react_native = case target_platform
                  when :ios then 'react-native'

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -43,7 +43,7 @@ def bundle_identifier(project_root, target_platform)
   @test_app_bundle_identifier
 end
 
-def react_native_path_from_manifest(project_root, target_platform)
+def react_native_from_manifest(project_root, target_platform)
   config = platform_config(project_root, target_platform)
   return if config.nil?
 
@@ -94,7 +94,7 @@ def project_path(file, target_platform)
 end
 
 def react_native_path(project_root, target_platform)
-  react_native_from_manifest = react_native_path_from_manifest(project_root, target_platform)
+  react_native_from_manifest = react_native_from_manifest(project_root, target_platform)
   return Pathname.new(resolve_module(react_native_from_manifest)) unless react_native_from_manifest.nil?
 
   react_native = case target_platform

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -95,7 +95,7 @@ end
 
 def react_native_path(project_root, target_platform)
   react_native_from_manifest = react_native_from_manifest(project_root, target_platform)
-  return Pathname.new(resolve_module(react_native_from_manifest)) unless react_native_from_manifest.nil?
+  return Pathname.new(resolve_module(react_native_from_manifest)) if !react_native_from_manifest.nil?
 
   react_native = case target_platform
                  when :ios then 'react-native'

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -48,7 +48,7 @@ def react_native_path_from_manifest(project_root, target_platform)
   return if config.nil?
 
   react_native_path = config['reactNativePath']
-  return Pathname.new(resolve_module(react_native_path)) if react_native_path.is_a? String 
+  return Pathname.new(resolve_module(react_native_path)) if react_native_path.is_a? String
 end
 
 def find_file(file_name, current_dir)
@@ -96,7 +96,7 @@ end
 def react_native_path(project_root, target_platform)
   react_native_from_manifest = react_native_path_from_manifest(project_root, target_platform)
   return react_native_from_manifest unless react_native_from_manifest.nil?
-  
+
   react_native = case target_platform
                  when :ios then 'react-native'
                  when :macos then 'react-native-macos'

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -94,8 +94,8 @@ def project_path(file, target_platform)
 end
 
 def react_native_path(project_root, target_platform)
-  react_native_from_manifest = react_native_from_manifest(project_root, target_platform)
-  return Pathname.new(resolve_module(react_native_from_manifest)) if !react_native_from_manifest.nil?
+  react_native_path = react_native_from_manifest(project_root, target_platform)
+  return Pathname.new(resolve_module(react_native_path)) unless react_native_path.nil?
 
   react_native = case target_platform
                  when :ios then 'react-native'

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -95,7 +95,7 @@ end
 def react_native_path(project_root, target_platform)
   react_native_from_manifest = react_native_path_from_manifest(project_root, target_platform)
   if !react_native_from_manifest.nil?
-    react_native_from_manifest
+    Pathname.new(resolve_module(react_native_from_manifest))
   else
     react_native = case target_platform
                   when :ios then 'react-native'

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -26,29 +26,29 @@ end
 
 def platform_config(project_root, target_platform)
   manifest_path = find_file('app.json', project_root)
-  unless manifest_path.nil?
-      manifest = JSON.parse(File.read(manifest_path))
-      config = manifest[target_platform.to_s]
-      return config if !config.nil? && !config.empty?
-  end
+  return if manifest_path.nil?
+
+  manifest = JSON.parse(File.read(manifest_path))
+  config = manifest[target_platform.to_s]
+  return config if !config.nil? && !config.empty?
 end
 
 def bundle_identifier(project_root, target_platform)
   config = platform_config(project_root, target_platform)
-  unless config.nil?
-    bundle_identifier = config['bundleIdentifier']
-    return bundle_identifier if bundle_identifier.is_a? String
-  end
+  return if config.nil?
+
+  bundle_identifier = config['bundleIdentifier']
+  return bundle_identifier if bundle_identifier.is_a? String
 
   @test_app_bundle_identifier
 end
 
-def react_native_path_from_manifest(project_root, target_platform) 
+def react_native_path_from_manifest(project_root, target_platform)
   config = platform_config(project_root, target_platform)
-  unless config.nil?
-    reactNativePath = config['reactNativePath']
-    return Pathname.new(resolve_module(reactNativePath)) if reactNativePath.is_a? String
-  end
+  return if config.nil?
+
+  react_native_path = config['reactNativePath']
+  return Pathname.new(resolve_module(react_native_path)) if react_native_path.is_a? String 
 end
 
 def find_file(file_name, current_dir)
@@ -96,11 +96,12 @@ end
 def react_native_path(project_root, target_platform)
   react_native_from_manifest = react_native_path_from_manifest(project_root, target_platform)
   return react_native_from_manifest unless react_native_from_manifest.nil?
+  
   react_native = case target_platform
-                  when :ios then 'react-native'
-                  when :macos then 'react-native-macos'
-                  else raise "Unsupported target platform: #{target_platform}"
-                  end
+                 when :ios then 'react-native'
+                 when :macos then 'react-native-macos'
+                 else raise "Unsupported target platform: #{target_platform}"
+                 end
   Pathname.new(resolve_module(react_native))
 end
 

--- a/test/__fixtures__/with_platform_resources/app.json
+++ b/test/__fixtures__/with_platform_resources/app.json
@@ -18,9 +18,11 @@
     ]
   },
   "ios": {
-    "bundleIdentifier": "com.react.ReactTestApp-ios"
+    "bundleIdentifier": "com.react.ReactTestApp-ios",
+    "reactNativePath":"react-native-ios"
   },
   "macos": {
-    "bundleIdentifier": "com.react.ReactTestApp-macos"
+    "bundleIdentifier": "com.react.ReactTestApp-macos",
+    "reactNativePath":"react-native-macos"
   }
 }

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -118,10 +118,10 @@ class TestTestApp < Minitest::Test
 
   %i[ios macos].each do |target|
     define_method("test_#{target}_react_native_path") do
-      assert_equal("react-native-#{target}", 
-                    react_native_path_from_manifest(fixture_path('with_platform_resources'), target))
-      assert_nil(react_native_path_from_manifest(fixture_path('without_platform_resources'), target))
-      assert_nil(react_native_path_from_manifest(fixture_path('without_resources'), target))
+      assert_equal("react-native-#{target}",
+                   react_native_from_manifest(fixture_path('with_platform_resources'), target))
+      assert_nil(react_native_from_manifest(fixture_path('without_platform_resources'), target))
+      assert_nil(react_native_from_manifest(fixture_path('without_resources'), target))
     end
   end
 

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -117,6 +117,15 @@ class TestTestApp < Minitest::Test
   end
 
   %i[ios macos].each do |target|
+    define_method("test_#{target}_react_native_path") do
+      assert_equal("react-native-#{target}", 
+                    react_native_path_from_manifest(fixture_path('with_platform_resources'), target))
+      assert_nil(react_native_path_from_manifest(fixture_path('without_platform_resources'), target))
+      assert_nil(react_native_path_from_manifest(fixture_path('without_resources'), target))
+    end
+  end
+
+  %i[ios macos].each do |target|
     define_method("test_#{target}_resources_pod_returns_spec_path") do
       assert_nil(resources_pod(Pathname.new('/'), target))
       assert_nil(resources_pod(Pathname.new('.'), target))


### PR DESCRIPTION
**Objective**

To support scenarios where there is custom react-native fork, we need to have configurable way to get react-native path.

**Changes**
We have added a new property in platform specific configuration in `manifest.json`, similar to `bundleIdentifier`.
```
{
  "name": "Example",
  "displayName": "Example",
  "components": [
    {
      "appKey": "Example",
      "displayName": "App"
    }
  ],
  "macos": {
    "bundleIdentifier": "..."
    "reactNativePath": "react-native-macos"
  }
}
```

If the **app manifest** has the property `reactNativePath`, we will use that as react-native path, else we fallback to default value.
