### PR TITLE
fix: work around Plop trying to replace variables in `App.js`

### DIFF
--- a/plopfile.js
+++ b/plopfile.js
@@ -11,6 +11,22 @@
  */
 
 /**
+ * Escapes tokens in specified file to prevent Handlebar from attempting to
+ * replace them.
+ *
+ * NOTE: This is a temporary workaround until we can deprecate the Plop template
+ * entirely.
+ *
+ * @param {string} file
+ * @returns {string}
+ */
+function escapeHandlebarTokens(file) {
+  const fs = require("fs");
+  const content = fs.readFileSync(file, { encoding: "utf-8" });
+  return content.replace(/\{\{/g, "\\{{");
+}
+
+/**
  * Returns whether the target platform is included.
  * @param {"all" | Platform} platform
  * @param {Platform} target
@@ -173,7 +189,9 @@ module.exports = (/** @type {import("plop").NodePlopAPI} */ plop) => {
         {
           type: "add",
           path: "App.js",
-          templateFile: require.resolve("react-native/template/App.js"),
+          template: escapeHandlebarTokens(
+            require.resolve("react-native/template/App.js")
+          ),
         },
         {
           type: "add",


### PR DESCRIPTION
### Description

Plop is trying to replace values between `{{` and `}}` even though we just want to copy the file verbatim. The real fix here is to replace Plop with something else since we don't really use Handlebar templates for anything, but that will come in a separate PR.

Resolves #290.

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

1. Checkout this branch and make sure it is clean (i.e. run `yarn clean`)
2. Run `yarn link` to register a link
3. Checkout https://github.com/pruthvip/rnta-test
4. Run the following commands in `rnta-test`:
    ```sh
    yarn
    yarn link react-native-test-app
    yarn plop --plopfile node_modules/react-native-test-app/plopfile.js --dest test test all
    ```