### PR TITLE
fix(android): ensure that RNTA can automatically link gradle scripts

### DIFF
--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -1,3 +1,8 @@
+buildscript {
+    def androidDir = "${buildscript.sourceFile.getParent()}/../"
+    apply from: "$androidDir/dependencies.gradle"
+}
+
 repositories {
     google()
     mavenCentral()

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript { scriptHandler ->
     def androidTestAppDir = "../node_modules/react-native-test-app/android"
     apply from: "$androidTestAppDir/dependencies.gradle"
-    apply from: "$androidTestAppDir/force-resolve-trove4j.gradle", to: scriptHandler
 
     repositories {
         google()

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -33,13 +33,16 @@ private static void apply(Settings settings) {
 }
 
 def scriptDir = buildscript.sourceFile.getParent()
-
 apply from: "$scriptDir/android/test-app-util.gradle"
 
 def cliAndroidDir = findNodeModulesPath(rootDir, "@react-native-community/cli-platform-android")
 apply from: "$cliAndroidDir/native_modules.gradle"
 
 ext.applyTestAppSettings = { DefaultSettings defaultSettings ->
+    buildscript { scriptHandler ->        
+        apply from: "$scriptDir/android/force-resolve-trove4j.gradle", to: scriptHandler
+    }
+
     apply(defaultSettings)
     applyNativeModulesSettingsGradle(defaultSettings)
 }


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

Fluent UI [broke](https://github.com/microsoft/fluentui-react-native/pull/665) when bumping RNTA, because certain scripts were not linked correctly. Instead of expecting the consumer to link required gradle scripts, we can do it automatically when applying the RNTA plugin. This PR does exactly that.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

Automation on CI should be sufficient to pick-up any issues with the build configuration.
