### PR TITLE
chore: address CVE-2021-28965

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,18 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    minitest (5.14.3)
+    minitest (5.14.4)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     rainbow (3.0.0)
-    regexp_parser (2.0.3)
-    rexml (3.2.4)
-    rubocop (1.9.1)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -18,10 +21,10 @@ GEM
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
-    rubocop-minitest (0.10.3)
-      rubocop (>= 0.87, < 2.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-minitest (0.12.1)
+      rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.0.0)
 
@@ -34,4 +37,4 @@ DEPENDENCIES
   rubocop-minitest!
 
 BUNDLED WITH
-   2.2.3
+   2.2.15


### PR DESCRIPTION
### Description

`rexml` is used in build tools only (hence the **chore** designation).

For more details, see https://nvd.nist.gov/vuln/detail/CVE-2021-28965.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.