### PR TITLE
fix(windows): prevent cli from autolinking react-native-test-app

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -102,4 +102,9 @@ module.exports = {
       ],
     },
   ],
+  dependency: {
+    platforms: {
+      windows: null,
+    },
+  },
 };


### PR DESCRIPTION
### Description

Due to a recent change in [`@react-native-windows/cli`](https://github.com/microsoft/react-native-windows/commit/11a322b373c28d0e73dde83550dc42cee1352457), `react-native-test-app` is now considered a native module and autolinked.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```sh
yarn set-react-version canary-windows
cd example
yarn
yarn install-windows-test-app --use-nuget
cd windows
nuget restore
```

`nuget restore` should succeed without any errors.