### PR TITLE
chore: pin Flipper-RSocket version to fix iOS nightly builds

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -2,7 +2,11 @@ require_relative '../node_modules/react-native-test-app/test_app'
 
 workspace 'Example.xcworkspace'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!({
+               'Flipper' => '0.75.1',
+               'Flipper-Folly' => '2.5.3',
+               'Flipper-RSocket' => '1.3.1',
+             })
 
 use_test_app! do |target|
   target.tests do

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -300,7 +300,7 @@ PODS:
     - React-jsi (= 0.63.4)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -315,7 +315,7 @@ DEPENDENCIES:
   - Flipper-Folly (= 2.5.3)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
-  - Flipper-RSocket (~> 1.1)
+  - Flipper-RSocket (= 1.3.1)
   - FlipperKit (= 0.75.1)
   - FlipperKit/Core (= 0.75.1)
   - FlipperKit/CppBridge (= 0.75.1)
@@ -477,10 +477,10 @@ SPEC CHECKSUMS:
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2c0dece69907a2f6c7b4245c6fc18a768efbb85d
+PODFILE CHECKSUM: 8c25858b89fe1d79499ef9a7350b4dc1cf0e8913
 
 COCOAPODS: 1.10.1

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.63.3)
-  - FBReactNativeSpec (0.63.3):
+  - FBLazyVector (0.63.33)
+  - FBReactNativeSpec (0.63.33):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.3)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
+    - RCTRequired (= 0.63.33)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -22,235 +22,235 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.3)
-  - RCTTypeSafety (0.63.3):
-    - FBLazyVector (= 0.63.3)
+  - RCTRequired (0.63.33)
+  - RCTTypeSafety (0.63.33):
+    - FBLazyVector (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.3)
-    - React-Core (= 0.63.3)
-  - React (0.63.3):
-    - React-Core (= 0.63.3)
-    - React-Core/DevSupport (= 0.63.3)
-    - React-Core/RCTWebSocket (= 0.63.3)
-    - React-RCTActionSheet (= 0.63.3)
-    - React-RCTAnimation (= 0.63.3)
-    - React-RCTBlob (= 0.63.3)
-    - React-RCTImage (= 0.63.3)
-    - React-RCTLinking (= 0.63.3)
-    - React-RCTNetwork (= 0.63.3)
-    - React-RCTSettings (= 0.63.3)
-    - React-RCTText (= 0.63.3)
-    - React-RCTVibration (= 0.63.3)
-  - React-callinvoker (0.63.3)
-  - React-Core (0.63.3):
+    - RCTRequired (= 0.63.33)
+    - React-Core (= 0.63.33)
+  - React (0.63.33):
+    - React-Core (= 0.63.33)
+    - React-Core/DevSupport (= 0.63.33)
+    - React-Core/RCTWebSocket (= 0.63.33)
+    - React-RCTActionSheet (= 0.63.33)
+    - React-RCTAnimation (= 0.63.33)
+    - React-RCTBlob (= 0.63.33)
+    - React-RCTImage (= 0.63.33)
+    - React-RCTLinking (= 0.63.33)
+    - React-RCTNetwork (= 0.63.33)
+    - React-RCTSettings (= 0.63.33)
+    - React-RCTText (= 0.63.33)
+    - React-RCTVibration (= 0.63.33)
+  - React-callinvoker (0.63.33)
+  - React-Core (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.3)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-Core/Default (= 0.63.33)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.63.3):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
-    - Yoga
-  - React-Core/Default (0.63.3):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
-    - Yoga
-  - React-Core/DevSupport (0.63.3):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.3)
-    - React-Core/RCTWebSocket (= 0.63.3)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
-    - React-jsinspector (= 0.63.3)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.3):
+  - React-Core/CoreModulesHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.3):
+  - React-Core/Default (0.63.33):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
+    - Yoga
+  - React-Core/DevSupport (0.63.33):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.33)
+    - React-Core/RCTWebSocket (= 0.63.33)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
+    - React-jsinspector (= 0.63.33)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.3):
+  - React-Core/RCTAnimationHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.3):
+  - React-Core/RCTBlobHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.3):
+  - React-Core/RCTImageHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.3):
+  - React-Core/RCTLinkingHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.3):
+  - React-Core/RCTNetworkHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.3):
+  - React-Core/RCTSettingsHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.3):
+  - React-Core/RCTTextHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.3):
+  - React-Core/RCTVibrationHeaders (0.63.33):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.3)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-jsiexecutor (= 0.63.3)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
     - Yoga
-  - React-CoreModules (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+  - React-Core/RCTWebSocket (0.63.33):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core/CoreModulesHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-RCTImage (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-cxxreact (0.63.3):
+    - React-Core/Default (= 0.63.33)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-jsiexecutor (= 0.63.33)
+    - Yoga
+  - React-CoreModules (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core/CoreModulesHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-RCTImage (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-cxxreact (0.63.33):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.3)
-    - React-jsinspector (= 0.63.3)
-  - React-jsi (0.63.3):
+    - React-callinvoker (= 0.63.33)
+    - React-jsinspector (= 0.63.33)
+  - React-jsi (0.63.33):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.3)
-  - React-jsi/Default (0.63.3):
+    - React-jsi/Default (= 0.63.33)
+  - React-jsi/Default (0.63.33):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.3):
+  - React-jsiexecutor (0.63.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
-  - React-jsinspector (0.63.3)
-  - React-RCTActionSheet (0.63.3):
-    - React-Core/RCTActionSheetHeaders (= 0.63.3)
-  - React-RCTAnimation (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
+  - React-jsinspector (0.63.33)
+  - React-RCTActionSheet (0.63.33):
+    - React-Core/RCTActionSheetHeaders (= 0.63.33)
+  - React-RCTAnimation (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core/RCTAnimationHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTBlob (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core/RCTAnimationHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTBlob (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.3)
-    - React-Core/RCTWebSocket (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-RCTNetwork (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTImage (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - React-Core/RCTBlobHeaders (= 0.63.33)
+    - React-Core/RCTWebSocket (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-RCTNetwork (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTImage (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core/RCTImageHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - React-RCTNetwork (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTLinking (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
-    - React-Core/RCTLinkingHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTNetwork (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core/RCTImageHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - React-RCTNetwork (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTLinking (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
+    - React-Core/RCTLinkingHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTNetwork (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core/RCTNetworkHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTSettings (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core/RCTNetworkHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTSettings (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.3)
-    - React-Core/RCTSettingsHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - React-RCTText (0.63.3):
-    - React-Core/RCTTextHeaders (= 0.63.3)
-  - React-RCTVibration (0.63.3):
-    - FBReactNativeSpec (= 0.63.3)
+    - RCTTypeSafety (= 0.63.33)
+    - React-Core/RCTSettingsHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - React-RCTText (0.63.33):
+    - React-Core/RCTTextHeaders (= 0.63.33)
+  - React-RCTVibration (0.63.33):
+    - FBReactNativeSpec (= 0.63.33)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.3)
-    - React-jsi (= 0.63.3)
-    - ReactCommon/turbomodule/core (= 0.63.3)
-  - ReactCommon/turbomodule/core (0.63.3):
+    - React-Core/RCTVibrationHeaders (= 0.63.33)
+    - React-jsi (= 0.63.33)
+    - ReactCommon/turbomodule/core (= 0.63.33)
+  - ReactCommon/turbomodule/core (0.63.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.3)
-    - React-Core (= 0.63.3)
-    - React-cxxreact (= 0.63.3)
-    - React-jsi (= 0.63.3)
+    - React-callinvoker (= 0.63.33)
+    - React-Core (= 0.63.33)
+    - React-cxxreact (= 0.63.33)
+    - React-jsi (= 0.63.33)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -358,34 +358,34 @@ SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
   Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
-  FBLazyVector: 657354f6c31b5554f62f2871937b8ecb5bea93d4
-  FBReactNativeSpec: 7f7b78001053c716765e21d1853f60a944772df8
+  FBLazyVector: 462de4c12a5e12deaee114d2341679c6abde70e2
+  FBReactNativeSpec: 8c128e7e95ec6907abcb1497208d81590ccba7e1
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: d2af397cdafc3d82ada5dc6e36dc5449b9a74f60
-  RCTTypeSafety: c7c534b2083faa6541bb4edf0f8ce3c4d295ac35
-  React: 29cb9f65bfb3661de10c6a675b3d1b773dfb72b0
-  React-callinvoker: 91d936bb2cec50e6be70d2cc0482f4417b2b8565
-  React-Core: 9cfcc0496b7174d90ef1d61fe13b7b7302766b0e
-  React-CoreModules: fbacd3f122a170eeac7868f3a6cf10fd314af470
-  React-cxxreact: f368d34ef9f7fec53cccf7a22201df4703107644
-  React-jsi: 53b60b4375dc0958dc0e1e2425f42cca337d0e0a
-  React-jsiexecutor: 41c73eeee7414609c93dcac6459e8cac32028bb4
-  React-jsinspector: 03d991db24519ee346eb782af5af3889ab63c475
-  React-RCTActionSheet: 61d95ef9a9702b5e5e6b35561c5ad2e35417d767
-  React-RCTAnimation: d4cedb42843c617f244a4e6ff39a15b7bc6a6719
-  React-RCTBlob: 4eb8dde7adcb663f78e947c5a83b378ab2ca8ace
-  React-RCTImage: 7e1d7b2551b3e9732a8634d3603170ef35f41674
-  React-RCTLinking: 373dbc3a5bf46ea00e01a225215c0ea2561932d8
-  React-RCTNetwork: 8475096673c04960b34fb5f710763e62fb234457
-  React-RCTSettings: eee67f3bcad299c68471e43abcf3a4e09b5b0659
-  React-RCTText: 0ee45c902f6f2444676be676e26126ce07f20e59
-  React-RCTVibration: 9b2107d5c328a58fb09c2b5be3f6fdee87186493
-  ReactCommon: f5e5ad0ae0ad1a5f38b6d585adab7dcde3e823b2
+  RCTRequired: c08f4fda746d91ad9e6bd6c9b53a4fcf87c04bcc
+  RCTTypeSafety: 2d3a98340d0d16b7dd431934fa965926cd9e1750
+  React: 5a904cbc3c91b17f41d27ed8ea0831065b6e5f10
+  React-callinvoker: bf1f05f128f9fcc20c846c4f4427fb569ba9578e
+  React-Core: 38b52c7415df64f883228d59e7f33c6d5b758126
+  React-CoreModules: 0b712a87a64c92c7d57768205571b65890bf4f1f
+  React-cxxreact: 7c93e59c19512130046b175c40939178b86d9308
+  React-jsi: 0ee08b248b68c950a84df740c8bd4835e5f863ff
+  React-jsiexecutor: 34d44a917be4583dc04d0715fbb73d988761a68b
+  React-jsinspector: d4bbf569451953b6dd7d4672aff697ae52fae510
+  React-RCTActionSheet: d0af02a1b84e1df8983c498eebce57ef17848ecf
+  React-RCTAnimation: cd443d8ddb0e404791a8bd05e34847ef3d600855
+  React-RCTBlob: 7991cf31f48ad925ee40439ffab8709fa0e23b74
+  React-RCTImage: 5c8beafbdeca4c7b4d64a0b965e1e104dc9adb5e
+  React-RCTLinking: f7fea934f0e728635bbbb3ff5c4ab4c0be1fd577
+  React-RCTNetwork: 18ccad8e2e320dffb3962faf59783e0f3c49bd40
+  React-RCTSettings: c42c7924082f8186ee910337cf15b46321445583
+  React-RCTText: ce757496be5df6397a3e493b9e869059a3680982
+  React-RCTVibration: e83a69cd0cdbc5a560ddc373a893675503a6558a
+  ReactCommon: da0330d5196a7d9c7adc3d2d371fcb1b0930ba6b
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
-  Yoga: cce07989d1dce536d190bf212ffff89ad7003f42
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
+  Yoga: ce9a881f81d3176fe76d841426d9654b8b629f18
 
 PODFILE CHECKSUM: 3c90d49455189425443ac97fd0ecb40d4f3b6b78
 


### PR DESCRIPTION
### Description

iOS nightly builds are failing due to `Flipper-RSocket` being resolved to a version that depends on a newer version of `Flipper-Folly`:

```
[!] CocoaPods could not find compatible versions for pod "Flipper-Folly":
  In snapshot (Podfile.lock):
    Flipper-Folly (= 2.5.3, ~> 2.5)

  In Podfile:
    Flipper-Folly (= 2.5.3)

    Flipper-RSocket (= 1.4.3) was resolved to 1.4.3, which depends on
      Flipper-Folly (~> 2.6)

    FlipperKit/FlipperKitLayoutPlugin (= 0.75.1) was resolved to 0.75.1, which depends on
      FlipperKit/Core (= 0.75.1) was resolved to 0.75.1, which depends on
        Flipper (~> 0.75.1) was resolved to 0.75.1, which depends on
          Flipper-Folly (~> 2.5)
Error: Process completed with exit code 1.
```

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.