### PR TITLE
fix(ios): call React Native's post-install script

### DIFF
--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -10,8 +10,15 @@ def include_react_native!(options)
     :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform
   )
 
-  require_relative File.join(project_root, react_native, 'scripts', 'react_native_pods')
+  require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
   use_react_native!(options)
+
+  # In 0.64, `react_native_post_install` should be called instead
+  if defined?(react_native_post_install)
+    return ->(installer) { react_native_post_install(installer) }
+  end
+
+  ->(installer) { flipper_post_install(installer) }
 end


### PR DESCRIPTION
### Description

Resolves #309.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Build Example app for iOS.
2. Run `yarn clean`, followed by `yarn set-react-version 0.62`, and repeat step 1
3. Run `yarn clean`, followed by `yarn set-react-version 0.64`, and repeat step 1
