### PR TITLE
fix(Windows): hard-coded react-native-windows path in .sln

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -368,6 +368,13 @@ function generateSolution(destPath, noAutolink) {
           fs.readFileSync(solutionTemplatePath, { encoding: "utf8" }),
           templateView
         )
+        // The current version of this template (v0.63.18) assumes that
+        // `react-native-windows` is always installed in
+        // `..\node_modules\react-native-windows`.
+        .replace(
+          /"\.\.\\node_modules\\react-native-windows/g,
+          '"' + path.relative(destPath, rnWindowsPath)
+        )
         .replace(
           "ReactTestApp\\ReactTestApp.vcxproj",
           path.relative(destPath, reactTestAppProjectPath)

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -372,8 +372,8 @@ function generateSolution(destPath, noAutolink) {
         // `react-native-windows` is always installed in
         // `..\node_modules\react-native-windows`.
         .replace(
-          /"\.\.\\node_modules\\react-native-windows/g,
-          '"' + path.relative(destPath, rnWindowsPath)
+          /"\.\.\\node_modules\\react-native-windows\\/g,
+          `"${path.relative(destPath, rnWindowsPath)}\\`
         )
         .replace(
           "ReactTestApp\\ReactTestApp.vcxproj",


### PR DESCRIPTION
### Description

The app solution template provided by `react-native-windows` currently assumes that `react-native-windows` is always installed in `..\node_modules\react-native-windows`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Currently breaks AsyncStorage: https://github.com/react-native-async-storage/async-storage/pull/524/checks?check_run_id=1758514238

The patch has been verified to work locally.