### PR TITLE
fix: Open last component from previous session

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,6 +61,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        allWarningsAsErrors = true
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId project.ext.react.applicationId
         minSdkVersion 21

--- a/android/app/src/main/java/com/microsoft/reacttestapp/Session.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/Session.kt
@@ -1,0 +1,42 @@
+package com.microsoft.reacttestapp
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+private const val MANIFEST_CHECKSUM = "ManifestChecksum"
+private const val REMEMBER_LAST_COMPONENT_ENABLED = "RememberLastComponent/Enabled"
+private const val REMEMBER_LAST_COMPONENT_INDEX = "RememberLastComponent/Index"
+
+class Session(context: Context) {
+
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(BuildConfig.APPLICATION_ID, MODE_PRIVATE)
+
+    private var lastComponentIndex: Int
+        get() = sharedPreferences.getInt(REMEMBER_LAST_COMPONENT_INDEX, -1)
+        set(index) = sharedPreferences.edit { putInt(REMEMBER_LAST_COMPONENT_INDEX, index) }
+
+    private var manifestChecksum: String?
+        get() = sharedPreferences.getString(MANIFEST_CHECKSUM, null)
+        set(checksum) = sharedPreferences.edit { putString(MANIFEST_CHECKSUM, checksum) }
+
+    var shouldRememberLastComponent: Boolean
+        get() = sharedPreferences.getBoolean(REMEMBER_LAST_COMPONENT_ENABLED, false)
+        set(enabled) = sharedPreferences.edit { putBoolean(REMEMBER_LAST_COMPONENT_ENABLED, enabled) }
+
+    fun lastOpenedComponent(checksum: String): Int? {
+        if (!shouldRememberLastComponent || checksum != manifestChecksum) {
+            return null
+        }
+
+        val index = lastComponentIndex
+        return if (index < 0) null else index
+    }
+
+    fun storeComponent(index: Int, checksum: String) {
+        lastComponentIndex = index
+        manifestChecksum = checksum
+    }
+}

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
@@ -9,7 +9,7 @@ import com.microsoft.reacttestapp.R
 class ComponentListAdapter(
     private val layoutInflater: LayoutInflater,
     private val components: List<ComponentViewModel>,
-    private val listener: (ComponentViewModel) -> Unit
+    private val listener: (ComponentViewModel, Int) -> Unit
 ) : RecyclerView.Adapter<ComponentListAdapter.ComponentViewHolder>() {
 
     override fun getItemCount() = components.size
@@ -28,7 +28,7 @@ class ComponentListAdapter(
 
     inner class ComponentViewHolder(private val view: TextView) : RecyclerView.ViewHolder(view) {
         init {
-            view.setOnClickListener { listener(components[adapterPosition]) }
+            view.setOnClickListener { listener(components[adapterPosition], adapterPosition) }
         }
 
         fun bindTo(component: ComponentViewModel) {

--- a/android/app/src/main/java/com/microsoft/reacttestapp/manifest/ManifestProvider.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/manifest/ManifestProvider.kt
@@ -2,6 +2,7 @@ package com.microsoft.reacttestapp.manifest
 
 import android.content.Context
 import com.squareup.moshi.JsonAdapter
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,16 +11,27 @@ class ManifestProvider @Inject constructor(
     private val context: Context,
     private val adapter: JsonAdapter<Manifest>
 ) {
-    val manifest: Manifest? by lazy {
+    fun fromResources(): Pair<Manifest, String>? {
         val appIdentifier = context.resources
             .getIdentifier("raw/app", null, context.packageName)
 
-        if (appIdentifier != 0) {
-            val manifest = context.resources
+        return if (appIdentifier == 0) {
+            null
+        } else {
+            val json = context.resources
                 .openRawResource(appIdentifier)
                 .bufferedReader()
                 .use { it.readText() }
-            adapter.fromJson(manifest)
-        } else null
+            val manifest = adapter.fromJson(json)
+            return if (manifest == null) null else Pair(manifest, json.checksum("SHA-256"))
+        }
     }
+}
+
+fun ByteArray.toHex(): String {
+    return joinToString("") { "%02x".format(it) }
+}
+
+fun String.checksum(algorithm: String): String {
+    return MessageDigest.getInstance(algorithm).digest(toByteArray()).toHex()
 }

--- a/android/app/src/main/res/menu/top_app_bar.xml
+++ b/android/app/src/main/res/menu/top_app_bar.xml
@@ -12,6 +12,12 @@
         android:title="@string/load_from_dev_server"
         app:showAsAction="never" />
     <item
+        android:id="@+id/remember_last_component"
+        android:checkable="true"
+        android:contentDescription="@string/content_description_remember_last_component"
+        android:title="@string/remember_last_component"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/show_dev_options"
         android:contentDescription="@string/content_description_show_dev_options"
         android:enabled="false"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="load_embedded_js_bundle">Load embedded JS bundle</string>
     <string name="content_description_load_from_dev_server">Load from dev server</string>
     <string name="load_from_dev_server">Load from dev server</string>
+    <string name="content_description_remember_last_component">Remember last opened component</string>
+    <string name="remember_last_component">Remember last opened component</string>
     <string name="content_description_show_dev_options">Show dev options</string>
     <string name="show_dev_options">Show dev options</string>
     <string name="runtime_info">React Native v%1$d.%2$d.%3$d\n(%4$s)</string>

--- a/example/ios/ExampleTests/ManifestTests.swift
+++ b/example/ios/ExampleTests/ManifestTests.swift
@@ -11,10 +11,12 @@ import XCTest
 class ManifestTests: XCTestCase {
 
     func testReadFromFile() {
-        guard let manifest = Manifest.fromFile() else {
+        guard let (manifest, checksum) = Manifest.fromFile() else {
             XCTFail("Failed to read 'app.json'")
             return
         }
+
+        XCTAssertEqual(checksum.count, 64)
 
         XCTAssertEqual(manifest.name, "Example")
         XCTAssertEqual(manifest.displayName, "Example")
@@ -71,10 +73,12 @@ class ManifestTests: XCTestCase {
         """
 
         guard let data = json.data(using: .utf8),
-              let manifest = Manifest.from(data: data) else {
+              let (manifest, checksum) = Manifest.from(data: data) else {
             XCTFail("Failed to read manifest")
             return
         }
+
+        XCTAssertEqual(checksum.count, 64)
 
         XCTAssertEqual(manifest.name, expected.name)
         XCTAssertEqual(manifest.displayName, expected.displayName)
@@ -136,7 +140,7 @@ class ManifestTests: XCTestCase {
         """
 
         guard let data = json.data(using: .utf8),
-              let manifest = Manifest.from(data: data),
+              let (manifest, _) = Manifest.from(data: data),
               let component = manifest.components.first,
               let initialProperties = component.initialProperties else {
             XCTFail("Failed to read manifest")

--- a/example/windows/ReactTestAppTests/ManifestTests.cpp
+++ b/example/windows/ReactTestAppTests/ManifestTests.cpp
@@ -26,58 +26,58 @@ namespace ReactTestAppTests
     public:
         TEST_METHOD(ParseManifestWithOneComponent)
         {
-            std::optional<ReactTestApp::Manifest> manifest =
-                ReactTestApp::GetManifest("manifestTestFiles/simpleManifest.json");
-            if (!manifest.has_value()) {
+            auto result = ReactTestApp::GetManifest("manifestTestFiles/simpleManifest.json");
+            if (!result.has_value()) {
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto &manifestContents = manifest.value();
-            Assert::AreEqual(manifestContents.name, {"Example"});
-            Assert::AreEqual(manifestContents.displayName, {"Example"});
-            Assert::AreEqual(manifestContents.components[0].appKey, {"Example"});
-            Assert::AreEqual(manifestContents.components[0].displayName.value(), {"App"});
-            Assert::IsFalse(manifestContents.components[0].initialProperties.has_value());
+            auto&& [manifest, checksum] = result.value();
+
+            Assert::AreEqual(manifest.name, {"Example"});
+            Assert::AreEqual(manifest.displayName, {"Example"});
+            Assert::AreEqual(manifest.components[0].appKey, {"Example"});
+            Assert::AreEqual(manifest.components[0].displayName.value(), {"App"});
+            Assert::IsFalse(manifest.components[0].initialProperties.has_value());
         }
 
         TEST_METHOD(ParseManifestWithMultipleComponents)
         {
-            std::optional<ReactTestApp::Manifest> manifest =
-                ReactTestApp::GetManifest("manifestTestFiles/withMultipleComponents.json");
-            if (!manifest.has_value()) {
+            auto result = ReactTestApp::GetManifest("manifestTestFiles/withMultipleComponents.json");
+            if (!result.has_value()) {
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto &manifestContents = manifest.value();
-            Assert::AreEqual(manifestContents.name, {"Example"});
-            Assert::AreEqual(manifestContents.displayName, {"Example"});
-            Assert::AreEqual(manifestContents.components.size(), {2});
+            auto&& [manifest, checksum] = result.value();
 
-            Assert::AreEqual(manifestContents.components[0].appKey, {"0"});
-            Assert::IsFalse(manifestContents.components[0].displayName.has_value());
-            Assert::IsTrue(manifestContents.components[0].initialProperties.has_value());
+            Assert::AreEqual(manifest.name, {"Example"});
+            Assert::AreEqual(manifest.displayName, {"Example"});
+            Assert::AreEqual(manifest.components.size(), {2});
+
+            Assert::AreEqual(manifest.components[0].appKey, {"0"});
+            Assert::IsFalse(manifest.components[0].displayName.has_value());
+            Assert::IsTrue(manifest.components[0].initialProperties.has_value());
             Assert::AreEqual(std::any_cast<std::string>(
-                                 manifestContents.components[0].initialProperties.value()["key"]),
+                                 manifest.components[0].initialProperties.value()["key"]),
                              {"value"});
 
-            Assert::AreEqual(manifestContents.components[1].appKey, {"1"});
-            Assert::AreEqual(manifestContents.components[1].displayName.value(), {"1"});
-            Assert::IsFalse(manifestContents.components[1].initialProperties.has_value());
+            Assert::AreEqual(manifest.components[1].appKey, {"1"});
+            Assert::AreEqual(manifest.components[1].displayName.value(), {"1"});
+            Assert::IsFalse(manifest.components[1].initialProperties.has_value());
         }
 
         TEST_METHOD(ParseManifestWithComplexInitialProperties)
         {
-            std::optional<ReactTestApp::Manifest> manifest =
-                ReactTestApp::GetManifest("manifestTestFiles/withComplexInitialProperties.json");
-            if (!manifest.has_value()) {
+            auto result = ReactTestApp::GetManifest("manifestTestFiles/withComplexInitialProperties.json");
+            if (!result.has_value()) {
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto &manifestContents = manifest.value();
-            auto &component = manifestContents.components[0];
-            Assert::AreEqual(manifestContents.name, {"Name"});
-            Assert::AreEqual(manifestContents.displayName, {"Display Name"});
+            auto&& [manifest, checksum] = result.value();
 
+            Assert::AreEqual(manifest.name, {"Name"});
+            Assert::AreEqual(manifest.displayName, {"Display Name"});
+
+            auto &component = manifest.components[0];
             Assert::AreEqual(component.appKey, {"AppKey"});
             Assert::IsFalse(component.displayName.has_value());
             Assert::IsTrue(component.initialProperties.has_value());

--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		196C724123319A85006556ED /* QRCodeReaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C724023319A85006556ED /* QRCodeReaderDelegate.swift */; };
 		196C7215232F1788006556ED /* ReactInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C7214232F1788006556ED /* ReactInstance.swift */; };
 		19ECD0D8232ED425003D8557 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ECD0D7232ED425003D8557 /* SceneDelegate.swift */; };
+		19A624A4258C95F000032776 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A624A3258C95F000032776 /* Session.swift */; };
 		1914199A234B2DD800D856AE /* RCTDevSupport+UIScene.m in Sources */ = {isa = PBXBuildFile; fileRef = 19141999234B2DD800D856AE /* RCTDevSupport+UIScene.m */; };
 		196C22622490CB7600449D3C /* React+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 196C22602490CB7600449D3C /* React+Compatibility.m */; };
 		1988284524105BEC005057FF /* UIViewController+ReactTestApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */; };
@@ -40,24 +41,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		19141999234B2DD800D856AE /* RCTDevSupport+UIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTDevSupport+UIScene.m"; sourceTree = "<group>"; };
-		192DD200240FCAF5004E9CEB /* Manifest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Manifest.swift; sourceTree = "<group>"; };
-		192F052624AD3CC500A48456 /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
-		192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
-		192F052824AD3CC500A48456 /* ReactTestApp.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.debug.xcconfig; sourceTree = "<group>"; };
-		196C22602490CB7600449D3C /* React+Compatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "React+Compatibility.m"; sourceTree = "<group>"; };
-		196C22612490CB7600449D3C /* React+Compatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "React+Compatibility.h"; sourceTree = "<group>"; };
-		196C7207232EF5DC006556ED /* ReactTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReactTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
-		196C7214232F1788006556ED /* ReactInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactInstance.swift; sourceTree = "<group>"; };
-		196C7216232F6CD9006556ED /* ReactTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReactTestApp.entitlements; sourceTree = "<group>"; };
-		196C724023319A85006556ED /* QRCodeReaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeReaderDelegate.swift; sourceTree = "<group>"; };
-		1988282224105BCC005057FF /* UIViewController+ReactTestApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+ReactTestApp.h"; sourceTree = "<group>"; };
-		1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+ReactTestApp.m"; sourceTree = "<group>"; };
 		19ECD0D2232ED425003D8557 /* ReactTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReactTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		19ECD0D5232ED425003D8557 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		19ECD0D7232ED425003D8557 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		19ECD0D9232ED425003D8557 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		192DD200240FCAF5004E9CEB /* Manifest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Manifest.swift; sourceTree = "<group>"; };
+		196C724023319A85006556ED /* QRCodeReaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeReaderDelegate.swift; sourceTree = "<group>"; };
+		196C7214232F1788006556ED /* ReactInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactInstance.swift; sourceTree = "<group>"; };
+		19ECD0D7232ED425003D8557 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		19A624A3258C95F000032776 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		196C7207232EF5DC006556ED /* ReactTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReactTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		19141999234B2DD800D856AE /* RCTDevSupport+UIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTDevSupport+UIScene.m"; sourceTree = "<group>"; };
+		196C22612490CB7600449D3C /* React+Compatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "React+Compatibility.h"; sourceTree = "<group>"; };
+		196C22602490CB7600449D3C /* React+Compatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "React+Compatibility.m"; sourceTree = "<group>"; };
+		1988282224105BCC005057FF /* UIViewController+ReactTestApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+ReactTestApp.h"; sourceTree = "<group>"; };
+		1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+ReactTestApp.m"; sourceTree = "<group>"; };
 		19ECD0DB232ED427003D8557 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		196C7216232F6CD9006556ED /* ReactTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReactTestApp.entitlements; sourceTree = "<group>"; };
+		192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
+		192F052824AD3CC500A48456 /* ReactTestApp.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.debug.xcconfig; sourceTree = "<group>"; };
+		192F052624AD3CC500A48456 /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
 		19ECD0E1232ED427003D8557 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		19ECD0E3232ED427003D8557 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		19ECD0E8232ED427003D8557 /* ReactTestAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactTestAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -122,6 +124,7 @@
 				192DD200240FCAF5004E9CEB /* Manifest.swift */,
 				196C724023319A85006556ED /* QRCodeReaderDelegate.swift */,
 				196C7214232F1788006556ED /* ReactInstance.swift */,
+				19A624A3258C95F000032776 /* Session.swift */,
 				196C7207232EF5DC006556ED /* ReactTestApp-Bridging-Header.h */,
 				19141999234B2DD800D856AE /* RCTDevSupport+UIScene.m */,
 				196C22612490CB7600449D3C /* React+Compatibility.h */,
@@ -319,6 +322,7 @@
 				196C22622490CB7600449D3C /* React+Compatibility.m in Sources */,
 				196C7215232F1788006556ED /* ReactInstance.swift in Sources */,
 				19ECD0D8232ED425003D8557 /* SceneDelegate.swift in Sources */,
+				19A624A4258C95F000032776 /* Session.swift in Sources */,
 				1988284524105BEC005057FF /* UIViewController+ReactTestApp.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -20,7 +20,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
 
     var remoteBundleURL: URL? {
         didSet {
-            initReact(onDidInitialize: { _ in /* noop */ })
+            initReact(onDidInitialize: { /* noop */ })
         }
     }
 
@@ -96,7 +96,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
         assert(forTestingPurposesOnly)
     }
 
-    func initReact(onDidInitialize: @escaping ([Component]) -> Void) {
+    func initReact(onDidInitialize: @escaping () -> Void) {
         if let bridge = bridge {
             if remoteBundleURL == nil {
                 // When loading the embedded bundle, we must disable remote
@@ -113,10 +113,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
                 object: bridge
             )
 
-            guard let manifest = Manifest.fromFile() else {
-                return
-            }
-            onDidInitialize(manifest.components)
+            onDidInitialize()
         } else {
             assertionFailure("Failed to instantiate RCTBridge")
         }

--- a/ios/ReactTestApp/Session.swift
+++ b/ios/ReactTestApp/Session.swift
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct Session {
+    private enum Keys {
+        static let checksum = "ManifestChecksum"
+        static let rememberLastComponentEnabled = "RememberLastComponent/Enabled"
+        static let rememberLastComponentIndex = "RememberLastComponent/Index"
+    }
+
+    private static var lastComponentIndex: Int {
+        get { UserDefaults.standard.integer(forKey: Keys.rememberLastComponentIndex) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.rememberLastComponentIndex) }
+    }
+
+    private static var manifestChecksum: String? {
+        get { UserDefaults.standard.string(forKey: Keys.checksum) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.checksum) }
+    }
+
+    static var shouldRememberLastComponent: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.rememberLastComponentEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.rememberLastComponentEnabled) }
+    }
+
+    static func lastOpenedComponent(_ checksum: String) -> Int? {
+        guard shouldRememberLastComponent, checksum == manifestChecksum else {
+            return nil
+        }
+
+        return lastComponentIndex
+    }
+
+    static func storeComponent(index: Int, checksum: String) {
+        lastComponentIndex = index
+        manifestChecksum = checksum
+    }
+}

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		193EF063247A736200BE8C79 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF062247A736200BE8C79 /* AppDelegate.swift */; };
 		193EF08F247A799D00BE8C79 /* Manifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF08E247A799D00BE8C79 /* Manifest.swift */; };
 		193EF098247B130700BE8C79 /* ReactInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF097247B130700BE8C79 /* ReactInstance.swift */; };
+		1960F339258C97C400AEC7A2 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1960F338258C97C400AEC7A2 /* Session.swift */; };
 		193EF065247A736200BE8C79 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF064247A736200BE8C79 /* ViewController.swift */; };
 		196C22652490CBAB00449D3C /* React+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 196C22632490CBAB00449D3C /* React+Compatibility.m */; };
 		193EF093247A830200BE8C79 /* UIViewController+ReactTestApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 193EF091247A830200BE8C79 /* UIViewController+ReactTestApp.m */; };
@@ -39,27 +40,28 @@
 /* Begin PBXFileReference section */
 		193EF05F247A736200BE8C79 /* ReactTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReactTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		193EF062247A736200BE8C79 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		193EF064247A736200BE8C79 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		193EF066247A736300BE8C79 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		193EF069247A736300BE8C79 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		193EF06B247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		193EF06C247A736300BE8C79 /* ReactTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReactTestApp.entitlements; sourceTree = "<group>"; };
-		193EF071247A736300BE8C79 /* ReactTestAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactTestAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		193EF077247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		193EF07C247A736300BE8C79 /* ReactTestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactTestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		193EF082247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		193EF08E247A799D00BE8C79 /* Manifest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Manifest.swift; path = ../ReactTestAppShared/Manifest.swift; sourceTree = "<group>"; };
-		193EF091247A830200BE8C79 /* UIViewController+ReactTestApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+ReactTestApp.m"; path = "../ReactTestAppShared/UIViewController+ReactTestApp.m"; sourceTree = "<group>"; };
-		193EF092247A830200BE8C79 /* UIViewController+ReactTestApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+ReactTestApp.h"; path = "../ReactTestAppShared/UIViewController+ReactTestApp.h"; sourceTree = "<group>"; };
-		193EF094247A84DA00BE8C79 /* ReactTestApp-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ReactTestApp-Bridging-Header.h"; path = "../ReactTestAppShared/ReactTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		193EF097247B130700BE8C79 /* ReactInstance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReactInstance.swift; path = ../ReactTestAppShared/ReactInstance.swift; sourceTree = "<group>"; };
-		196C22632490CBAB00449D3C /* React+Compatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "React+Compatibility.m"; path = "../ReactTestAppShared/React+Compatibility.m"; sourceTree = "<group>"; };
+		1960F338258C97C400AEC7A2 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Session.swift; path = ../ReactTestAppShared/Session.swift; sourceTree = "<group>"; };
+		193EF064247A736200BE8C79 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		193EF094247A84DA00BE8C79 /* ReactTestApp-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ReactTestApp-Bridging-Header.h"; path = "../ReactTestAppShared/ReactTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		196C22642490CBAB00449D3C /* React+Compatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "React+Compatibility.h"; path = "../ReactTestAppShared/React+Compatibility.h"; sourceTree = "<group>"; };
+		196C22632490CBAB00449D3C /* React+Compatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "React+Compatibility.m"; path = "../ReactTestAppShared/React+Compatibility.m"; sourceTree = "<group>"; };
+		193EF092247A830200BE8C79 /* UIViewController+ReactTestApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+ReactTestApp.h"; path = "../ReactTestAppShared/UIViewController+ReactTestApp.h"; sourceTree = "<group>"; };
+		193EF091247A830200BE8C79 /* UIViewController+ReactTestApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+ReactTestApp.m"; path = "../ReactTestAppShared/UIViewController+ReactTestApp.m"; sourceTree = "<group>"; };
+		193EF066247A736300BE8C79 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		193EF06C247A736300BE8C79 /* ReactTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReactTestApp.entitlements; sourceTree = "<group>"; };
 		19B368BC24B12C24002CCEFF /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
 		19B368BD24B12C24002CCEFF /* ReactTestApp.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.debug.xcconfig; sourceTree = "<group>"; };
 		19B368BE24B12C24002CCEFF /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
+		193EF069247A736300BE8C79 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		193EF06B247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		193EF071247A736300BE8C79 /* ReactTestAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactTestAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		19E791BF24B08E1400FA6468 /* ReactTestAppTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactTestAppTests.swift; sourceTree = "<group>"; };
+		193EF077247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		193EF07C247A736300BE8C79 /* ReactTestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactTestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		19E791C224B08E4D00FA6468 /* ReactTestAppUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactTestAppUITests.swift; sourceTree = "<group>"; };
+		193EF082247A736300BE8C79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 				193EF062247A736200BE8C79 /* AppDelegate.swift */,
 				193EF08E247A799D00BE8C79 /* Manifest.swift */,
 				193EF097247B130700BE8C79 /* ReactInstance.swift */,
+				1960F338258C97C400AEC7A2 /* Session.swift */,
 				193EF064247A736200BE8C79 /* ViewController.swift */,
 				193EF094247A84DA00BE8C79 /* ReactTestApp-Bridging-Header.h */,
 				196C22642490CBAB00449D3C /* React+Compatibility.h */,
@@ -307,6 +310,7 @@
 				193EF08F247A799D00BE8C79 /* Manifest.swift in Sources */,
 				196C22652490CBAB00449D3C /* React+Compatibility.m in Sources */,
 				193EF098247B130700BE8C79 /* ReactInstance.swift in Sources */,
+				1960F339258C97C400AEC7A2 /* Session.swift in Sources */,
 				193EF065247A736200BE8C79 /* ViewController.swift in Sources */,
 				193EF093247A830200BE8C79 /* UIViewController+ReactTestApp.m in Sources */,
 			);

--- a/macos/ReactTestApp/Base.lproj/Main.storyboard
+++ b/macos/ReactTestApp/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -376,13 +377,19 @@
                                         <menuItem title="Load Embedded JS Bundle" id="eKz-kn-Unx">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="onLoadEmbeddedBundle:" target="Voe-Tx-rLC" id="Dp5-bz-UTv"/>
+                                                <action selector="onLoadEmbeddedBundleSelected:" target="Voe-Tx-rLC" id="Dp5-bz-UTv"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Load From Dev Server" id="175-aB-GZg">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="onLoadFromDevServer:" target="Voe-Tx-rLC" id="FOl-Nq-cWc"/>
+                                                <action selector="onLoadFromDevServerSelected:" target="Voe-Tx-rLC" id="FOl-Nq-cWc"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Remember Last Opened Component" id="lzS-xk-P1D">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="onRememberLastComponentSelected:" target="Voe-Tx-rLC" id="TFw-gh-YQX"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="uJa-x1-YNS"/>
@@ -435,6 +442,7 @@
                 <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="ReactTestApp" customModuleProvider="target">
                     <connections>
                         <outlet property="reactMenu" destination="nwF-AT-VY9" id="mZ4-MI-fvy"/>
+                        <outlet property="rememberLastComponentMenuItem" destination="lzS-xk-P1D" id="azf-vw-Bvd"/>
                     </connections>
                 </customObject>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -22,10 +22,16 @@ namespace winrt::ReactTestApp::implementation
     public:
         MainPage();
 
+        // React menu
+
         void LoadFromDevServer(Windows::Foundation::IInspectable const &,
                                Windows::UI::Xaml::RoutedEventArgs);
         void LoadFromJSBundle(Windows::Foundation::IInspectable const &,
                               Windows::UI::Xaml::RoutedEventArgs);
+        void ToggleRememberLastComponent(Windows::Foundation::IInspectable const &,
+                                         Windows::UI::Xaml::RoutedEventArgs);
+
+        // Debug menu
 
         void Reload(Windows::Foundation::IInspectable const &, Windows::UI::Xaml::RoutedEventArgs);
         void ToggleBreakOnFirstLine(Windows::Foundation::IInspectable const &,
@@ -46,6 +52,7 @@ namespace winrt::ReactTestApp::implementation
         using Base = MainPageT;
 
         ::ReactTestApp::ReactInstance reactInstance_;
+        std::string manifestChecksum_;
 
         void InitializeDebugMenu();
         void InitializeReactMenu();

--- a/windows/ReactTestApp/MainPage.xaml
+++ b/windows/ReactTestApp/MainPage.xaml
@@ -21,6 +21,12 @@
                 <MenuBarItem x:Name="ReactMenuBarItem" Title="React" AccessKey="R">
                     <MenuFlyoutItem Text="Load from JS bundle" Click="LoadFromJSBundle" AccessKey="E"/>
                     <MenuFlyoutItem Text="Load from dev server" Click="LoadFromDevServer" AccessKey="D"/>
+                    <ToggleMenuFlyoutItem
+                        x:Name="RememberLastComponentMenuItem"
+                        Text="Remember last opened component"
+                        Click="ToggleRememberLastComponent"
+                        AccessKey="R"
+                    />
                     <MenuFlyoutSeparator/>
                 </MenuBarItem>
                 <MenuBarItem x:Name="DebugMenuBarItem" IsEnabled="false" Title="Debug" AccessKey="D">

--- a/windows/ReactTestApp/Manifest.h
+++ b/windows/ReactTestApp/Manifest.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace ReactTestApp
@@ -28,6 +29,6 @@ namespace ReactTestApp
         std::vector<Component> components;
     };
 
-    std::optional<Manifest> GetManifest(std::string const &manifestFileName);
+    std::optional<std::pair<Manifest, std::string>> GetManifest(std::string const &filename);
 
 }  // namespace ReactTestApp

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -153,6 +153,7 @@
         <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
         <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
         <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
+        <ClInclude Include="$(ReactTestAppDir)\Session.h" />
     </ItemGroup>
     <ItemGroup>
         <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml">

--- a/windows/ReactTestApp/ReactTestApp.vcxproj.filters
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj.filters
@@ -28,6 +28,7 @@
         <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
         <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
         <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
+        <ClInclude Include="$(ReactTestAppDir)\Session.h" />
     </ItemGroup>
     <ItemGroup>
         <Text Include="$(ProjectRootDir)\app.json">

--- a/windows/ReactTestApp/Session.h
+++ b/windows/ReactTestApp/Session.h
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#pragma once
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Storage.h>
+
+using winrt::Windows::Foundation::PropertyValue;
+using winrt::Windows::Storage::ApplicationData;
+
+namespace ReactTestApp
+{
+    struct Session {
+    private:
+        static inline const std::wstring kChecksum = L"ManifestChecksum";
+        static inline const std::wstring kRememberLastComponentEnabled =
+            L"RememberLastComponent/Enabled";
+        static inline const std::wstring kRememberLastComponentIndex =
+            L"RememberLastComponent/Index";
+
+        static auto LocalSettings()
+        {
+            return ApplicationData::Current().LocalSettings().Values();
+        }
+
+        static int LastComponentIndex()
+        {
+            auto index = LocalSettings().Lookup(kRememberLastComponentIndex);
+            return winrt::unbox_value_or<int>(index, -1);
+        }
+
+        static void LastComponentIndex(int value)
+        {
+            LocalSettings().Insert(kRememberLastComponentIndex, PropertyValue::CreateInt32(value));
+        }
+
+        static std::string ManifestChecksum()
+        {
+            auto checksum = LocalSettings().Lookup(kChecksum);
+            auto value = winrt::unbox_value_or<winrt::hstring>(checksum, L"");
+            return winrt::to_string(value);
+        }
+
+        static void ManifestChecksum(std::string const &value)
+        {
+            auto v = PropertyValue::CreateString(winrt::to_hstring(value));
+            LocalSettings().Insert(kChecksum, v);
+        }
+
+    public:
+        static bool ShouldRememberLastComponent()
+        {
+            auto value = LocalSettings().Lookup(kRememberLastComponentEnabled);
+            return winrt::unbox_value_or<bool>(value, false);
+        }
+
+        static void ShouldRememberLastComponent(bool enable)
+        {
+            auto value = PropertyValue::CreateBoolean(enable);
+            LocalSettings().Insert(kRememberLastComponentEnabled, value);
+        }
+
+        static std::optional<int> GetLastOpenedComponent(std::string const &manifestChecksum)
+        {
+            if (!ShouldRememberLastComponent() || manifestChecksum != ManifestChecksum()) {
+                return std::nullopt;
+            }
+
+            return LastComponentIndex();
+        }
+
+        static void StoreComponent(int index, std::string const &manifestChecksum)
+        {
+            LastComponentIndex(index);
+            ManifestChecksum(manifestChecksum);
+        }
+    };
+}  // namespace ReactTestApp


### PR DESCRIPTION
### Description

Adds a toggle to reopen the component that was last opened in previous session.

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

1. Build and run Example app
2. Note that we are seeing a blank window on desktop, and the component list on mobile
3. Enable _Remember last opened component_ (see screenshots below)
4. Open any component
5. Restart Example app
6. The component that was opened last session should now be reopened
7. Disable _Remember last opened component_
8. Restart Example app
9. We should now see either a blank window or the component list
10. Repeat steps 1-9 for all platforms

| Android | iOS | macOS | Windows |
|:-:|:-:|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/4123478/102710441-9e288680-42b2-11eb-9847-f124583f9260.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2020-12-20 at 11 00 04](https://user-images.githubusercontent.com/4123478/102710458-bc8e8200-42b2-11eb-8964-23330b3a2d53.png) | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/4123478/102698794-5b2dcb00-4240-11eb-9699-c952fd6aea4c.png"> | ![image](https://user-images.githubusercontent.com/4123478/102698222-23bd1f80-423c-11eb-8c0d-62ddfbdd6a87.png) |