### PR TITLE
fix(Windows): Test app fails to load embedded JS bundle

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "optional": "cpp",
         "string": "cpp",
         "vector": "cpp"
-    }
+    },
+    "react-native-tools.projectRoot": "./example"
 }

--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -113,17 +113,16 @@ MainPage::MainPage()
     InitializeComponent();
     InitializeTitleBar();
     InitializeReactMenu();
-    InitializeDebugMenu();
 }
 
 void MainPage::LoadFromDevServer(IInspectable const &, RoutedEventArgs)
 {
-    reactInstance_.LoadJSBundleFrom(JSBundleSource::DevServer);
+    LoadJSBundleFrom(JSBundleSource::DevServer);
 }
 
 void MainPage::LoadFromJSBundle(IInspectable const &, RoutedEventArgs)
 {
-    reactInstance_.LoadJSBundleFrom(JSBundleSource::Embedded);
+    LoadJSBundleFrom(JSBundleSource::Embedded);
 }
 
 void MainPage::Reload(Windows::Foundation::IInspectable const &, Windows::UI::Xaml::RoutedEventArgs)
@@ -170,8 +169,13 @@ IAsyncAction MainPage::OnNavigatedTo(NavigationEventArgs const &e)
     Base::OnNavigatedTo(e);
 
     bool devServerIsRunning = co_await ::ReactTestApp::IsDevServerRunning();
-    reactInstance_.LoadJSBundleFrom(devServerIsRunning ? JSBundleSource::DevServer
-                                                       : JSBundleSource::Embedded);
+    LoadJSBundleFrom(devServerIsRunning ? JSBundleSource::DevServer : JSBundleSource::Embedded);
+}
+
+void MainPage::LoadJSBundleFrom(JSBundleSource source)
+{
+    reactInstance_.LoadJSBundleFrom(source);
+    InitializeDebugMenu();
 }
 
 void MainPage::LoadReactComponent(::ReactTestApp::Component const &component)
@@ -200,9 +204,14 @@ void MainPage::InitializeDebugMenu()
     }
 
     SetWebDebuggerMenuItem(WebDebuggerMenuItem(), reactInstance_.UseWebDebugger());
+    WebDebuggerMenuItem().IsEnabled(reactInstance_.isWebDebuggerAvailable());
+
     SetDirectDebuggerMenuItem(DirectDebuggingMenuItem(), reactInstance_.UseDirectDebugger());
     SetBreakOnFirstLineMenuItem(BreakOnFirstLineMenuItem(), reactInstance_.BreakOnFirstLine());
+
     SetFastRefreshMenuItem(FastRefreshMenuItem(), reactInstance_.UseFastRefresh());
+    FastRefreshMenuItem().IsEnabled(reactInstance_.isFastRefreshAvailable());
+
     DebugMenuBarItem().IsEnabled(true);
 }
 

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -51,6 +51,7 @@ namespace winrt::ReactTestApp::implementation
         void InitializeReactMenu();
         void InitializeTitleBar();
 
+        void LoadJSBundleFrom(::ReactTestApp::JSBundleSource);
         void LoadReactComponent(::ReactTestApp::Component const &);
 
         void OnCoreTitleBarLayoutMetricsChanged(

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -86,6 +86,8 @@ ReactInstance::ReactInstance()
 
 void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
 {
+    source_ = source;
+
     auto instanceSettings = reactNativeHost_.InstanceSettings();
     switch (source) {
         case JSBundleSource::DevServer:
@@ -154,7 +156,7 @@ void ReactInstance::UseDirectDebugger(bool useDirectDebugger)
 
 bool ReactInstance::UseFastRefresh() const
 {
-    return RetrieveLocalSetting(kUseFastRefresh, true);
+    return isFastRefreshAvailable() && RetrieveLocalSetting(kUseFastRefresh, true);
 }
 
 void ReactInstance::UseFastRefresh(bool useFastRefresh)
@@ -165,7 +167,7 @@ void ReactInstance::UseFastRefresh(bool useFastRefresh)
 
 bool ReactInstance::UseWebDebugger() const
 {
-    return RetrieveLocalSetting(kUseWebDebugger, false);
+    return isWebDebuggerAvailable() && RetrieveLocalSetting(kUseWebDebugger, false);
 }
 
 void ReactInstance::UseWebDebugger(bool useWebDebugger)

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -35,6 +35,16 @@ namespace ReactTestApp
         bool BreakOnFirstLine() const;
         void BreakOnFirstLine(bool);
 
+        bool isFastRefreshAvailable() const
+        {
+            return source_ == JSBundleSource::DevServer;
+        }
+
+        bool isWebDebuggerAvailable() const
+        {
+            return source_ == JSBundleSource::DevServer;
+        }
+
         void ToggleElementInspector() const;
 
         bool UseCustomDeveloperMenu() const;
@@ -50,6 +60,7 @@ namespace ReactTestApp
 
     private:
         winrt::Microsoft::ReactNative::ReactNativeHost reactNativeHost_;
+        JSBundleSource source_ = JSBundleSource::DevServer;
     };
 
     std::string GetBundleName();


### PR DESCRIPTION
### Description

The test app on Windows doesn't render anything when loading the embedded JS bundle due to incompatible settings. This change ensures that those settings can not be enabled while the embedded bundle is loaded.

ADO-367196

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

1. Build the test app for Windows
    ```sh
    cd example
    yarn
    yarn build:windows
    yarn install-windows-test-app
    start windows/Example.sln
    ```
2. Run the test app without the dev server
3. Try switching between embedded and dev server
4. Run the test app with the dev server (`yarn start:windows`)
5. Try switching between embedded and dev server

| Before | After |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/4123478/100025294-c83c7500-2de8-11eb-949a-f4f7bc778d7e.png) | ![image](https://user-images.githubusercontent.com/4123478/100025178-8b707e00-2de8-11eb-88f1-4279c50e5114.png) |
