### PR TITLE
fix(ios): background color doesn't respect dark mode

### DIFF
--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -186,6 +186,7 @@ final class ContentViewController: UITableViewController {
                 moduleName: component.appKey,
                 initialProperties: component.initialProperties
             )
+            viewController.view.backgroundColor = UIColor.systemBackground
             return viewController
         }()
 


### PR DESCRIPTION
### Description

Background colour of `RCTRootView` is [always white](https://github.com/facebook/react-native/blob/master/React/Base/RCTRootView.m#L61), even when in dark mode. This issue does not repro on macOS because a background colour is [never set](https://github.com/microsoft/react-native-macos/blob/master/React/Base/RCTRootView.m#L81).

Resolves #285.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows
