### PR TITLE
fix(windows): crash when no JS bundle is found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,8 +251,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          script: cd android/ && ./gradlew clean build connectedCheck
-          arch: x86_64
+          working-directory: android
+          script: ./gradlew clean build connectedCheck
   android-template:
     name: "Android [template]"
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
     name: "Android"
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-11, windows-latest]
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'schedule' && !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
@@ -237,17 +237,17 @@ jobs:
         shell: bash
         working-directory: example
       - name: Cache /.yarn-offline-mirror
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-11' }}
         uses: actions/cache@v2
         with:
           path: .yarn-offline-mirror
           key: ${{ hashFiles('yarn.lock') }}
       - name: Install /
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-11' }}
         run: |
           yarn ci
       - name: Run instrumented tests
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-11' }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29

--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -155,18 +155,18 @@ IAsyncAction MainPage::LoadFromDevServer(IInspectable const &, RoutedEventArgs)
 void MainPage::LoadFromJSBundle(IInspectable const &, RoutedEventArgs)
 {
     if (!LoadJSBundleFrom(JSBundleSource::Embedded)) {
-        std::string message{
-            "No JavaScript bundle with one of the following names was found in the app:\n\n"};
+        std::wstring message{
+            L"No JavaScript bundle with one of the following names was found in the app:\n\n"};
         for (auto &&name : ::ReactTestApp::JSBundleNames) {
-            message += "    • " + name + ".bundle\n";
+            message += L"    \u2022 " + name + L".bundle\n";
         }
         message +=
-            "\nPlease make sure the bundle has been built, is appropriately named, and that it has "
-            "been added to 'app.json'. You may have to run 'install-windows-test-app' again to "
-            "update the project files.\n"
-            "\n"
-            "If you meant to use a development server, please make sure it is running.";
-        MessageDialog(winrt::to_hstring(message)).ShowAsync();
+            L"\nPlease make sure the bundle has been built, is appropriately named, and that it "
+            L"has been added to 'app.json'. You may have to run 'install-windows-test-app' again "
+            L"to update the project files.\n"
+            L"\n"
+            L"If you meant to use a development server, please make sure it is running.";
+        MessageDialog(message).ShowAsync();
     }
 }
 

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -24,8 +24,8 @@ namespace winrt::ReactTestApp::implementation
 
         // React menu
 
-        void LoadFromDevServer(Windows::Foundation::IInspectable const &,
-                               Windows::UI::Xaml::RoutedEventArgs);
+        Windows::Foundation::IAsyncAction LoadFromDevServer(
+            Windows::Foundation::IInspectable const &, Windows::UI::Xaml::RoutedEventArgs);
         void LoadFromJSBundle(Windows::Foundation::IInspectable const &,
                               Windows::UI::Xaml::RoutedEventArgs);
         void ToggleRememberLastComponent(Windows::Foundation::IInspectable const &,

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -58,7 +58,7 @@ namespace winrt::ReactTestApp::implementation
         void InitializeReactMenu();
         void InitializeTitleBar();
 
-        void LoadJSBundleFrom(::ReactTestApp::JSBundleSource);
+        bool LoadJSBundleFrom(::ReactTestApp::JSBundleSource);
         void LoadReactComponent(::ReactTestApp::Component const &);
 
         void OnCoreTitleBarLayoutMetricsChanged(

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -77,6 +77,15 @@ namespace
     winrt::Microsoft::ReactNative::ReactContext DevSettings::context_ = nullptr;
 }  // namespace
 
+const std::vector<std::string> ReactTestApp::JSBundleNames = {
+    "index.windows",
+    "main.windows",
+    "index.native",
+    "main.native",
+    "index",
+    "main",
+};
+
 ReactInstance::ReactInstance()
 {
     reactNativeHost_.PackageProviders().Append(winrt::make<ReactPackageProvider>());
@@ -84,7 +93,7 @@ ReactInstance::ReactInstance()
         reactNativeHost_.PackageProviders());
 }
 
-void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
+bool ReactInstance::LoadJSBundleFrom(JSBundleSource source)
 {
     source_ = source;
 
@@ -99,11 +108,16 @@ void ReactInstance::LoadJSBundleFrom(JSBundleSource source)
 #endif
             break;
         case JSBundleSource::Embedded:
-            instanceSettings.JavaScriptBundleFile(winrt::to_hstring(GetBundleName()));
+            const auto bundleName = GetBundleName();
+            if (!bundleName.has_value()) {
+                return false;
+            }
+            instanceSettings.JavaScriptBundleFile(winrt::to_hstring(bundleName.value()));
             break;
     }
 
     Reload();
+    return true;
 }
 
 void ReactInstance::Reload()
@@ -184,23 +198,15 @@ void ReactInstance::UseWebDebugger(bool useWebDebugger)
     Reload();
 }
 
-std::string ReactTestApp::GetBundleName()
+std::optional<std::string> ReactTestApp::GetBundleName()
 {
-    auto entryFileNames = {"index.windows",
-                           "main.windows",
-                           "index.native",
-                           "main.native",
-                           "index"
-                           "main"};
-
-    for (std::string main : entryFileNames) {
-        std::string path = "Bundle\\" + main + ".bundle";
-        if (std::filesystem::exists(path)) {
+    for (auto &&main : JSBundleNames) {
+        if (std::filesystem::exists("Bundle\\" + main + ".bundle")) {
             return main;
         }
     }
 
-    return "";
+    return std::nullopt;
 }
 
 IAsyncOperation<bool> ReactTestApp::IsDevServerRunning()

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -77,7 +77,7 @@ namespace
     winrt::Microsoft::ReactNative::ReactContext DevSettings::context_ = nullptr;
 }  // namespace
 
-const std::vector<std::string> ReactTestApp::JSBundleNames = {
+std::vector<std::string> const ReactTestApp::JSBundleNames = {
     "index.windows",
     "main.windows",
     "index.native",
@@ -108,7 +108,7 @@ bool ReactInstance::LoadJSBundleFrom(JSBundleSource source)
 #endif
             break;
         case JSBundleSource::Embedded:
-            const auto bundleName = GetBundleName();
+            auto const bundleName = GetBundleName();
             if (!bundleName.has_value()) {
                 return false;
             }

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -77,13 +77,13 @@ namespace
     winrt::Microsoft::ReactNative::ReactContext DevSettings::context_ = nullptr;
 }  // namespace
 
-std::vector<std::string> const ReactTestApp::JSBundleNames = {
-    "index.windows",
-    "main.windows",
-    "index.native",
-    "main.native",
-    "index",
-    "main",
+std::vector<std::wstring> const ReactTestApp::JSBundleNames = {
+    L"index.windows",
+    L"main.windows",
+    L"index.native",
+    L"main.native",
+    L"index",
+    L"main",
 };
 
 ReactInstance::ReactInstance()
@@ -112,7 +112,7 @@ bool ReactInstance::LoadJSBundleFrom(JSBundleSource source)
             if (!bundleName.has_value()) {
                 return false;
             }
-            instanceSettings.JavaScriptBundleFile(winrt::to_hstring(bundleName.value()));
+            instanceSettings.JavaScriptBundleFile(bundleName.value());
             break;
     }
 
@@ -198,10 +198,10 @@ void ReactInstance::UseWebDebugger(bool useWebDebugger)
     Reload();
 }
 
-std::optional<std::string> ReactTestApp::GetBundleName()
+std::optional<std::wstring> ReactTestApp::GetBundleName()
 {
     for (auto &&main : JSBundleNames) {
-        if (std::filesystem::exists("Bundle\\" + main + ".bundle")) {
+        if (std::filesystem::exists(L"Bundle\\" + main + L".bundle")) {
             return main;
         }
     }

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -16,7 +16,7 @@
 
 namespace ReactTestApp
 {
-    extern const std::vector<std::string> JSBundleNames;
+    extern std::vector<std::string> const JSBundleNames;
 
     enum class JSBundleSource {
         DevServer,

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -7,13 +7,17 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.h>
 
 namespace ReactTestApp
 {
+    extern const std::vector<std::string> JSBundleNames;
+
     enum class JSBundleSource {
         DevServer,
         Embedded,
@@ -29,7 +33,7 @@ namespace ReactTestApp
             return reactNativeHost_;
         }
 
-        void LoadJSBundleFrom(JSBundleSource);
+        bool LoadJSBundleFrom(JSBundleSource);
         void Reload();
 
         bool BreakOnFirstLine() const;
@@ -63,7 +67,7 @@ namespace ReactTestApp
         JSBundleSource source_ = JSBundleSource::DevServer;
     };
 
-    std::string GetBundleName();
+    std::optional<std::string> GetBundleName();
     winrt::Windows::Foundation::IAsyncOperation<bool> IsDevServerRunning();
 
 }  // namespace ReactTestApp

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -16,7 +16,7 @@
 
 namespace ReactTestApp
 {
-    extern std::vector<std::string> const JSBundleNames;
+    extern std::vector<std::wstring> const JSBundleNames;
 
     enum class JSBundleSource {
         DevServer,
@@ -67,7 +67,7 @@ namespace ReactTestApp
         JSBundleSource source_ = JSBundleSource::DevServer;
     };
 
-    std::optional<std::string> GetBundleName();
+    std::optional<std::wstring> GetBundleName();
     winrt::Windows::Foundation::IAsyncOperation<bool> IsDevServerRunning();
 
 }  // namespace ReactTestApp


### PR DESCRIPTION
### Description

Windows test app crashes when trying to load a JS bundle that doesn't exist.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```sh
cd example
yarn
yarn install-windows-test-app --use-nuget
start windows/Example.sln
yarn start:windows
```

When the test app is loaded, try switching to embedded JS bundle.

![Screenshot 2021-06-18 201327](https://user-images.githubusercontent.com/4123478/122601811-2a551400-d072-11eb-9e93-11c294c5eca3.png)
