### PR TITLE
fix(macOS): RCTRootView.minimumSize doesn't exist before 0.63

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.4)
+  - CocoaAsyncSocket (7.6.5)
   - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
   - Example-Tests (0.0.1-dev):
@@ -18,12 +18,12 @@ PODS:
     - Flipper-Folly (~> 2.2)
     - Flipper-RSocket (~> 1.1)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.2.0):
+  - Flipper-Folly (2.3.0):
     - boost-for-react-native
     - CocoaLibEvent (~> 1.0)
     - Flipper-DoubleConversion
     - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.19)
+    - OpenSSL-Universal (= 1.0.2.20)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.1.0):
@@ -70,9 +70,9 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.19):
-    - OpenSSL-Universal/Static (= 1.0.2.19)
-  - OpenSSL-Universal/Static (1.0.2.19)
+  - OpenSSL-Universal (1.0.2.20):
+    - OpenSSL-Universal/Static (= 1.0.2.20)
+  - OpenSSL-Universal/Static (1.0.2.20)
   - QRCodeReader.swift (10.1.0)
   - RCTRequired (0.63.4)
   - RCTTypeSafety (0.63.4):
@@ -302,7 +302,7 @@ PODS:
     - React-jsi (= 0.63.4)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.40.0)
+  - SwiftLint (0.42.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -440,7 +440,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
@@ -448,14 +448,14 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
+  Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b
@@ -479,10 +479,10 @@ SPEC CHECKSUMS:
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
-  SwiftLint: 4154893c73a4c52d6240195507eb7a3e3c64087e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 2e7c7df6fd87cf74da985794a7d8f186edd6ac1f
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -250,7 +250,7 @@ PODS:
     - React-jsi (= 0.63.3)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.40.2)
+  - SwiftLint (0.42.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -384,9 +384,9 @@ SPEC CHECKSUMS:
   ReactCommon: f5e5ad0ae0ad1a5f38b6d585adab7dcde3e823b2
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
-  SwiftLint: 1216c910d27c2633ade33b4f071bb6b930982e62
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Yoga: cce07989d1dce536d190bf212ffff89ad7003f42
 
 PODFILE CHECKSUM: 46118b2425d29bf77d0f229aa6514b3efa6510fa
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -150,9 +150,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         switch component.presentationStyle {
         case "modal":
-            viewController.view.frame = NSRect(size: WindowSize.modalSize)
+            let modalFrame = NSRect(size: WindowSize.modalSize)
+            viewController.view.frame = modalFrame
             if let rootView = viewController.view as? RCTRootView {
-                rootView.minimumSize = WindowSize.modalSize
+                var token: NSObjectProtocol?
+                token = NotificationCenter.default.addObserver(
+                    forName: .RCTContentDidAppear,
+                    object: rootView,
+                    queue: nil,
+                    using: { _ in
+                        rootView.contentView.frame = modalFrame
+                        NotificationCenter.default.removeObserver(token!)
+                    }
+                )
             }
             window.contentViewController?.presentAsModalWindow(viewController)
         default:


### PR DESCRIPTION
### Description

`-[RCTRootView minimumSize]` wasn't added until [0.63](https://github.com/facebook/react-native/commit/432868b0c0c591c245a9cdb91201c64aa5bd70c6):

```
/Users/runner/work/async-storage/async-storage/node_modules/.generated/macos/ReactTestApp/AppDelegate.swift:155:26: error: value of type 'RCTRootView' has no member 'minimumSize'
                rootView.minimumSize = WindowSize.modalSize
                ~~~~~~~~ ^~~~~~~~~~~
```

Instead, we will set the frame size when the view is presented.

Resolves #268.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. `yarn set-react-version 0.62`
2. Build Example app
3. Open Example app and make sure "App (modal)" works
4. `yarn set-react-version 0.63`
5. Repeat steps 2-3