### PR TITLE
fix(Android): Remove deprecated `kotlin-android-extensions` plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,7 +37,6 @@ repositories {
 
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 
 def testAppDir = file("$projectDir/../../")


### PR DESCRIPTION
### Description

Gradle is complaining about `kotlin-android-extensions` being deprecated. It doesn't look like we're using it so I removed it.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Android CI should pass.