### PR TITLE
A mechanism for listening to lifecycle events in RNTA

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,6 +94,8 @@ android {
 }
 
 dependencies {
+    implementation project(":support")
+    
     implementation "com.google.dagger:dagger:2.28.3"
     implementation "com.google.dagger:dagger-android:2.28.3"
     implementation "com.google.dagger:dagger-android-support:2.28.3"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,13 +16,11 @@ buildscript {
     apply from: "$buildscriptDir/../test-app-util.gradle"
 
     repositories {
-        google()
         jcenter()
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.android.tools.build:gradle:4.0.2"
     }
 }
 
@@ -45,7 +43,7 @@ apply from: file("${testAppDir}/test-app.gradle")
 applyTestAppModule(project, "com.microsoft.reacttestapp")
 
 project.ext.react = [
-    appName: getAppName(),
+    appName      : getAppName(),
     applicationId: getApplicationId(),
     enableFlipper: getFlipperVersion(rootDir),
     enableHermes : true,
@@ -95,7 +93,7 @@ android {
 
 dependencies {
     implementation project(":support")
-    
+
     implementation "com.google.dagger:dagger:2.28.3"
     implementation "com.google.dagger:dagger-android:2.28.3"
     implementation "com.google.dagger:dagger-android-support:2.28.3"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,10 +10,9 @@ def hermesEngineDir =
 def hermesAndroidDir = "$hermesEngineDir/android"
 
 buildscript {
-    ext.kotlinVersion = "1.4.20"
-
-    def buildscriptDir = buildscript.sourceFile.getParent()
-    apply from: "$buildscriptDir/../test-app-util.gradle"
+    def androidDir = "${buildscript.sourceFile.getParent()}/../"
+    apply from: "$androidDir/test-app-util.gradle"
+    apply from: "$androidDir/dependencies.gradle"
 
     repositories {
         jcenter()
@@ -50,8 +49,8 @@ project.ext.react = [
 ]
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion sdk.version
+    buildToolsVersion sdk.buildToolsVersion
 
     // TODO: Remove this block when minSdkVersion >= 24. See
     // https://stackoverflow.com/q/53402639 for details.
@@ -67,10 +66,10 @@ android {
 
     defaultConfig {
         applicationId project.ext.react.applicationId
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion sdk.minVersion
+        targetSdkVersion sdk.version
+        versionCode rntaVersion.code
+        versionName rntaVersion.label
 
         resValue "string", "app_name", project.ext.react.appName
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -29,8 +29,8 @@ class TestApp : Application(), HasAndroidInjector, ReactApplication {
         eventConsumers.forEach { it.onTestAppCreated() }
 
         val testAppComponent = DaggerTestAppComponent.builder()
-                .binds(this)
-                .build()
+            .binds(this)
+            .build()
         testAppComponent.inject(this)
 
         eventConsumers.forEach { it.onPreInitReactNativeInstance() }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -5,6 +5,7 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.microsoft.reacttestapp.di.DaggerTestAppComponent
 import com.microsoft.reacttestapp.react.TestAppReactNativeHost
+import com.microsoft.reacttestapp.support.ReactTestAppLifecycleEvents
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -1,6 +1,7 @@
 package com.microsoft.reacttestapp
 
 import android.app.Application
+import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.microsoft.reacttestapp.di.DaggerTestAppComponent
 import com.microsoft.reacttestapp.react.TestAppReactNativeHost
@@ -8,6 +9,16 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import javax.inject.Inject
+
+private fun PackageList.invokeLifecycleMethod(name: String) {
+    packages.forEach {
+        try {
+            val methodToFind = it.javaClass.getMethod(name)
+            methodToFind.invoke(it)
+        } catch (e: NoSuchMethodException) {
+        }
+    }
+}
 
 class TestApp : Application(), HasAndroidInjector, ReactApplication {
 
@@ -20,12 +31,15 @@ class TestApp : Application(), HasAndroidInjector, ReactApplication {
     override fun onCreate() {
         super.onCreate()
 
-        val testAppComponent = DaggerTestAppComponent.builder()
-            .binds(this)
-            .build()
+        val packageList = PackageList(this)
+        packageList.invokeLifecycleMethod("onAppCreated")
 
+        val testAppComponent = DaggerTestAppComponent.builder()
+                .binds(this)
+                .build()
         testAppComponent.inject(this)
 
+        packageList.invokeLifecycleMethod("onPreReactNativeInit")
         reactNativeHostInternal.init()
     }
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -38,7 +38,7 @@ class TestApp : Application(), HasAndroidInjector, ReactApplication {
                 eventConsumers.forEach { it.onTestAppWillInitializeReactNative() }
             },
             afterReactNativeInit = {
-                eventConsumers.forEach { it.onTestAppDidInitializeReactNative()}
+                eventConsumers.forEach { it.onTestAppDidInitializeReactNative() }
             },
         )
     }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -38,7 +38,7 @@ class TestApp : Application(), HasAndroidInjector, ReactApplication {
                 eventConsumers.forEach { it.onTestAppWillInitializeReactNative() }
             },
             afterReactNativeInit = {
-                eventConsumers.forEach { it.onTestAppInitializedReactNative()}
+                eventConsumers.forEach { it.onTestAppDidInitializeReactNative()}
             },
         )
     }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -26,15 +26,21 @@ class TestApp : Application(), HasAndroidInjector, ReactApplication {
             .filter { it is ReactTestAppLifecycleEvents }
             .map { it as ReactTestAppLifecycleEvents }
 
-        eventConsumers.forEach { it.onTestAppCreated() }
+        eventConsumers.forEach { it.onTestAppInitialized() }
 
         val testAppComponent = DaggerTestAppComponent.builder()
             .binds(this)
             .build()
         testAppComponent.inject(this)
 
-        eventConsumers.forEach { it.onPreInitReactNativeInstance() }
-        reactNativeHostInternal.init()
+        reactNativeHostInternal.init(
+            beforeReactNativeInit = {
+                eventConsumers.forEach { it.onTestAppWillInitializeReactNative() }
+            },
+            afterReactNativeInit = {
+                eventConsumers.forEach { it.onTestAppInitializedReactNative()}
+            },
+        )
     }
 
     override fun androidInjector(): AndroidInjector<Any> = dispatchingAndroidInjector

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,11 @@ buildscript {
         jcenter()
         google()
     }
+    
+    def buildscriptDir = buildscript.sourceFile.getParent()
+    apply from: "$buildscriptDir/dependencies.gradle"
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.2"
+        classpath "com.android.tools.build:gradle:$androidPluginVersion"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,10 @@
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:4.0.2"
+    }
+}

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,0 +1,16 @@
+
+ext {
+    androidPluginVersion = "4.0.2"
+    kotlinVersion = "1.4.20"
+
+    rntaVersion = [
+        code: 1,
+        label: "1.0"
+    ]
+
+    sdk = [
+        version: 29,
+        minVersion: 21,
+        buildToolsVersion: "29.0.3"
+    ]    
+}

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,16 +1,15 @@
-
 ext {
     androidPluginVersion = "4.0.2"
     kotlinVersion = "1.4.20"
 
     rntaVersion = [
-        code: 1,
+        code : 1,
         label: "1.0"
     ]
 
     sdk = [
-        version: 29,
-        minVersion: 21,
+        version          : 29,
+        minVersion       : 21,
         buildToolsVersion: "29.0.3"
-    ]    
+    ]
 }

--- a/android/react-native-build.gradle
+++ b/android/react-native-build.gradle
@@ -1,10 +1,14 @@
 buildscript {
+    def buildscriptDir = buildscript.sourceFile.getParent()
+    apply from: "$buildscriptDir/dependencies.gradle"
+
     repositories {
         google()
         jcenter()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath "com.android.tools.build:gradle:$androidPluginVersion"
         classpath 'de.undercouch:gradle-download-task:4.1.1'
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name='react-test-app'
-include ':app'
+include ':app', ':support'

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -1,0 +1,23 @@
+repositories {
+    jcenter()
+    google()
+}
+
+apply plugin: "com.android.library"
+
+android {
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -5,15 +5,18 @@ repositories {
 
 apply plugin: "com.android.library"
 
+def androidDir = "${buildscript.sourceFile.getParent()}/../"
+apply from: "$androidDir/dependencies.gradle"
+
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion sdk.version
+    buildToolsVersion sdk.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion sdk.minVersion
+        targetSdkVersion sdk.version
+        versionCode rntaVersion.code
+        versionName rntaVersion.label
     }
 
     compileOptions {

--- a/android/support/src/main/AndroidManifest.xml
+++ b/android/support/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.microsoft.reacttestapp" />

--- a/android/support/src/main/AndroidManifest.xml
+++ b/android/support/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.microsoft.reacttestapp" />
+<manifest package="com.microsoft.reacttestapp.support" />

--- a/android/support/src/main/java/com/microsoft/reacttestapp/ReactTestAppLifecycleEvents.java
+++ b/android/support/src/main/java/com/microsoft/reacttestapp/ReactTestAppLifecycleEvents.java
@@ -1,0 +1,6 @@
+package com.microsoft.reacttestapp;
+
+public interface ReactTestAppLifecycleEvents {
+    void onTestAppCreated();
+    void onPreInitReactNativeInstance();
+}

--- a/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
+++ b/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
@@ -1,4 +1,4 @@
-package com.microsoft.reacttestapp;
+package com.microsoft.reacttestapp.support;
 
 public interface ReactTestAppLifecycleEvents {
     void onTestAppCreated();

--- a/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
+++ b/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
@@ -3,5 +3,5 @@ package com.microsoft.reacttestapp.support;
 public interface ReactTestAppLifecycleEvents {
     void onTestAppInitialized();
     void onTestAppWillInitializeReactNative();
-    void onTestAppInitializedReactNative();
+    void onTestAppDidInitializeReactNative();
 }

--- a/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
+++ b/android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java
@@ -1,6 +1,7 @@
 package com.microsoft.reacttestapp.support;
 
 public interface ReactTestAppLifecycleEvents {
-    void onTestAppCreated();
-    void onPreInitReactNativeInstance();
+    void onTestAppInitialized();
+    void onTestAppWillInitializeReactNative();
+    void onTestAppInitializedReactNative();
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,1 +1,10 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:4.0.2"
+    }
+}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
+    apply from: file("../node_modules/react-native-test-app/android/dependencies.gradle")
+
     repositories {
         jcenter()
         google()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.2"
+        classpath "com.android.tools.build:gradle:$androidPluginVersion"
     }
 }

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -18,7 +18,7 @@
 {
     XCTAssertNotNil(ReactTestAppDidInitializeNotification);
     XCTAssertNotNil(ReactTestAppWillInitializeReactNativeNotification);
-    XCTAssertNotNil(ReactTestAppInitializedReactNativeNotification);
+    XCTAssertNotNil(ReactTestAppDidInitializeReactNativeNotification);
     XCTAssertNotNil(ReactTestAppSceneDidOpenURLNotification);
 }
 

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -17,7 +17,7 @@
 - (void)testDevSupportIsLinked
 {
     XCTAssertNotNil(ReactTestAppDidInitializeNotification);
-    XCTAssertNotNil(ReactTestAppPreInitReactNativeInstanceNotification);
+    XCTAssertNotNil(ReactTestAppWillInitializeReactNativeNotification);
     XCTAssertNotNil(ReactTestAppSceneDidOpenURLNotification);
 }
 

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -18,6 +18,7 @@
 {
     XCTAssertNotNil(ReactTestAppDidInitializeNotification);
     XCTAssertNotNil(ReactTestAppWillInitializeReactNativeNotification);
+    XCTAssertNotNil(ReactTestAppInitializedReactNativeNotification);
     XCTAssertNotNil(ReactTestAppSceneDidOpenURLNotification);
 }
 

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -17,6 +17,7 @@
 - (void)testDevSupportIsLinked
 {
     XCTAssertNotNil(ReactTestAppDidInitializeNotification);
+    XCTAssertNotNil(ReactTestAppPreInitReactNativeInstanceNotification);
     XCTAssertNotNil(ReactTestAppSceneDidOpenURLNotification);
 }
 

--- a/ios/ReactTestApp/AppDelegate.swift
+++ b/ios/ReactTestApp/AppDelegate.swift
@@ -24,10 +24,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     {
         self.application = application
 
-        NotificationCenter.default.post(
-            name: .ReactTestAppDidInitialize,
-            object: nil
-        )
+        defer {
+            NotificationCenter.default.post(
+                name: .ReactTestAppDidInitialize,
+                object: nil
+            )
+        }
 
         return true
     }

--- a/ios/ReactTestApp/AppDelegate.swift
+++ b/ios/ReactTestApp/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.application = application
 
         NotificationCenter.default.post(
-            name: .ReactTestAppDidInitializeNotification,
+            name: .ReactTestAppDidInitialize,
             object: nil
         )
 

--- a/ios/ReactTestApp/AppDelegate.swift
+++ b/ios/ReactTestApp/AppDelegate.swift
@@ -23,6 +23,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
     {
         self.application = application
+
+        NotificationCenter.default.post(
+            name: .ReactTestAppDidInitializeNotification,
+            object: nil
+        )
+
         return true
     }
 

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -10,7 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSNotificationName const ReactTestAppDidInitializeNotification;
-extern NSNotificationName const ReactTestAppPreInitReactNativeInstanceNotification;
+extern NSNotificationName const ReactTestAppWillInitializeReactNativeNotification;
 extern NSNotificationName const ReactTestAppSceneDidOpenURLNotification;
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -10,6 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSNotificationName const ReactTestAppDidInitializeNotification;
+extern NSNotificationName const ReactTestAppPreInitReactNativeInstanceNotification;
 extern NSNotificationName const ReactTestAppSceneDidOpenURLNotification;
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSNotificationName const ReactTestAppDidInitializeNotification;
 extern NSNotificationName const ReactTestAppWillInitializeReactNativeNotification;
-extern NSNotificationName const ReactTestAppInitializedReactNativeNotification;
+extern NSNotificationName const ReactTestAppDidInitializeReactNativeNotification;
 extern NSNotificationName const ReactTestAppSceneDidOpenURLNotification;
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSNotificationName const ReactTestAppDidInitializeNotification;
 extern NSNotificationName const ReactTestAppWillInitializeReactNativeNotification;
+extern NSNotificationName const ReactTestAppInitializedReactNativeNotification;
 extern NSNotificationName const ReactTestAppSceneDidOpenURLNotification;
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -97,6 +97,13 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
     }
 
     func initReact(onDidInitialize: @escaping () -> Void) {
+        if bridge == nil {
+            NotificationCenter.default.post(
+                name: .ReactTestAppPreInitReactNativeInstance,
+                object: []
+            )
+        }
+
         if let bridge = bridge {
             if remoteBundleURL == nil {
                 // When loading the embedded bundle, we must disable remote

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -99,8 +99,8 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
     func initReact(onDidInitialize: @escaping () -> Void) {
         if bridge == nil {
             NotificationCenter.default.post(
-                name: .ReactTestAppPreInitReactNativeInstance,
-                object: []
+                name: .ReactTestAppWillInitializeReactNative,
+                object: nil
             )
         }
 

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -116,7 +116,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
             self.bridge = bridge
 
             NotificationCenter.default.post(
-                name: .ReactTestAppDidInitialize,
+                name: .ReactTestAppInitializedReactNative,
                 object: bridge
             )
 

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -116,7 +116,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
             self.bridge = bridge
 
             NotificationCenter.default.post(
-                name: .ReactTestAppInitializedReactNative,
+                name: .ReactTestAppDidInitializeReactNative,
                 object: bridge
             )
 

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -9,7 +9,7 @@
 
 NSNotificationName const ReactTestAppDidInitializeNotification =
     @"ReactTestAppDidInitializeNotification";
-NSNotificationName const ReactTestAppPreInitReactNativeInstanceNotification =
-    @"ReactTestAppPreInitReactNativeInstanceNotification";
+NSNotificationName const ReactTestAppWillInitializeReactNativeNotification =
+    @"ReactTestAppWillInitializeReactNativeNotification";
 NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
     @"ReactTestAppSceneDidOpenURLNotification";

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -9,5 +9,7 @@
 
 NSNotificationName const ReactTestAppDidInitializeNotification =
     @"ReactTestAppDidInitializeNotification";
+NSNotificationName const ReactTestAppPreInitReactNativeInstanceNotification =
+    @"ReactTestAppPreInitReactNativeInstanceNotification";
 NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
     @"ReactTestAppSceneDidOpenURLNotification";

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -11,5 +11,7 @@ NSNotificationName const ReactTestAppDidInitializeNotification =
     @"ReactTestAppDidInitializeNotification";
 NSNotificationName const ReactTestAppWillInitializeReactNativeNotification =
     @"ReactTestAppWillInitializeReactNativeNotification";
+NSNotificationName const ReactTestAppInitializedReactNativeNotification =
+    @"ReactTestAppInitializedReactNativeNotification";
 NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
     @"ReactTestAppSceneDidOpenURLNotification";

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -11,7 +11,7 @@ NSNotificationName const ReactTestAppDidInitializeNotification =
     @"ReactTestAppDidInitializeNotification";
 NSNotificationName const ReactTestAppWillInitializeReactNativeNotification =
     @"ReactTestAppWillInitializeReactNativeNotification";
-NSNotificationName const ReactTestAppInitializedReactNativeNotification =
-    @"ReactTestAppInitializedReactNativeNotification";
+NSNotificationName const ReactTestAppDidInitializeReactNativeNotification =
+    @"ReactTestAppDidInitializeReactNativeNotification";
 NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
     @"ReactTestAppSceneDidOpenURLNotification";

--- a/plopfile.js
+++ b/plopfile.js
@@ -301,6 +301,11 @@ module.exports = (/** @type {import("plop").NodePlopAPI} */ plop) => {
         });
         actions.push({
           type: "add",
+          path: `${prefix}build.gradle`,
+          templateFile: path.join(androidTemplateDir, "build.gradle")
+        });
+        actions.push({
+          type: "add",
           path: `${prefix}settings.gradle`,
           template: [
             "rootProject.name='example'",

--- a/plopfile.js
+++ b/plopfile.js
@@ -302,7 +302,7 @@ module.exports = (/** @type {import("plop").NodePlopAPI} */ plop) => {
         actions.push({
           type: "add",
           path: `${prefix}build.gradle`,
-          templateFile: path.join(androidTemplateDir, "build.gradle")
+          templateFile: path.join(androidTemplateDir, "build.gradle"),
         });
         actions.push({
           type: "add",

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -17,8 +17,12 @@ private static void apply(Settings settings) {
     }
 
     settings.include(":app")
+    settings.include(":support")
+
     settings.project(":app")
         .projectDir = new File("${projectDir}/android/app")
+    settings.project(":support")
+        .projectDir = new File("${projectDir}/android/support")
 }
 
 def scriptDir = buildscript.sourceFile.getParent()


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
-->

This PR adds a mechanism for listening lifecycle events such as application start, RN init, etc. It does it by looking-up methods in ReactPackage's provided by native modules using reflection.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

The issue #145 is somewhat relevant, but doesn't address the exact problem.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

To test this change, you will need to link a native module that has a ReactPackage with one (or all) of the following methods:

```java
public class LpcAndroidTestReactPackage implements ReactPackage, ReactTestAppLifecycleEvents {
    
    @Override
    public void onTestAppCreated() {
        System.out.println("onTestAppCreated()");
    }

    @Override
    public void onPreInitReactNativeInstance() {
        System.out.println("onPreInitReactNativeInstance()");
    }
    
    ...
}
```