### PR TITLE
fix(apple): add support for nightlies/canaries

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -120,7 +120,7 @@ end
 
 def react_native_pods(version)
   v = version.release
-  if v >= Gem::Version.new('0.63')
+  if v == Gem::Version.new('0.0.0') || v >= Gem::Version.new('0.63')
     'use_react_native-0.63'
   elsif v >= Gem::Version.new('0.62')
     'use_react_native-0.62'


### PR DESCRIPTION
### Description

Adds support for react-native/react-native-macos nightlies/canaries.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. `yarn set-react-version nightly`
2. Build Example app