### PR TITLE
ci: cache Gradle dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
           set -eo pipefail
           yarn build:android || yarn build:android
           pushd android 1> /dev/null
-          ./gradlew clean build check test
+          ./gradlew --gradle-user-home .gradle clean build check test
         shell: bash
         working-directory: example
       - name: Cache /.yarn-offline-mirror
@@ -253,6 +253,11 @@ jobs:
           api-level: 29
           script: cd android/ && ./gradlew clean build connectedCheck
           arch: x86_64
+      - name: Clean Gradle cache
+        run: |
+          GRADLE_USER_HOME=.gradle ../../scripts/gradle-clean-cache.sh
+        shell: bash
+        working-directory: example/android
   android-template:
     name: "Android [template]"
     strategy:

--- a/scripts/gradle-clean-cache.sh
+++ b/scripts/gradle-clean-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+GRADLE_USER_HOME=${GRADLE_USER_HOME:-~/.gradle}
+
+if [[ ! $CI ]]; then
+  echo "This script is only meant to be used on CI"
+  exit 0
+fi
+
+./gradlew clean cleanBuildCache
+./gradlew --quiet --stop
+npx --quiet rimraf $GRADLE_USER_HOME/caches/transforms*/
+npx --quiet rimraf $GRADLE_USER_HOME/wrapper/dists/gradle-*-all/*/gradle-*/
+du -hs $GRADLE_USER_HOME/caches $GRADLE_USER_HOME/wrapper


### PR DESCRIPTION
### Description

`./gradlew androidDependencies` often fails with network errors. Cache downloaded dependencies to help mitigate network issues.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.