### PR TITLE
ci: 'trunk' fits better with the tree analogy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - trunk
   pull_request:
   schedule:
     # nightly builds against react-native@nightly at 4:00

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:c": "clang-format -i $(git ls-files '*.cpp' '*.h' '*.m' '*.mm')",
     "format:js": "prettier --write $(git ls-files '*.js' '*.yml' 'test/**/*.json')",
     "format:swift": "swiftformat --swiftversion 5.3 ios macos",
-    "lint:commit": "git log --format='%s' origin/master..HEAD | tail -1 | commitlint",
+    "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | commitlint",
     "lint:js": "eslint $(git ls-files '*.js')",
     "lint:kt": "ktlint --relative --verbose 'android/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
@@ -149,6 +149,7 @@
     ]
   },
   "release": {
+    "branches": ["trunk"],
     "tagFormat": "${version}"
   }
 }


### PR DESCRIPTION
### Description

Default branch was renamed to `trunk`. Mostly because it fits better with the tree analogy.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.