### PR TITLE
fix(android): configure script cannot find `gradle.properties`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,7 @@ android/app/build/
 android/app/src/androidTest/
 android/app/src/test/
 coverage/
-example/*
+example/**/*
 !example/android/gradle.properties
 !example/metro.config.js
 !example/react-native.config.js

--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,7 @@ android/app/src/androidTest/
 android/app/src/test/
 coverage/
 example/*
+!example/android/gradle.properties
 !example/metro.config.js
 !example/react-native.config.js
 scripts/


### PR DESCRIPTION
### Description

Running `yarn configure-test-app --force` fails because `example/android/gradle.properties` is not shipped.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.