### PR TITLE
fix: Support for specifying presentation style

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,7 +10,7 @@ def hermesEngineDir =
 def hermesAndroidDir = "$hermesEngineDir/android"
 
 buildscript {
-    ext.kotlinVersion = "1.4.10"
+    ext.kotlinVersion = "1.4.20"
 
     def buildscriptDir = buildscript.sourceFile.getParent()
     apply from: "$buildscriptDir/../test-app-util.gradle"
@@ -22,7 +22,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:4.0.2"
     }
 }
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
@@ -1,0 +1,49 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+package com.microsoft.reacttestapp.component
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactRootView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class ComponentBottomSheetDialogFragment : BottomSheetDialogFragment() {
+
+    companion object {
+        const val TAG = "ReactComponentBottomSheetDialog"
+
+        private const val DISPLAY_NAME = "displayName"
+        private const val INITIAL_PROPERTIES = "initialProperties"
+        private const val NAME = "name"
+
+        fun newInstance(component: ComponentViewModel): ComponentBottomSheetDialogFragment {
+            val args = Bundle()
+            args.putString(NAME, component.name)
+            args.putString(DISPLAY_NAME, component.displayName)
+            args.putBundle(INITIAL_PROPERTIES, component.initialProperties)
+
+            val fragment = ComponentBottomSheetDialogFragment()
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val reactApplication = requireActivity().application as ReactApplication
+        return ReactRootView(context).apply {
+            startReactApplication(
+                reactApplication.reactNativeHost.reactInstanceManager,
+                requireArguments().getString(NAME),
+                requireArguments().getBundle(INITIAL_PROPERTIES)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentViewModel.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentViewModel.kt
@@ -12,5 +12,6 @@ import android.os.Bundle
 data class ComponentViewModel(
     val name: String,
     val displayName: String,
-    val initialProperties: Bundle?
+    val initialProperties: Bundle?,
+    val presentationStyle: String?
 )

--- a/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
@@ -21,5 +21,6 @@ data class Manifest(
 data class Component(
     val appKey: String,
     val displayName: String?,
-    val initialProperties: Bundle?
+    val initialProperties: Bundle?,
+    val presentationStyle: String?
 )

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,4 +1,5 @@
 *.binlog
+*.hprof
 *.xcworkspace/
 *.zip
 .DS_Store

--- a/example/app.json
+++ b/example/app.json
@@ -5,6 +5,11 @@
     {
       "appKey": "Example",
       "displayName": "App"
+    },
+    {
+      "appKey": "Example",
+      "displayName": "App (modal)",
+      "presentationStyle": "modal"
     }
   ],
   "resources": {

--- a/example/ios/ExampleTests/ManifestTests.swift
+++ b/example/ios/ExampleTests/ManifestTests.swift
@@ -18,12 +18,19 @@ class ManifestTests: XCTestCase {
 
         XCTAssertEqual(manifest.name, "Example")
         XCTAssertEqual(manifest.displayName, "Example")
-        XCTAssertEqual(manifest.components.count, 1)
+        XCTAssertEqual(manifest.components.count, 2)
 
         let component = manifest.components[0]
         XCTAssertEqual(component.appKey, "Example")
         XCTAssertEqual(component.displayName, "App")
+        XCTAssertNil(component.presentationStyle)
         XCTAssertNil(component.initialProperties)
+
+        let modalComponent = manifest.components[1]
+        XCTAssertEqual(modalComponent.appKey, "Example")
+        XCTAssertEqual(modalComponent.displayName, "App (modal)")
+        XCTAssertEqual(modalComponent.presentationStyle, "modal")
+        XCTAssertNil(modalComponent.initialProperties)
     }
 
     func testMultipleComponents() {
@@ -31,8 +38,18 @@ class ManifestTests: XCTestCase {
             name: "Name",
             displayName: "Display Name",
             components: [
-                Component(appKey: "0", displayName: nil, initialProperties: ["key": "value"]),
-                Component(appKey: "1", displayName: "1", initialProperties: nil),
+                Component(
+                    appKey: "0",
+                    displayName: nil,
+                    initialProperties: ["key": "value"],
+                    presentationStyle: nil
+                ),
+                Component(
+                    appKey: "1",
+                    displayName: "1",
+                    initialProperties: nil,
+                    presentationStyle: nil
+                ),
             ]
         )
 

--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -137,7 +137,13 @@ final class ContentViewController: UITableViewController {
             )
             return viewController
         }()
-        navigationController.pushViewController(viewController, animated: true)
+
+        switch component.presentationStyle {
+        case "modal":
+            present(viewController, animated: true, completion: nil)
+        default:
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
     private func runtimeInfo() -> String {

--- a/ios/ReactTestApp/Manifest.swift
+++ b/ios/ReactTestApp/Manifest.swift
@@ -11,17 +11,24 @@ struct Component: Decodable {
     let appKey: String
     let displayName: String?
     let initialProperties: [AnyHashable: Any]?
+    let presentationStyle: String?
 
     private enum Keys: String, CodingKey {
         case appKey
         case displayName
         case initialProperties
+        case presentationStyle
     }
 
-    init(appKey: String, displayName: String?, initialProperties: [AnyHashable: Any]?) {
+    init(appKey: String,
+         displayName: String?,
+         initialProperties: [AnyHashable: Any]?,
+         presentationStyle: String?)
+    {
         self.appKey = appKey
         self.displayName = displayName
         self.initialProperties = initialProperties
+        self.presentationStyle = presentationStyle
     }
 
     init(from decoder: Decoder) throws {
@@ -34,6 +41,7 @@ struct Component: Decodable {
             }
             return try? [AnyHashable: Any].decode(from: decoder)
         }()
+        presentationStyle = try container.decodeIfPresent(String.self, forKey: .presentationStyle)
     }
 }
 

--- a/windows/ReactTestApp/MainPage.xaml
+++ b/windows/ReactTestApp/MainPage.xaml
@@ -39,5 +39,8 @@
 
         <react:ReactRootView x:Name="ReactRootView" Grid.Row="2"/>
 
+        <ContentDialog x:Name="ContentDialog" CloseButtonText="OK">
+            <react:ReactRootView x:Name="DialogReactRootView" MinWidth="320" MinHeight="200"/>
+        </ContentDialog>
     </Grid>
 </Page>

--- a/windows/ReactTestApp/Manifest.cpp
+++ b/windows/ReactTestApp/Manifest.cpp
@@ -89,6 +89,7 @@ namespace ReactTestApp
         c.appKey = j.at("appKey");
         c.displayName = get_optional<std::string>(j, "displayName");
         c.initialProperties = parseInitialProps(j);
+        c.presentationStyle = get_optional<std::string>(j, "presentationStyle");
     }
 
     void from_json(const nlohmann::json &j, Manifest &m)

--- a/windows/ReactTestApp/Manifest.h
+++ b/windows/ReactTestApp/Manifest.h
@@ -19,6 +19,7 @@ namespace ReactTestApp
         std::string appKey;
         std::optional<std::string> displayName;
         std::optional<std::map<std::string, std::any>> initialProperties;
+        std::optional<std::string> presentationStyle;
     };
 
     struct Manifest {


### PR DESCRIPTION
### Description

Adds support for specifying presentation style in `app.json`. Only modal is implemented in this PR.

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

1. Build Example app
2. Launching "App" should open the example app as usual
3. Launching "App (modal)" should open the example app in a modal dialog/window
4. Repeat steps 1-3 for each platform

| Android | iOS | macOS | Windows |
|:-:|:-:|:-:|:-:|
| ![Screenshot_1607199618](https://user-images.githubusercontent.com/4123478/101262528-ce631780-373f-11eb-8035-b6d7d3d00be0.png) | ![image](https://user-images.githubusercontent.com/4123478/101262272-ab376880-373d-11eb-963c-c56ae5c9a53b.png) | <img width="776" alt="image" src="https://user-images.githubusercontent.com/4123478/101262392-ab843380-373e-11eb-9bc3-fc0ecb0344e4.png"> | ![image](https://user-images.githubusercontent.com/4123478/101261986-67436400-373b-11eb-8c07-545b5bbd7f7c.png) |