### PR TITLE
fix(android): crash on startup due to Android API being on 30

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
     ]
 
     sdk = [
-        version          : 30,
+        version          : 29,
         minVersion       : 21,
         buildToolsVersion: "30.0.3"
     ]


### PR DESCRIPTION
### Description

```
Caused by: java.lang.IllegalStateException: Expected Android API level 21+ but was 30
   at okhttp3.internal.platform.AndroidPlatform.buildIfSupported(AndroidPlatform.java:238)
   at okhttp3.internal.platform.Platform.findPlatform(Platform.java:202)
   at okhttp3.internal.platform.Platform.<clinit>(Platform.java:79)
   ...
```

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.