### PR TITLE
ci(Windows): Bump microsoft/setup-msbuild to address security vulnerability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
         configuration: [Debug, Release]
     steps:
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Setup VSTest.console.exe
         uses: darenm/Setup-VSTest@v1
       - name: Set up Node.js
@@ -384,7 +384,7 @@ jobs:
         template: [all, windows]
     steps:
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
### Description

Windows CI is failing due to a security vulnerability in the `add-path` command used by `microsoft/setup-msbuild`. This is addressed in the latest version.

```
Run microsoft/setup-msbuild@v1.0.1
  with:
C:\ProgramData\Chocolatey\bin\vswhere.exe -products * -requires Microsoft.Component.MSBuild -property installationPath -latest
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
Error: Unable to process command '::add-path::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This is currently blocking #246 from getting merged.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Windows CI should succeed.