### PR TITLE
fix(iOS): Correctly initialize Flipper with defaults

### DIFF
--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -82,7 +82,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
             if let flipper = FlipperClient.shared() {
                 flipper.add(FlipperKitLayoutPlugin(
                     rootNode: UIApplication.shared,
-                    with: SKDescriptorMapper()
+                    with: SKDescriptorMapper(defaults: ())
                 ))
                 flipper.add(FKUserDefaultsPlugin(suiteName: nil))
                 flipper.add(FlipperKitReactPlugin())


### PR DESCRIPTION
### Description

`SKDescriptorMapper` was initialized without defaults, breaking the
Layout and Logs plugins in Flipper.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.