### PR TITLE
chore: add Gemfile and example/yarn.lock to Dependabot [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: "weekly"
-    versioning-strategy: "lockfile-only"
+      interval: weekly
+    versioning-strategy: increase
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    versioning-strategy: lockfile-only
+  - package-ecosystem: npm
+    directory: "/example"
+    schedule:
+      interval: weekly
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
### Description

Adds more lock files for Dependabot to manage.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

There's nothing to test.