### PR TITLE
fix(windows): support for custom Package.appxmanifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/mustache": "^4.0.0",
     "@types/node": "^12.0.0",
     "@types/prompts": "^2.0.0",
+    "@types/rimraf": "^3.0.0",
     "eslint": "^7.10.0",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -605,7 +605,6 @@ function isDestructive(packagePath, { files, oldFiles }) {
  */
 function removeAllFiles(files, destination) {
   /** @type {(p: string, cb: (error?: Error) => void) => void} */
-  // @ts-ignore
   const rimraf = require("rimraf");
 
   const rethrow = (/** @type {Error | undefined} */ error) => {

--- a/test/configure/getAppName.test.js
+++ b/test/configure/getAppName.test.js
@@ -9,7 +9,7 @@
 jest.mock("fs");
 
 describe("getAppName()", () => {
-  const { mockFiles } = require("./mockFiles");
+  const { mockFiles } = require("../mockFiles");
   const { getAppName } = require("../../scripts/configure");
 
   const consoleSpy = jest.spyOn(global.console, "warn");

--- a/test/configure/isDestructive.test.js
+++ b/test/configure/isDestructive.test.js
@@ -9,7 +9,7 @@
 jest.mock("fs");
 
 describe("isDestructive()", () => {
-  const { mockFiles } = require("./mockFiles");
+  const { mockFiles } = require("../mockFiles");
   const { isDestructive } = require("../../scripts/configure");
 
   /**

--- a/test/configure/removeAllFiles.test.js
+++ b/test/configure/removeAllFiles.test.js
@@ -11,7 +11,7 @@ jest.mock("fs");
 const fs = require("fs");
 
 describe("removeAllFiles()", () => {
-  const { mockFiles } = require("./mockFiles");
+  const { mockFiles } = require("../mockFiles");
   const { removeAllFiles } = require("../../scripts/configure");
 
   beforeEach(() => {

--- a/test/configure/updatePackageManifest.test.js
+++ b/test/configure/updatePackageManifest.test.js
@@ -9,7 +9,7 @@
 jest.mock("fs");
 
 describe("updatePackageManifest()", () => {
-  const { mockFiles } = require("./mockFiles");
+  const { mockFiles } = require("../mockFiles");
   const { updatePackageManifest } = require("../../scripts/configure");
 
   afterEach(() => mockFiles());

--- a/test/configure/writeAllFiles.test.js
+++ b/test/configure/writeAllFiles.test.js
@@ -12,7 +12,7 @@ const fs = require("fs");
 const path = require("path");
 
 describe("writeAllFiles()", () => {
-  const { mockFiles } = require("./mockFiles");
+  const { mockFiles } = require("../mockFiles");
   const { writeAllFiles } = require("../../scripts/configure");
 
   afterEach(() => {

--- a/test/mockFiles.js
+++ b/test/mockFiles.js
@@ -19,7 +19,10 @@ function mockFiles(...files) {
   // @ts-ignore `__setMockFiles`
   fs.__setMockFiles(
     Object.fromEntries(
-      files.map(([filename, content]) => [filename, JSON.stringify(content)])
+      files.map(([filename, content]) => [
+        filename,
+        typeof content === "string" ? content : JSON.stringify(content),
+      ])
     )
   );
 }

--- a/test/windows-test-app/copyAndReplace.test.js
+++ b/test/windows-test-app/copyAndReplace.test.js
@@ -9,19 +9,19 @@
 jest.mock("fs");
 
 describe("copyAndReplace", () => {
+  const { mockFiles } = require("../mockFiles");
   const { copyAndReplace } = require("../../windows/test-app");
 
-  // @ts-ignore `__setMockFiles`
-  afterEach(() => require("fs").__setMockFiles({}));
+  afterEach(() => mockFiles());
 
   test("replaces text files only", () => {
+    mockFiles(
+      ["ReactTestApp_TemporaryKey.pfx", "binary"],
+      ["ReactTestApp.png", "binary"],
+      ["ReactTestApp.sln", "binary"]
+    );
+
     const fs = require("fs");
-    // @ts-ignore `__setMockFiles`
-    fs.__setMockFiles({
-      "ReactTestApp_TemporaryKey.pfx": "binary",
-      "ReactTestApp.png": "binary",
-      "ReactTestApp.sln": "binary",
-    });
 
     const replacements = { binary: "text" };
 

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -10,6 +10,7 @@ jest.mock("fs");
 
 describe("generateSolution", () => {
   const path = require("path");
+  const { mockFiles } = require("../mockFiles");
   const { generateSolution } = require("../../windows/test-app");
 
   const cwd = process.cwd();
@@ -24,8 +25,7 @@ describe("generateSolution", () => {
   });
 
   afterEach(() => {
-    // @ts-ignore `__setMockFiles`
-    require("fs").__setMockFiles({});
+    mockFiles();
     process.chdir(cwd);
   });
 
@@ -42,10 +42,7 @@ describe("generateSolution", () => {
   });
 
   test("exits if 'react-native-windows' folder cannot be found", () => {
-    // @ts-ignore `__setMockFiles`
-    require("fs").__setMockFiles({
-      [path.resolve("", "node_modules")]: "directory",
-    });
+    mockFiles([path.resolve("", "node_modules"), "directory"]);
 
     expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-windows'"
@@ -53,11 +50,10 @@ describe("generateSolution", () => {
   });
 
   test("exits if 'react-native-test-app' folder cannot be found", () => {
-    // @ts-ignore `__setMockFiles`
-    require("fs").__setMockFiles({
-      [path.resolve("", "node_modules")]: "directory",
-      [path.resolve("", "node_modules", "react-native-windows")]: "directory",
-    });
+    mockFiles(
+      [path.resolve("", "node_modules"), "directory"],
+      [path.resolve("", "node_modules", "react-native-windows"), "directory"]
+    );
 
     expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-test-app'"

--- a/test/windows-test-app/parseResources.test.js
+++ b/test/windows-test-app/parseResources.test.js
@@ -9,10 +9,10 @@
 jest.mock("fs");
 
 describe("parseResources", () => {
+  const { mockFiles } = require("../mockFiles");
   const { parseResources } = require("../../windows/test-app");
 
-  // @ts-ignore `__setMockFiles`
-  afterEach(() => require("fs").__setMockFiles({}));
+  afterEach(() => mockFiles());
 
   test("returns empty strings for no resources", () => {
     expect(parseResources(undefined, "", "")).toEqual(["", ""]);
@@ -22,11 +22,7 @@ describe("parseResources", () => {
   });
 
   test("returns references to existing assets", () => {
-    // @ts-ignore `__setMockFiles`
-    require("fs").__setMockFiles({
-      "dist/assets": "directory",
-      "dist/main.jsbundle": "text",
-    });
+    mockFiles(["dist/assets", "directory"], ["dist/main.jsbundle", "text"]);
 
     expect(
       parseResources(

--- a/windows/ReactTestApp/App.cpp
+++ b/windows/ReactTestApp/App.cpp
@@ -9,8 +9,6 @@
 
 #include "App.h"
 
-#include "MainPage.h"
-
 using winrt::ReactTestApp::implementation::App;
 using winrt::Windows::ApplicationModel::SuspendingEventArgs;
 using winrt::Windows::ApplicationModel::Activation::ApplicationExecutionState;
@@ -73,12 +71,10 @@ void App::OnLaunched(LaunchActivatedEventArgs const &e)
             // Ensure the current window is active
             Window::Current().Activate();
         }
-    } else {
-        if (!e.PrelaunchActivated()) {
-            NavigateToFirstPage(rootFrame, e);
-            // Ensure the current window is active
-            Window::Current().Activate();
-        }
+    } else if (!e.PrelaunchActivated()) {
+        NavigateToFirstPage(rootFrame, e);
+        // Ensure the current window is active
+        Window::Current().Activate();
     }
 }
 
@@ -110,6 +106,6 @@ void App::NavigateToFirstPage(Frame &rootFrame, LaunchActivatedEventArgs const &
         // When the navigation stack isn't restored navigate to the first page,
         // configuring the new page by passing required information as a navigation
         // parameter
-        rootFrame.Navigate(xaml_typename<ReactTestApp::MainPage>(), box_value(e.Arguments()));
+        rootFrame.Navigate(xaml_typename<MainPage>(), box_value(e.Arguments()));
     }
 }

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -166,7 +166,10 @@
         </Page>
     </ItemGroup>
     <ItemGroup>
-        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest">
+        <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" Condition="Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
+            <SubType>Designer</SubType>
+        </AppxManifest>
+        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" Condition="!Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
             <SubType>Designer</SubType>
         </AppxManifest>
     </ItemGroup>

--- a/windows/ReactTestApp/ReactTestApp.vcxproj.filters
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj.filters
@@ -36,6 +36,7 @@
         </Text>
     </ItemGroup>
     <ItemGroup>
+        <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" />
         <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" />
     </ItemGroup>
     <ItemGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,14 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/glob@*":
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
+  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
@@ -1583,6 +1591,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/minimatch@*":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
+  integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
+
 "@types/minimist@^1.2.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
@@ -1629,6 +1642,14 @@
   version "0.12.0"
   resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/rimraf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
### Description

Picks up the `Package.appxmanifest` placed next to the generated `.sln`.

Resolves #224.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

1. Generate the solution:
    ```
    cd example
    yarn
    yarn install-windows-test-app
    start windows/Example.sln
    ```
2. Observe that `Package.appxmanifest` is the same as the one from `react-native-test-app`.
3. Close Visual Studio.
4. Copy `/windows/ReactTestApp/Package.appxmanifest` ito `/example/windows`
5. Modify `/example/windows/Package.appxmanifest`, e.g. change the display name to `Example`
6. Open `app.json` and add the following:
    ```diff
    diff --git a/example/app.json b/example/app.json
    index 8463354..941fa30 100644
    --- a/example/app.json
    +++ b/example/app.json
    @@ -29,5 +29,8 @@
           "dist/assets",
           "dist/main.windows.bundle"
         ]
    +  },
    +  "windows": {
    +    "appxManifest": "windows/Package.appxmanifest"
       }
     }
    ```
7. Regenerate the solution: `yarn install-windows-test-app`
8. Open the new Visual Studio solution
9. Observe that the display name is now `Example`

Docs have been updated to include the new property: https://github.com/microsoft/react-native-test-app/wiki/Manifest-(app.json)#appxmanifest