### PR TITLE
chore(Apple): Remove unused RCTTurboModuleLookupDelegate implementation

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					19ECD0D1232ED425003D8557 = {

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class ReactInstance: NSObject, RCTBridgeDelegate, RCTTurboModuleLookupDelegate {
+final class ReactInstance: NSObject, RCTBridgeDelegate {
     public static let scanForQRCodeNotification =
         NSNotification.Name("ReactInstance.scanForQRCodeNotification")
 
@@ -24,11 +24,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate, RCTTurboModuleLookupDele
         }
     }
 
-    private(set) var bridge: RCTBridge? {
-        didSet {
-            bridge?.setRCTTurboModuleLookupDelegate(self)
-        }
-    }
+    private(set) var bridge: RCTBridge?
 
     override init() {
         #if DEBUG
@@ -169,20 +165,6 @@ final class ReactInstance: NSObject, RCTBridgeDelegate, RCTTurboModuleLookupDele
 
     func extraModules(for _: RCTBridge!) -> [RCTBridgeModule] {
         []
-    }
-
-    // MARK: - RCTTurboModuleLookupDelegate details
-
-    func module(forName _: UnsafePointer<Int8>?) -> Any? {
-        nil
-    }
-
-    func module(forName _: UnsafePointer<Int8>?, warnOnLookupFailure _: Bool) -> Any? {
-        nil
-    }
-
-    func moduleIsInitialized(_: UnsafePointer<Int8>?) -> Bool {
-        false
     }
 
     // MARK: - Private

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1150;
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					193EF05E247A736100BE8C79 = {


### PR DESCRIPTION
### Description

`RCTTurboModuleLookupDelegate` was renamed in RN 0.64 but we don't really use it so we're removing it before it causes trouble.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

iOS and macOS CI should pass.