### PR TITLE
fix(windows): add flag for enabling Hermes

### DIFF
--- a/example/windows/.gitignore
+++ b/example/windows/.gitignore
@@ -25,4 +25,5 @@ packages/
 
 **/Generated Files/**
 *.sln
+ExperimentalFeatures.props
 NuGet.Config

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -17,6 +17,7 @@ describe("generateSolution", () => {
 
   const options = {
     autolink: false,
+    useHermes: false,
     useNuGet: false,
   };
 

--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
+    <!--
+      Enables default usage of Hermes.
+
+      See https://microsoft.github.io/react-native-windows/docs/hermes
+    -->
+    <UseHermes>false</UseHermes>
+
+    <!--
+      Changes compilation to assume use of WinUI 3 instead of System XAML.
+      Requires creation of new project.
+
+      See https://microsoft.github.io/react-native-windows/docs/winui3
+    -->
+    <UseWinUI3>false</UseWinUI3>
+  </PropertyGroup>
+</Project>

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(SolutionDir)ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)ExperimentalFeatures.props')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
     <PropertyGroup Label="Globals">
         <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -25,7 +26,7 @@
         <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
         <ReactTestAppDir Condition="'$(ReactTestAppDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows\ReactTestApp\</ReactTestAppDir>
         <UseExperimentalNuget>false</UseExperimentalNuget>
-        <WinUI2xVersion>2.5.0</WinUI2xVersion>
+        <WinUI2xVersionDisabled />
     </PropertyGroup>
     <ItemGroup Label="ProjectConfigurations">
         <ProjectConfiguration Include="Debug|ARM">
@@ -242,6 +243,7 @@
         <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
         <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets')" />
         <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets')" />
+        <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)' == 'true'" />
         <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
         <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
     </ImportGroup>

--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" />
-  <package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" />
-  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
+  <!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" / -->
+  <!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" / -->
+  <!-- package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" / -->
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
+  <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native" / -->
   <package id="nlohmann.json" version="3.9.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
### Description

Let users opt-in to using Hermes JS engine on Windows.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
yarn set-react-version 0.64
cd example
yarn
yarn install-windows-test-app --use-hermes
start windows/Example.sln
yarn start
```

![Windows+Hermes](https://user-images.githubusercontent.com/4123478/123537957-897ded00-d732-11eb-925f-d1254c1b022e.png)
