### PR TITLE
ci: use rubocop-minitest as suggested by RuboCop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source 'https://rubygems.org' do
   gem 'minitest'
   gem 'rubocop', require: false
+  gem 'rubocop-minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-minitest (0.10.3)
+      rubocop (>= 0.87, < 2.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.0.0)
 
@@ -29,6 +31,7 @@ PLATFORMS
 DEPENDENCIES
   minitest!
   rubocop!
+  rubocop-minitest!
 
 BUNDLED WITH
    2.2.3


### PR DESCRIPTION
### Description

```
$ bundle exec rubocop
Inspecting 15 files
...............

15 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (http://github.com/rubocop-hq/rubocop-minitest)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should be green.