### PR TITLE
feat(android): bump appcompat and remove onActivityResult

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,8 +122,8 @@ dependencies {
     }
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.core:core-ktx:1.3.2"
+    implementation "androidx.appcompat:appcompat:1.3.0"
+    implementation "androidx.core:core-ktx:1.5.0"
     implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "com.google.android.material:material:1.3.0"

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -86,14 +86,6 @@ class ComponentActivity : ReactActivity() {
         return super.getSystemService(name)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        supportFragmentManager.fragments.forEach {
-            it.onActivityResult(requestCode, resultCode, data)
-        }
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (android.R.id.home == item.itemId) {
             onBackPressed()


### PR DESCRIPTION
### Description

- Removes deprecated onActivityResult from ComponentActivity
- androidx.appcompat:appcompat v1.2.0 -> v1.3.0
- androidx.core:core-ktx v1.3.2 -> v1.5.0

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows