### PR TITLE
fix(Windows): `install-windows-test-app` fails with yarn link

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -400,6 +400,14 @@ function generateSolution(destPath, noAutolink) {
 }
 
 if (require.main === module) {
+  // Add the `node_modules` path whence the script was invoked. Without it, this
+  // script will fail to resolve any packages when `react-native-test-app` was
+  // linked using npm or yarn link.
+  const nodeModulesDir = process.argv[1].match(/(.*?[/\\]node_modules)[/\\]/);
+  if (nodeModulesDir) {
+    module.paths.push(nodeModulesDir[1]);
+  }
+
   require("yargs").usage(
     "$0 [options]",
     "Generate a Visual Studio solution for React Test App",


### PR DESCRIPTION
### Description

If you follow the [instructions](https://github.com/microsoft/react-native-test-app#developing-react-native-test-app) for developing React Native Test App on Windows, `yarn install-windows-test-app` will fail because of the `yarn link` step:

```
$ yarn install-windows-test-app
yarn run v1.22.5
$ D:\Source\react-native-test-app\example\node_modules\.bin\install-windows-test-app
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'yargs'
Require stack:
- D:\Source\react-native-test-app\windows\test-app.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (D:\Source\react-native-test-app\windows\test-app.js:405:3)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'D:\\Source\\react-native-test-app\\windows\\test-app.js' ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It fails because Node tries to find dependencies from the resolved path, rather than from the path of the link itself.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Follow the Windows instructions as described in [Developing React Native Test App](https://github.com/microsoft/react-native-test-app#developing-react-native-test-app).