### PR TITLE
ci(ios): build nightlies off master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,12 @@ jobs:
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          yarn set-react-version nightly
+          # `nightly` currently doesn't build due to use of version numbers that
+          # are incompatible with CocoaPods. See
+          # https://github.com/facebook/react-native/issues/30036 and
+          # https://github.com/microsoft/react-native-macos/issues/620 for more
+          # details.
+          yarn set-react-version master
       - name: Install
         run: |
           yarn ci


### PR DESCRIPTION
### Description

`nightly` currently doesn't build due to use of version numbers that are incompatible with CocoaPods. See https://github.com/facebook/react-native/issues/30036 and https://github.com/microsoft/react-native-macos/issues/620 for more details.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.