### PR TITLE
fix(iOS): Monkey-patch RedBox not displaying on 0.62

### DIFF
--- a/ios/ReactTestApp/RCTDevSupport+UIScene.m
+++ b/ios/ReactTestApp/RCTDevSupport+UIScene.m
@@ -20,33 +20,71 @@
 
 // MARK: - RCTRedBoxWindow
 
+// MARK: - [0.64] `RCTRedBox` doesn't appear in apps implementing `UISceneDelegate`
+// https://github.com/facebook/react-native/commit/46c77dc296dfab754356cd9346a01dae8d4869f4
+
+#if REACT_NATIVE_VERSION < 6400
+
+// MARK: - [0.63] `RCTRedBox` doesn't appear in apps implementing `UISceneDelegate`
+// https://github.com/facebook/react-native/commit/d0a32c2011ca00991be45ac3fa320f4fc663b2e8
+
 @protocol RCTRedBoxWindowActionDelegate;
 
-// TODO: Re-declared RCTRedBoxWindow here in order to monkey patch in UIScene
-//       support. Revisit when we bump React Native.
 @interface RCTRedBoxWindow : UIWindow <UITableViewDelegate, UITableViewDataSource>
+@property (nonatomic, strong) UIViewController *rootViewController;
 @property (nonatomic, weak) id<RCTRedBoxWindowActionDelegate> actionDelegate;
+
 - (void)dismiss;
+
+// showErrorMessage:withStack:isUpdate: was renamed showErrorMessage:withStack:isUpdate:errorCookie:
+// https://github.com/facebook/react-native/commit/850a8352c91f10842d84c3e811cf6e2a0927f349
+#if REACT_NATIVE_VERSION < 6200
 - (void)showErrorMessage:(NSString *)message
                withStack:(NSArray<RCTJSStackFrame *> *)stack
                 isUpdate:(BOOL)isUpdate;
+#else
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie;
+#endif
 @end
 
 @implementation RCTRedBoxWindow (UISceneSupport)
+
+#if REACT_NATIVE_VERSION < 6200
+static void (*orig_showErrorMessage)(id, SEL, NSString *, NSArray<RCTJSStackFrame *> *, BOOL);
+#else
+static void (*orig_showErrorMessage)(id, SEL, NSString *, NSArray<RCTJSStackFrame *> *, BOOL, int);
+#endif
 
 + (void)load
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
       Class class = [self class];
-      RTASwizzleSelector(class,
-                         @selector(showErrorMessage:withStack:isUpdate:),
-                         @selector(rta_showErrorMessage:withStack:isUpdate:));
+
+#if REACT_NATIVE_VERSION < 6200
+      orig_showErrorMessage =
+          (void (*)(id, SEL, NSString *, NSArray<RCTJSStackFrame *> *, BOOL))RTASwizzleSelector(
+              class,
+              @selector(showErrorMessage:withStack:isUpdate:),
+              @selector(rta_showErrorMessage:withStack:isUpdate:));
+#else
+      orig_showErrorMessage =
+          (void (*)(id, SEL, NSString *, NSArray<RCTJSStackFrame *> *, BOOL, int))
+              RTASwizzleSelector(class,
+                                 @selector(showErrorMessage:withStack:isUpdate:errorCookie:),
+                                 @selector(rta_showErrorMessage:withStack:isUpdate:errorCookie:));
+#endif  // REACT_NATIVE_VERSION < 6200
+#if REACT_NATIVE_VERSION < 6300
       RTASwizzleSelector(class, @selector(dismiss), @selector(rta_dismiss));
       RTASwizzleSelector(class, @selector(makeKeyAndVisible), @selector(rta_makeKeyAndVisible));
+#endif  // REACT_NATIVE_VERSION < 6300
     });
 }
 
+#if REACT_NATIVE_VERSION < 6300
 - (void)rta_makeKeyAndVisible
 {
     // Manually adding the rootViewController's view to the view hierarchy is no
@@ -58,7 +96,9 @@
 {
     [self.rootViewController dismissViewControllerAnimated:YES completion:nil];
 }
+#endif  // REACT_NATIVE_VERSION < 6300
 
+#if REACT_NATIVE_VERSION < 6200
 - (void)rta_showErrorMessage:(NSString *)message
                    withStack:(NSArray<RCTJSStackFrame *> *)stack
                     isUpdate:(BOOL)isUpdate
@@ -69,15 +109,45 @@
             presentViewController:self.rootViewController
                          animated:NO
                        completion:nil];
-        [self rta_showErrorMessage:message withStack:stack isUpdate:isUpdate];
+        orig_showErrorMessage(
+            self, @selector(showErrorMessage:withStack:isUpdate:), message, stack, isUpdate);
     }
 }
+#else
+- (void)rta_showErrorMessage:(NSString *)message
+                   withStack:(NSArray<RCTJSStackFrame *> *)stack
+                    isUpdate:(BOOL)isUpdate
+                 errorCookie:(int)errorCookie
+{
+#if REACT_NATIVE_VERSION < 6300
+    if (self.rootViewController.presentingViewController == nil) {
+        self.rootViewController.view.backgroundColor = UIColor.blackColor;
+        [RCTSharedApplication().delegate.window.rootViewController
+            presentViewController:self.rootViewController
+                         animated:NO
+                       completion:nil];
+    }
+#endif  // REACT_NATIVE_VERSION < 6300
+    orig_showErrorMessage(self,
+                          @selector(showErrorMessage:withStack:isUpdate:),
+                          message,
+                          stack,
+                          isUpdate && self.rootViewController.presentingViewController != nil,
+                          errorCookie);
+}
+#endif  // REACT_NATIVE_VERSION < 6200
 
 @end
 
-// MARK: - RCTDevLoadingView
+#endif  // REACT_NATIVE_VERSION < 6400
 
+// MARK: - [0.63] RCTDevLoadingView doesn't show up with UIScene
+// https://github.com/facebook/react-native/commit/74b667dbc2a48183dec0b9c3b5401bc3f9e54e7b
+
+#if REACT_NATIVE_VERSION < 6300
 @implementation RCTDevLoadingView (UISceneSupport)
+
+static void (*orig_showMessage)(id, SEL, NSString *, UIColor *, UIColor *);
 
 + (void)initialize
 {
@@ -86,9 +156,10 @@
     }
 
     if (@available(iOS 13.0, *)) {
-        RTASwizzleSelector([self class],
-                           @selector(showMessage:color:backgroundColor:),
-                           @selector(rta_showMessage:color:backgroundColor:));
+        orig_showMessage = (void (*)(id, SEL, NSString *, UIColor *, UIColor *))RTASwizzleSelector(
+            [self class],
+            @selector(showMessage:color:backgroundColor:),
+            @selector(rta_showMessage:color:backgroundColor:));
     }
 }
 
@@ -96,7 +167,8 @@
                   color:(UIColor *)color
         backgroundColor:(UIColor *)backgroundColor
 {
-    [self rta_showMessage:message color:color backgroundColor:backgroundColor];
+    orig_showMessage(
+        self, @selector(showMessage:color:backgroundColor:), message, color, backgroundColor);
     if (@available(iOS 13.0, *)) {
         dispatch_async(dispatch_get_main_queue(), ^{
           Ivar _window = class_getInstanceVariable([self class], [@"_window" UTF8String]);
@@ -111,5 +183,6 @@
 }
 
 @end
+#endif  // REACT_NATIVE_VERSION < 6300
 
 #endif  // DEBUG


### PR DESCRIPTION
### Description

A monkey-patch for RedBox not displaying on iOS 13+ was added some time
ago but stopped working in 0.62 because the method signature had
changed.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. `yarn set-react-version 0.61`
2. Build and run Example app
3. Make a change that causes a RedBox to appear, e.g.:
    ```diff
    diff --git a/example/App.js b/example/App.js
    index 8cfe754..442ee32 100644
    --- a/example/App.js
    +++ b/example/App.js
    @@ -69,6 +69,7 @@ const App = () => {

       return (
         <SafeAreaView style={backgroundStyle}>
    +      fail
           <StatusBar barStyle={isDarkMode ? "light-content" : "dark-content"} />
           <ScrollView
             contentInsetAdjustmentBehavior="automatic"
    ```
4. Hit "Dismiss" to make sure RedBox can be dismissed
4. Repeat steps 1-4 for versions 0.62 and 0.63