### PR TITLE
fix(windows): restore ability to use NuGet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,7 +405,7 @@ jobs:
       - name: Build bundle and create solution
         run: |
           yarn build:windows
-          yarn install-windows-test-app
+          yarn install-windows-test-app --use-nuget
         working-directory: example
       - name: Install NuGet packages
         run: |
@@ -460,7 +460,7 @@ jobs:
         run: |
           yarn build:windows
           if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app }
-          else { yarn install-windows-test-app --projectDirectory=. }
+          else { yarn install-windows-test-app --project-directory=. }
         working-directory: template-example
       - name: Install NuGet packages
         run: |

--- a/example/package.json
+++ b/example/package.json
@@ -28,6 +28,6 @@
     "react-native": "0.63.4",
     "react-native-macos": "0.63.23",
     "react-native-test-app": "../",
-    "react-native-windows": "0.63.24"
+    "react-native-windows": "0.63.26"
   }
 }

--- a/example/windows/.gitignore
+++ b/example/windows/.gitignore
@@ -25,3 +25,4 @@ packages/
 
 **/Generated Files/**
 *.sln
+NuGet.Config

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -880,15 +880,16 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-windows/cli@0.63.10":
-  version "0.63.10"
-  resolved "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.63.10.tgz#d26f54003ebf6fa4909db57d07a765057b35f7b8"
-  integrity sha512-nCVCN6DKciOtmou71Sj3b30CvQfnD+t9TbSYa8uuGTguB57A3F2gOBl+6fS+r9cAQ5V5mMAX2LWg1YovT8sPcw==
+"@react-native-windows/cli@0.63.11":
+  version "0.63.11"
+  resolved "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.63.11.tgz#239c7d905c9198fbbb08b117acb6260d5ce94828"
+  integrity sha512-RRfeoBwFIIdctcvT8Ynrew7kdYCqnGY/35CrW6M2/G+f3ZVwHhTpdF8I5zyLAQskvFgztRE40MdMofylgcRI0Q==
   dependencies:
-    "@react-native-windows/telemetry" "^0.63.4"
+    "@react-native-windows/telemetry" "^0.63.5"
     chalk "^3.0.0"
     cli-spinners "^2.2.0"
     envinfo "^7.5.0"
+    find-up "^4.1.0"
     glob "^7.1.1"
     inquirer "^3.0.6"
     mustache "^4.0.1"
@@ -899,13 +900,13 @@
     username "^5.1.0"
     uuid "^3.3.2"
     xml-parser "^1.2.1"
-    xmldom "^0.3.0"
+    xmldom "^0.5.0"
     xpath "^0.0.27"
 
-"@react-native-windows/telemetry@^0.63.4":
-  version "0.63.4"
-  resolved "https://registry.npmjs.org/@react-native-windows/telemetry/-/telemetry-0.63.4.tgz#940cffe1cb890ac22c76ba04af2284e1412c7faa"
-  integrity sha512-jTCLw1JcKVaNbRYq6KJIu72VcJ61a80ZjT6++KDJcLROA6DyRxiX3LhW5anIbV4Ww9vA5CNlU0SUb2pAIw8Jpw==
+"@react-native-windows/telemetry@^0.63.5":
+  version "0.63.5"
+  resolved "https://registry.npmjs.org/@react-native-windows/telemetry/-/telemetry-0.63.5.tgz#77d3a490b26490a642e7d7ce21cd5c06b768f4be"
+  integrity sha512-Ifd54IIcGbPjwAGfjJkRfdk5+SNtc9oCWgKMrJszIrlJ1REYVUXBo+6Xw3taKyA1Jf1eCB7DWlb98/NbqdLgcg==
   dependencies:
     applicationinsights "^1.8.8"
 
@@ -3672,13 +3673,13 @@ react-native-test-app@../:
     rimraf "^3.0.0"
     yargs "^16.0.0"
 
-react-native-windows@0.63.24:
-  version "0.63.24"
-  resolved "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.63.24.tgz#40d6aca2a748ef3985b5942b29d0b05631fecca7"
-  integrity sha512-N+C3NR4cYM7uOXbhx4sMT3QmjSJ7tPKEJBZOVlieEHJ1Bm0ZyP9Bv7ZKzLeouCA/z78/5NhixIwiJVJ1CPIjMA==
+react-native-windows@0.63.26:
+  version "0.63.26"
+  resolved "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.63.26.tgz#af5213c5a0f7ecfd013701531490e9120b9192e4"
+  integrity sha512-ZbxskcsR+7nJ8uqXnnuZgHHzBB8gZ7RJ556skiTUXlXKs1vh4/PODmSvvNroX/56UXw35/Zi/YtapT/sMqgPJQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@react-native-windows/cli" "0.63.10"
+    "@react-native-windows/cli" "0.63.11"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     base64-js "^1.1.2"
@@ -4664,10 +4665,10 @@ xmldom@0.1.x:
   resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
-xmldom@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz#e625457f4300b5df9c2e1ecb776147ece47f3e5a"
-  integrity sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpath@^0.0.27:
   version "0.0.27"

--- a/package.json
+++ b/package.json
@@ -1,19 +1,5 @@
 {
   "name": "react-native-test-app",
-  "license": "MIT",
-  "author": {
-    "name": "Microsoft Open Source",
-    "email": "microsoftopensource@users.noreply.github.com"
-  },
-  "bin": {
-    "configure-test-app": "scripts/configure.js",
-    "init-test-app": "scripts/init.js",
-    "install-windows-test-app": "windows/test-app.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/react-native-test-app.git"
-  },
   "version": "0.0.1-dev",
   "description": "react-native-test-app provides a test app for all supported platforms as a package",
   "keywords": [
@@ -29,6 +15,20 @@
     "windows"
   ],
   "homepage": "https://github.com/microsoft/react-native-test-app",
+  "license": "MIT",
+  "author": {
+    "name": "Microsoft Open Source",
+    "email": "microsoftopensource@users.noreply.github.com"
+  },
+  "bin": {
+    "configure-test-app": "scripts/configure.js",
+    "init-test-app": "scripts/init.js",
+    "install-windows-test-app": "windows/test-app.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-test-app.git"
+  },
   "scripts": {
     "ci": "yarn --use-yarnrc .yarnrc-offline --prefer-offline --frozen-lockfile --non-interactive",
     "clean": "npx --quiet rimraf example/node_modules/react-native-test-app && git clean -dfqx",
@@ -88,7 +88,7 @@
     "react": "16.13.1",
     "react-native": "0.63.4",
     "react-native-macos": "0.63.23",
-    "react-native-windows": "0.63.24",
+    "react-native-windows": "0.63.26",
     "semantic-release": "^17.0.0",
     "suggestion-bot": "^1.0.0",
     "typescript": "^4.0.0"

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -39,7 +39,7 @@ const profiles = {
     react: "17.0.1",
     "react-native": "0.64.0",
     "react-native-macos": undefined,
-    "react-native-windows": "0.64.1",
+    "react-native-windows": "0.64.3",
   },
   master: {
     "@react-native-community/cli": "^5.0.1-alpha.0",

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -14,6 +14,11 @@ describe("generateSolution", () => {
 
   const cwd = process.cwd();
 
+  const options = {
+    autolink: false,
+    useNuGet: false,
+  };
+
   beforeEach(() => {
     process.chdir(path.dirname(cwd));
   });
@@ -25,13 +30,15 @@ describe("generateSolution", () => {
   });
 
   test("throws if destination path is missing/invalid", () => {
-    expect(() => generateSolution("")).toThrow(
+    expect(() => generateSolution("", options)).toThrow(
       "Missing or invalid destination path"
     );
   });
 
   test("exits if 'node_modules' folder cannot be found", () => {
-    expect(generateSolution("test")).toBe("Could not find 'node_modules'");
+    expect(generateSolution("test", options)).toBe(
+      "Could not find 'node_modules'"
+    );
   });
 
   test("exits if 'react-native-windows' folder cannot be found", () => {
@@ -40,7 +47,7 @@ describe("generateSolution", () => {
       [path.resolve("", "node_modules")]: "directory",
     });
 
-    expect(generateSolution("test")).toBe(
+    expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-windows'"
     );
   });
@@ -52,7 +59,7 @@ describe("generateSolution", () => {
       [path.resolve("", "node_modules", "react-native-windows")]: "directory",
     });
 
-    expect(generateSolution("test")).toBe(
+    expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-test-app'"
     );
   });

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
     <PropertyGroup Label="Globals">
         <CppWinRTOptimized>true</CppWinRTOptimized>
         <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -16,12 +16,16 @@
         <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
         <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
         <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+        <PackageCertificateKeyFile>ReactTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
+        <PackageCertificateThumbprint>4AC7A41A12F06BCFEDBADCE05ECFFDF546109B66</PackageCertificateThumbprint>
     </PropertyGroup>
     <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
     <PropertyGroup Label="ReactNativeWindowsProps">
         <ProjectRootDir Condition="'$(ProjectRootDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'app.json'))</ProjectRootDir>
         <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
         <ReactTestAppDir Condition="'$(ReactTestAppDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows\ReactTestApp\</ReactTestAppDir>
+        <UseExperimentalNuget>false</UseExperimentalNuget>
+        <WinUI2xVersion>2.5.0</WinUI2xVersion>
     </PropertyGroup>
     <ItemGroup Label="ProjectConfigurations">
         <ProjectConfiguration Include="Debug|ARM">
@@ -65,8 +69,6 @@
         <BundleFileAssets>$(BundleFileContentPaths)</BundleFileAssets>
         <AssetsContentRoot>$(ReactTestAppDir)\Assets</AssetsContentRoot>
         <AssetsContent>$(AssetsContentRoot)\**\*</AssetsContent>
-        <PackageCertificateThumbprint>4AC7A41A12F06BCFEDBADCE05ECFFDF546109B66</PackageCertificateThumbprint>
-        <PackageCertificateKeyFile>ReactTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
         <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -92,28 +94,28 @@
         <Import Project="$(SolutionDir)packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)' != '' And Exists('$(SolutionDir)packages\$(WinUIPackageProps)')" />
     </ImportGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ReactTestAppDir)</IncludePath>
+        <IncludePath>$(ReactTestAppDir);$(IncludePath)</IncludePath>
     </PropertyGroup>
     <ItemDefinitionGroup>
         <ClCompile>
@@ -229,24 +231,24 @@
     </ImportGroup>
     <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
         <PropertyGroup>
-            <ErrorText>This project references targets in your node_modules\react-native-windows folder. The missing file is {0}.</ErrorText>
+            <ErrorText>This project references targets in your node_modules\react-native-windows folder that are missing. The missing file is {0}.</ErrorText>
         </PropertyGroup>
         <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props'))" />
         <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
     </Target>
     <ImportGroup Label="ExtensionTargets">
-        <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
-        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.0.63.2\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.0.63.2\build\native\Microsoft.ReactNative.targets')" />
-        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.0.63.2\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.0.63.2\build\native\Microsoft.ReactNative.Cxx.targets')" />
-        <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets')" />
+        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets')" />
         <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+        <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
     </ImportGroup>
     <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
         <PropertyGroup>
             <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
         </PropertyGroup>
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
         <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets'))" />
     </Target>
 </Project>

--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.4.3" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" />
+  <package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="nlohmann.json" version="3.9.1" targetFramework="native" />
 </packages>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,15 +1379,16 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-windows/cli@0.63.10":
-  version "0.63.10"
-  resolved "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.63.10.tgz#d26f54003ebf6fa4909db57d07a765057b35f7b8"
-  integrity sha512-nCVCN6DKciOtmou71Sj3b30CvQfnD+t9TbSYa8uuGTguB57A3F2gOBl+6fS+r9cAQ5V5mMAX2LWg1YovT8sPcw==
+"@react-native-windows/cli@0.63.11":
+  version "0.63.11"
+  resolved "https://registry.npmjs.org/@react-native-windows/cli/-/cli-0.63.11.tgz#239c7d905c9198fbbb08b117acb6260d5ce94828"
+  integrity sha512-RRfeoBwFIIdctcvT8Ynrew7kdYCqnGY/35CrW6M2/G+f3ZVwHhTpdF8I5zyLAQskvFgztRE40MdMofylgcRI0Q==
   dependencies:
-    "@react-native-windows/telemetry" "^0.63.4"
+    "@react-native-windows/telemetry" "^0.63.5"
     chalk "^3.0.0"
     cli-spinners "^2.2.0"
     envinfo "^7.5.0"
+    find-up "^4.1.0"
     glob "^7.1.1"
     inquirer "^3.0.6"
     mustache "^4.0.1"
@@ -1398,13 +1399,13 @@
     username "^5.1.0"
     uuid "^3.3.2"
     xml-parser "^1.2.1"
-    xmldom "^0.3.0"
+    xmldom "^0.5.0"
     xpath "^0.0.27"
 
-"@react-native-windows/telemetry@^0.63.4":
-  version "0.63.4"
-  resolved "https://registry.npmjs.org/@react-native-windows/telemetry/-/telemetry-0.63.4.tgz#940cffe1cb890ac22c76ba04af2284e1412c7faa"
-  integrity sha512-jTCLw1JcKVaNbRYq6KJIu72VcJ61a80ZjT6++KDJcLROA6DyRxiX3LhW5anIbV4Ww9vA5CNlU0SUb2pAIw8Jpw==
+"@react-native-windows/telemetry@^0.63.5":
+  version "0.63.5"
+  resolved "https://registry.npmjs.org/@react-native-windows/telemetry/-/telemetry-0.63.5.tgz#77d3a490b26490a642e7d7ce21cd5c06b768f4be"
+  integrity sha512-Ifd54IIcGbPjwAGfjJkRfdk5+SNtc9oCWgKMrJszIrlJ1REYVUXBo+6Xw3taKyA1Jf1eCB7DWlb98/NbqdLgcg==
   dependencies:
     applicationinsights "^1.8.8"
 
@@ -8309,13 +8310,13 @@ react-native-macos@0.63.23:
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
-react-native-windows@0.63.24:
-  version "0.63.24"
-  resolved "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.63.24.tgz#40d6aca2a748ef3985b5942b29d0b05631fecca7"
-  integrity sha512-N+C3NR4cYM7uOXbhx4sMT3QmjSJ7tPKEJBZOVlieEHJ1Bm0ZyP9Bv7ZKzLeouCA/z78/5NhixIwiJVJ1CPIjMA==
+react-native-windows@0.63.26:
+  version "0.63.26"
+  resolved "https://registry.npmjs.org/react-native-windows/-/react-native-windows-0.63.26.tgz#af5213c5a0f7ecfd013701531490e9120b9192e4"
+  integrity sha512-ZbxskcsR+7nJ8uqXnnuZgHHzBB8gZ7RJ556skiTUXlXKs1vh4/PODmSvvNroX/56UXw35/Zi/YtapT/sMqgPJQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@react-native-windows/cli" "0.63.10"
+    "@react-native-windows/cli" "0.63.11"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     base64-js "^1.1.2"
@@ -10487,10 +10488,10 @@ xmldom@0.1.x:
   resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
-xmldom@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz#e625457f4300b5df9c2e1ecb776147ece47f3e5a"
-  integrity sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpath@^0.0.27:
   version "0.0.27"


### PR DESCRIPTION
### Description

Restores the ability to use the experimental NuGet packages.

Resolves #299.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

CI should pass.

To test locally, specify the `--use-nuget` flag when installing the Windows test app:
```
cd example
yarn
yarn install-windows-test-app --use-nuget
start windows/Example.sln
```