### PR TITLE
fix(Apple): Allow passing options to use_react_native!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ AllCops:
 Layout/LineLength:
   Max: 100
 
-Lint/UnusedMethodArgument:
-  AllowUnusedKeywordArguments: true
-
 Metrics/AbcSize:
   Enabled: false
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -197,16 +197,17 @@ def use_flipper!(versions = {})
   @flipper_versions = versions
 end
 
-def use_react_native!(project_root, target_platform)
+def use_react_native!(project_root, target_platform, options)
   react_native = react_native_path(project_root, target_platform)
   version = package_version(react_native.to_s)
 
   require_relative(react_native_pods(version))
 
-  include_react_native!(react_native: react_native.relative_path_from(project_root).to_s,
-                        target_platform: target_platform,
-                        project_root: project_root,
-                        flipper_versions: flipper_versions)
+  include_react_native!(**options,
+                        path: react_native.relative_path_from(project_root).to_s,
+                        rta_flipper_versions: flipper_versions,
+                        rta_project_root: project_root,
+                        rta_target_platform: target_platform)
 end
 
 def make_project!(xcodeproj, project_root, target_platform)
@@ -275,7 +276,7 @@ def make_project!(xcodeproj, project_root, target_platform)
   dst_xcodeproj
 end
 
-def use_test_app_internal!(target_platform)
+def use_test_app_internal!(target_platform, options)
   assert(%i[ios macos].include?(target_platform), "Unsupported platform: #{target_platform}")
 
   xcodeproj = 'ReactTestApp.xcodeproj'
@@ -293,7 +294,7 @@ def use_test_app_internal!(target_platform)
     pod 'QRCodeReader.swift' if target_platform == :ios
     pod 'SwiftLint'
 
-    use_react_native!(project_root, target_platform)
+    use_react_native!(project_root, target_platform, options)
 
     if (resources_pod_path = resources_pod(project_root, target_platform))
       pod 'ReactTestApp-Resources', :path => resources_pod_path

--- a/ios/use_react_native-0.60.rb
+++ b/ios/use_react_native-0.60.rb
@@ -8,7 +8,9 @@
 
 require_relative('pod_helpers.rb')
 
-def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
+def include_react_native!(options)
+  react_native, project_root = options.values_at(:path, :rta_project_root)
+
   pod 'React', :path => react_native
   pod 'React-Core', :path => "#{react_native}/React", :inhibit_warnings => true
   pod 'React-DevSupport', :path => "#{react_native}/React"

--- a/ios/use_react_native-0.61.rb
+++ b/ios/use_react_native-0.61.rb
@@ -6,7 +6,9 @@
 #
 # rubocop:disable Layout/LineLength
 
-def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
+def include_react_native!(options)
+  react_native, project_root = options.values_at(:path, :rta_project_root)
+
   pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "#{react_native}/Libraries/FBReactNativeSpec"
   pod 'RCTRequired', :path => "#{react_native}/Libraries/RCTRequired"

--- a/ios/use_react_native-0.62.rb
+++ b/ios/use_react_native-0.62.rb
@@ -40,7 +40,11 @@ def add_flipper_pods!(versions = {})
   pod 'FlipperKit/FlipperKitNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
 end
 
-def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
+def include_react_native!(options)
+  react_native, flipper_versions, project_root, target_platform = options.values_at(
+    :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform
+  )
+
   add_flipper_pods!(flipper_versions) if target_platform == :ios && flipper_versions
 
   pod 'FBLazyVector', :path => "#{react_native}/Libraries/FBLazyVector"

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -5,8 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-def include_react_native!(react_native:, target_platform:, project_root:, flipper_versions:)
+def include_react_native!(options)
+  react_native, flipper_versions, project_root, target_platform = options.values_at(
+    :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform
+  )
+
   require_relative File.join(project_root, react_native, 'scripts', 'react_native_pods')
+
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
-  use_react_native!(:path => react_native)
+  use_react_native!(options)
 end

--- a/macos/test_app.rb
+++ b/macos/test_app.rb
@@ -7,6 +7,6 @@
 
 require_relative('../ios/test_app.rb')
 
-def use_test_app!(&block)
-  use_test_app_internal!(:macos, &block)
+def use_test_app!(options = {}, &block)
+  use_test_app_internal!(:macos, options, &block)
 end

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint:js": "eslint $(git ls-files '*.js')",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",
+    "set-react-version": "scripts/set-react-version.js",
     "test:js": "jest",
     "test:rb": "bundle exec ruby -Ilib:test test/test_test_app.rb"
   },

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// @ts-check
+
+const profiles = {
+  "0.60": {
+    react: "16.8.6",
+    "react-native": "0.60.6",
+    "react-native-macos": "0.60.0-microsoft.79",
+    "react-native-windows": undefined,
+  },
+  0.61: {
+    react: "16.9.0",
+    "react-native": "0.61.5",
+    "react-native-macos": "0.61.65",
+    "react-native-windows": undefined,
+  },
+  0.62: {
+    react: "16.11.0",
+    "react-native": "0.62.2",
+    "react-native-macos": "0.62.16",
+    "react-native-windows": "0.62.17",
+  },
+  0.63: {
+    react: "16.13.1",
+    "react-native": "0.63.4",
+    "react-native-macos": "0.63.3",
+    "react-native-windows": "0.63.14",
+  },
+  master: {
+    react: "17.0.1",
+    "react-native": "facebook/react-native#master",
+    "react-native-codegen": "^0.0.6",
+    "react-native-macos": undefined,
+    "react-native-windows": undefined,
+  },
+};
+
+/**
+ * Coerces string value to version literal.
+ * @param {string} v
+ * @return {v is keyof profiles}
+ */
+function isValidVersion(v) {
+  return Boolean(Object.prototype.hasOwnProperty.call(profiles, v));
+}
+
+const path = require("path");
+
+const { [1]: scriptPath, [2]: version } = process.argv;
+if (!isValidVersion(version)) {
+  const script = path.basename(scriptPath);
+  console.log(`Usage: ${script} [${Object.keys(profiles).join(" | ")}]`);
+  process.exit();
+}
+
+const profile = profiles[version];
+
+const fs = require("fs");
+const { EOL } = require("os");
+
+["package.json", "example/package.json"].forEach((manifestPath) => {
+  const content = fs.readFileSync(manifestPath, { encoding: "utf-8" });
+  const manifest = JSON.parse(content);
+  Object.keys(profile).forEach((packageName) => {
+    manifest["devDependencies"][packageName] = profile[packageName];
+  });
+
+  const tmpFile = `${manifestPath}.tmp`;
+  fs.writeFile(tmpFile, JSON.stringify(manifest, undefined, 2) + EOL, (err) => {
+    if (err) {
+      throw err;
+    }
+
+    fs.rename(tmpFile, manifestPath, (err) => {
+      if (err) {
+        throw err;
+      }
+    });
+  });
+});

--- a/test_app.rb
+++ b/test_app.rb
@@ -7,6 +7,6 @@
 
 require_relative('ios/test_app.rb')
 
-def use_test_app!(&block)
-  use_test_app_internal!(:ios, &block)
+def use_test_app!(options = {}, &block)
+  use_test_app_internal!(:ios, options, &block)
 end


### PR DESCRIPTION
### Description

Allow options to be passed directly to `use_react_native!`, such as `:hermes_enabled` introduced in 0.64:

```rb
use_test_app! :hermes_enabled => true
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Navigate to `/example`
2. Delete `ios/Podfile.lock` and `ios/Pods/`
3. Run `yarn`
4. Run `pod install --project-directory=ios`
5. Build `ios/Example.xcworkspace`
6. Repeat steps 1-6 for versions 0.60, 0.61, 0.62, 0.63
    - Use `yarn set-react-version` to set the correct package versions