### PR TITLE
fix(android): init fails because of missing Gradle wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,10 @@ jobs:
       - name: Install
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
+      - name: Init test app
+        run: |
+          yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
+        working-directory: template-example
       - name: Build
         run: |
           set -eo pipefail
@@ -293,6 +297,11 @@ jobs:
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
         shell: bash
+      - name: Init test app
+        run: |
+          yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
+        shell: bash
+        working-directory: template-example
       - name: Build
         run: |
           set -eo pipefail
@@ -376,6 +385,10 @@ jobs:
       - name: Install
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
+      - name: Init test app
+        run: |
+          yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
+        working-directory: template-example
       - name: Build
         run: |
           set -eo pipefail
@@ -476,6 +489,11 @@ jobs:
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
         shell: bash
+      - name: Init test app
+        run: |
+          yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
+        shell: bash
+        working-directory: template-example
       - name: Build bundle and create solution
         run: |
           yarn build:windows

--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,8 @@ android/app/src/test/
 coverage/
 example/**/*
 !example/android/gradle.properties
+!example/android/gradle/wrapper/*
+!example/android/gradlew*
 !example/metro.config.js
 !example/react-native.config.js
 scripts/


### PR DESCRIPTION
### Description

We recently switched to using our own wrappers but neglected to include them in the published packages.

Resolves #367

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI has been updated to run `init-test-app`.