### PR TITLE
fix(windows): JavaScriptMainModuleName is deprecated

### DIFF
--- a/example/metro.config.windows.js
+++ b/example/metro.config.windows.js
@@ -6,7 +6,15 @@
  */
 const fs = require("fs");
 const path = require("path");
-const blacklist = require("metro-config/src/defaults/blacklist");
+
+const exclusionList = (() => {
+  try {
+    return require("metro-config/src/defaults/exclusionList");
+  } catch (_) {
+    // `blacklist` was renamed to `exclusionList` in 0.60
+    return require("metro-config/src/defaults/blacklist");
+  }
+})();
 
 const rnPath = fs.realpathSync(
   path.resolve(require.resolve("react-native/package.json"))
@@ -15,6 +23,20 @@ const rnwPath = fs.realpathSync(
   path.resolve(require.resolve("react-native-windows/package.json"))
 );
 
+const blockList = exclusionList([
+  // Since there are multiple copies of react-native, we need to ensure that
+  // Metro only sees one of them. This should go when haste-map is removed.
+  new RegExp(`${(path.resolve(rnPath) + path.sep).replace(/[/\\]/g, "/")}.*`),
+
+  // This stops "react-native run-windows" from causing the metro server to
+  // crash if its already running
+  new RegExp(`${path.resolve(__dirname, "windows").replace(/[/\\]/g, "/")}.*`),
+
+  // Workaround for `EBUSY: resource busy or locked, open
+  // '~\msbuild.ProjectImports.zip'` when building with `yarn windows --release`
+  /.*\.ProjectImports\.zip/,
+]);
+
 module.exports = {
   resolver: {
     extraNodeModules: {
@@ -22,24 +44,9 @@ module.exports = {
       "react-native": rnwPath,
       "react-native-windows": rnwPath,
     },
-    // Include the macos platform in addition to the defaults because the fork includes macos, but doesn't declare it
-    platforms: ["ios", "android", "windesktop", "windows", "web", "macos"],
-    // Since there are multiple copies of react-native, we need to ensure that metro only sees one of them
-    // This should go in RN 0.61 when haste is removed
-    blacklistRE: blacklist([
-      new RegExp(
-        `${(path.resolve(rnPath) + path.sep).replace(/[/\\]/g, "/")}.*`
-      ),
-
-      // This stops "react-native run-windows" from causing the metro server to crash if its already running
-      new RegExp(
-        `${path.resolve(__dirname, "windows").replace(/[/\\]/g, "/")}.*`
-      ),
-
-      // Workaround for `EBUSY: resource busy or locked, open '~\msbuild.ProjectImports.zip'`
-      // when building with `yarn windows --release`
-      /.*\.ProjectImports\.zip/,
-    ]),
+    platforms: ["windesktop", "windows"],
+    blacklistRE: blockList,
+    blockList,
   },
   transformer: {
     getTransformOptions: async () => ({

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -91,8 +91,12 @@ void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
     auto instanceSettings = reactNativeHost_.InstanceSettings();
     switch (source) {
         case JSBundleSource::DevServer:
+#if REACT_NATIVE_VERSION < 6400
             instanceSettings.JavaScriptMainModuleName(L"index");
             instanceSettings.JavaScriptBundleFile(L"");
+#else
+            instanceSettings.JavaScriptBundleFile(L"index");
+#endif
             break;
         case JSBundleSource::Embedded:
             instanceSettings.JavaScriptBundleFile(winrt::to_hstring(GetBundleName()));


### PR DESCRIPTION
### Description

`JavaScriptMainModuleName` was deprecated in 0.64, and removed in https://github.com/microsoft/react-native-windows/commit/22e1206ce28eb55e75af5e7740ef8bb8ad25e183.

Caught with Windows nightly builds: https://github.com/microsoft/react-native-test-app/runs/2855115978?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```sh
yarn clean
yarn set-react-version 0.64
cd example
yarn
yarn build:windows
yarn install-windows-test-app --use-nuget
start windows/Example.sln
yarn start:windows
```

Build and run the test app. You should be able to switch between embedded and dev server.