### PR TITLE
fix(android): migrate away from JCenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .watchman-*
 .yarn-offline-mirror/
 Pods/
+android/**/build/
 clang-format-diff.py
 coverage/
 dist/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,7 +15,8 @@ buildscript {
     apply from: "$androidDir/dependencies.gradle"
 
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {
@@ -29,8 +30,21 @@ repositories {
     }
 
     google()
-    jcenter()
+    mavenCentral()
+
+    // TODO: Remove these when they've been published to Maven Central.
+    // See https://github.com/microsoft/react-native-test-app/issues/305
+    jcenter() {
+        content {
+            includeGroup("com.facebook.fbjni")
+            includeGroup("com.facebook.flipper")
+            includeGroup("com.facebook.fresco")
+            includeGroup("com.facebook.yoga")
+        }
+    }
 }
+
+apply from: "$projectDir/../force-resolve-trove4j.gradle"
 
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,12 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-
+buildscript { scriptHandler ->
     def buildscriptDir = buildscript.sourceFile.getParent()
     apply from: "$buildscriptDir/dependencies.gradle"
+    apply from: "$buildscriptDir/force-resolve-trove4j.gradle", to: scriptHandler
+
+    repositories {
+        google()
+        mavenCentral()
+    }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidPluginVersion"

--- a/android/force-resolve-trove4j.gradle
+++ b/android/force-resolve-trove4j.gradle
@@ -1,0 +1,13 @@
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            // https://issuetracker.google.com/issues/109894262#comment9
+            if (requested.group == "org.jetbrains.trove4j" &&
+                requested.name == "trove4j" &&
+                requested.version == "20160824")
+            {
+                useTarget("org.jetbrains.intellij.deps:trove4j:1.0.20181211")
+            }
+        }
+    }
+}

--- a/android/react-native-build.gradle
+++ b/android/react-native-build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     configurations.all {
         resolutionStrategy {

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -1,12 +1,12 @@
 repositories {
-    jcenter()
     google()
+    mavenCentral()
 }
 
-apply plugin: "com.android.library"
-
 def androidDir = "${buildscript.sourceFile.getParent()}/../"
-apply from: "$androidDir/dependencies.gradle"
+apply from: "$androidDir/force-resolve-trove4j.gradle"
+
+apply plugin: "com.android.library"
 
 android {
     compileSdkVersion sdk.version

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,9 +1,11 @@
-buildscript {
-    apply from: file("../node_modules/react-native-test-app/android/dependencies.gradle")
+buildscript { scriptHandler ->
+    def androidTestAppDir = "../node_modules/react-native-test-app/android"
+    apply from: "$androidTestAppDir/dependencies.gradle"
+    apply from: "$androidTestAppDir/force-resolve-trove4j.gradle", to: scriptHandler
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -348,12 +348,14 @@ const getConfig = (() => {
         android: {
           files: {
             "build.gradle": join(
-              "buildscript {",
-              `    apply from: file("${testAppRelPath}/android/dependencies.gradle")`,
+              "buildscript { scriptHandler ->",
+              `    def androidTestAppDir = "${testAppRelPath}/android"`,
+              '    apply from: "$androidTestAppDir/dependencies.gradle"',
+              '    apply from: "$androidTestAppDir/force-resolve-trove4j.gradle", to: scriptHandler',
               "",
               "    repositories {",
-              "        jcenter()",
               "        google()",
+              "        mavenCentral()",
               "    }",
               "",
               "    dependencies {",

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -54,12 +54,14 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript {
-    apply from: file(\\"../../../android/dependencies.gradle\\")
+    "android/build.gradle": "buildscript { scriptHandler ->
+    def androidTestAppDir = \\"../../../android\\"
+    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
+    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -184,12 +186,14 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript {
-    apply from: file(\\"../../../android/dependencies.gradle\\")
+    "android/build.gradle": "buildscript { scriptHandler ->
+    def androidTestAppDir = \\"../../../android\\"
+    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
+    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -287,12 +291,14 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript {
-    apply from: file(\\"../../../android/dependencies.gradle\\")
+    "android/build.gradle": "buildscript { scriptHandler ->
+    def androidTestAppDir = \\"../../../android\\"
+    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
+    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
### Description

JCenter is being sunset: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.