### PR TITLE
fix(android): include missing `react-native-codegen`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,6 +52,11 @@ android {
     compileSdkVersion sdk.version
     buildToolsVersion sdk.buildToolsVersion
 
+    // We need only set `ndkVersion` when building react-native from source.
+    if (hasProperty("ANDROID_NDK_VERSION")) {
+        ndkVersion ANDROID_NDK_VERSION
+    }
+
     // TODO: Remove this block when minSdkVersion >= 24. See
     // https://stackoverflow.com/q/53402639 for details.
     compileOptions {
@@ -68,8 +73,8 @@ android {
         applicationId project.ext.react.applicationId
         minSdkVersion sdk.minVersion
         targetSdkVersion sdk.version
-        versionCode rntaVersion.code
-        versionName rntaVersion.label
+        versionCode reactTestApp.versionCode
+        versionName reactTestApp.versionName
 
         resValue "string", "app_name", project.ext.react.appName
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
         google()
     }
-    
+
     def buildscriptDir = buildscript.sourceFile.getParent()
     apply from: "$buildscriptDir/dependencies.gradle"
 

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -2,9 +2,9 @@ ext {
     androidPluginVersion = "4.0.2"
     kotlinVersion = "1.4.20"
 
-    rntaVersion = [
-        code : 1,
-        label: "1.0"
+    reactTestApp = [
+        versionCode: 1,
+        versionName: "1.0"
     ]
 
     sdk = [

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion sdk.minVersion
         targetSdkVersion sdk.version
-        versionCode rntaVersion.code
-        versionName rntaVersion.label
+        versionCode reactTestApp.versionCode
+        versionName reactTestApp.versionName
     }
 
     compileOptions {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,6 @@
 # These properties are required to enable AndroidX for the test app.
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Uncomment the line below if building react-native from source
+#ANDROID_NDK_VERSION=20.1.5948944

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,3 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+        google()
+    }
+}
+
 rootProject.name='example'
 
 apply from: file("../node_modules/react-native-test-app/test-app.gradle")

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -35,7 +35,7 @@ const profiles = {
   master: {
     react: "17.0.1",
     "react-native": "facebook/react-native#master",
-    "react-native-codegen": "^0.0.6",
+    "react-native-codegen": "^0.0.7",
     "react-native-macos": undefined,
     "react-native-windows": undefined,
   },

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -14,6 +14,13 @@ private static void apply(Settings settings) {
         settings.include(":ReactAndroid")
         settings.project(":ReactAndroid")
             .projectDir = new File("${reactNativeDir}/ReactAndroid")
+
+        settings.include(":packages:react-native-codegen:android")
+        settings.project(":packages:react-native-codegen:android")
+            .projectDir = new File("${reactNativeDir}/packages/react-native-codegen/android")
+
+        settings.includeBuild("${reactNativeDir}/packages/react-native-codegen/android")
+        settings.includeBuild("${reactNativeDir}/packages/react-native-gradle-plugin")
     }
 
     settings.include(":app")


### PR DESCRIPTION
### Description

When building react-native from source, `react-native-codegen` also needs to be included.

Even with this fix, building will still fail due to `react-native-codegen` being out of sync with `react-native#master`:
```
> Task :ReactAndroid:buildReactNdkLib FAILED
make: Entering directory `~/Source/react-native-test-app/example/node_modules/react-native/ReactAndroid/src/main/jni/react/jni'
make: Leaving directory `~/Source/react-native-test-app/example/node_modules/react-native/ReactAndroid/src/main/jni/react/jni'
~/Library/Android/sdk/ndk/20.1.5948944/build/core/build-binary.mk:666: Android NDK: Module react_codegen_rncore depends on undefined modules: react_render_components_view
~/Library/Android/sdk/ndk/20.1.5948944/build/core/build-binary.mk:679: *** Android NDK: Aborting (set APP_ALLOW_MISSING_DEPS=true to allow missing dependencies)    .  Stop.

FAILURE: Build failed with an exception.
```

Manually fixing `react-native-codegen`, replacing `react_render_components_view` with `rrc_view`, will get you get past this point but you'll hit build errors in Java further down the line.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Set react-native version: `yarn set-react-version master`
2. Build Example app:
    ```sh
    cd example
    yarn
    cd android
    ./gradlew clean build
    ```