### PR TITLE
fix: Suppress nullability-completeness for React

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -309,6 +309,12 @@ def use_test_app_internal!(target_platform)
         target.build_configurations.each do |config|
           config.build_settings['SWIFT_VERSION'] = '4.1'
         end
+      when /\AReact/
+        target.build_configurations.each do |config|
+          # Xcode 10.2 requires suppression of nullability for React
+          # https://stackoverflow.com/questions/37691049/xcode-compile-flag-to-suppress-nullability-warnings-not-working
+          config.build_settings['WARNING_CFLAGS'] ||= ['"-Wno-nullability-completeness"']
+        end
       end
     end
   end


### PR DESCRIPTION
Newer React Native versions have incomplete nullability annotations,
causing build errors when -Wall is enabled. This change disables these
annotation warnings for the React pods.