### PR TITLE
fix(windows): auto-link step fails when running 'install-windows-test-app'

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -10,7 +10,7 @@ if (
     project: {
       windows: {
         sourceDir,
-        solutionFile: path.join(sourceDir, "Example.sln"),
+        solutionFile: "Example.sln",
         project: {
           projectFile: path.relative(
             path.join(__dirname, sourceDir),

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -232,7 +232,7 @@ function reactNativeConfig({ name, testAppPath, platforms, flatten }) {
           "  project: {",
           "    windows: {",
           "      sourceDir,",
-          `      solutionFile: path.join(sourceDir, "${name}.sln"),`,
+          `      solutionFile: "${name}.sln",`,
           "      project: {",
           "        projectFile: path.relative(",
           "          path.join(__dirname, sourceDir),",


### PR DESCRIPTION
### Description

Latest Windows nightly build has revealed a bug in `react-native.config.js`: https://github.com/microsoft/react-native-test-app/runs/2863315020?check_suite_focus=true

```
$ yarn install-windows-test-app --use-nuget
yarn run v1.22.5
$ ~\example\node_modules\.bin\install-windows-test-app --use-nuget
warning: resource with path 'dist/assets' was not found
warning: resource with path 'dist/main.windows.bundle' was not found
 × Auto-linking...
Error: Error: ENOENT: no such file or directory, open '~\example\windows\windows\Example.sln'. (317ms)
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

CI should pass.