### PR TITLE
fix(iOS): Ignore nullability-completeness warning in RCTAnimatedImage.h

### DIFF
--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -56,7 +56,10 @@ void RTATriggerReloadCommand(RCTBridge *bridge, NSString *reason)
 
 #if !TARGET_OS_OSX && REACT_NATIVE_VERSION < 6302
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
 #import <React/RCTUIImageViewAnimated.h>
+#pragma clang diagnostic pop
 
 @implementation RCTUIImageViewAnimated (ReactTestApp)
 


### PR DESCRIPTION
### Description

`react-native-test-app` fails to build due to a nullability-completeness warning in `RCTAnimatedImage.h`.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Build Example iOS app in Release mode (Product > Build For > Profiling ⇧⌘I)