### PR TITLE
fix: `yarn ios` fails in a flattened project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Install
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
-      - name: Init test app
+      - name: react-native init-test-app
         run: |
           yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
         working-directory: template-example
@@ -196,6 +196,10 @@ jobs:
             pod install --project-directory=ios
             ../scripts/xcodebuild.sh ios/TemplateExample.xcworkspace build
           fi
+        working-directory: template-example
+      - name: react-native run-ios
+        run: |
+          ../test/react-native.js run-ios
         working-directory: template-example
   android:
     name: "Android"
@@ -297,7 +301,7 @@ jobs:
         run: |
           scripts/install-test-template.sh ${{ matrix.template }}
         shell: bash
-      - name: Init test app
+      - name: react-native init-test-app
         run: |
           yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ matrix.template }}
         shell: bash
@@ -309,6 +313,10 @@ jobs:
           [[ -d android ]] && pushd android 1> /dev/null
           ./gradlew clean build check test
         shell: bash
+        working-directory: template-example
+      - name: react-native run-android
+        run: |
+          ../test/react-native.js run-android
         working-directory: template-example
   macos:
     name: "macOS"

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -304,7 +304,8 @@ const getConfig = (() => {
       typeof configuration === "undefined" ||
       "JEST_WORKER_ID" in process.env // skip caching when testing
     ) {
-      const { name, testAppPath, init } = params;
+      const { name, testAppPath, flatten, init } = params;
+      const projectPathFlag = flatten ? " --project-path ." : "";
       const testAppRelPath = projectRelativePath(params);
       const templateDir = path.relative(
         process.cwd(),
@@ -470,7 +471,7 @@ const getConfig = (() => {
           scripts: {
             "build:ios":
               "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
-            ios: "react-native run-ios",
+            ios: `react-native run-ios${projectPathFlag}`,
           },
           dependencies: {},
           getDependencies: () => ({}),
@@ -495,7 +496,7 @@ const getConfig = (() => {
           scripts: {
             "build:macos":
               "mkdirp dist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
-            macos: `react-native run-macos --scheme ${name}`,
+            macos: `react-native run-macos --scheme ${name}${projectPathFlag}`,
           },
           dependencies: {},
           getDependencies: ({ targetVersion }) => {
@@ -542,11 +543,11 @@ function gatherConfig(params) {
   const { flatten, platforms } = params;
   const config = (() => {
     const shouldFlatten = platforms.length === 1 && flatten;
-
+    const options = { ...params, flatten: shouldFlatten };
     return platforms.reduce(
       (config, platform) => {
         const { getDependencies, ...platformConfig } = getConfig(
-          params,
+          options,
           platform
         );
 

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -38,7 +38,7 @@ use_test_app!
   ],
   "scripts": Object {
     "build:ios": "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
-    "ios": "react-native run-ios",
+    "ios": "react-native run-ios --project-path .",
     "start": "react-native start",
   },
 }

--- a/test/react-native.js
+++ b/test/react-native.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// @ts-check
+
+const { spawnSync } = require("child_process");
+
+const DEVICE_ID = "T-800";
+
+/**
+ * Runs the specified command.
+ * @param {string} successString The string to look for
+ * @param  {...any} args The command to run and its arguments
+ */
+function run(successString, ...args) {
+  const { stderr } = spawnSync("yarn", args, { encoding: "utf-8" });
+  if (!stderr.includes(successString)) {
+    throw new Error(stderr);
+  }
+}
+
+function runAndroid() {
+  // If `@react-native-community/cli` reaches the point where it is looking for
+  // a device, we can assume that it has successfully created a config and
+  // determined that there is an Android project that can be built and launched.
+  const success = "No Android device or emulator connected.";
+  run(success, "android", "--deviceId", DEVICE_ID, "--no-packager");
+}
+
+function runIOS() {
+  // If `@react-native-community/cli` reaches the point where it is looking for
+  // a device, we can assume that it has successfully created a config and
+  // determined that there is an iOS project that can be built and launched.
+  const success = `Could not find a device named: "${DEVICE_ID}"`;
+  run(success, "ios", "--device", DEVICE_ID, "--no-packager");
+}
+
+function runMacOS() {
+  throw new Error("Function not implemented.");
+}
+
+function runWindows() {
+  throw new Error("Function not implemented.");
+}
+
+const { [2]: command } = process.argv;
+switch (command) {
+  case "run-android":
+    runAndroid();
+    break;
+
+  case "run-ios":
+    runIOS();
+    break;
+
+  case "run-macos":
+    runMacOS();
+    break;
+
+  case "run-windows":
+    runWindows();
+    break;
+
+  default:
+    throw new Error(`Unknown command: ${command}`);
+}


### PR DESCRIPTION
### Description

Invoke `run-android` and `run-ios` on CI to ensure that they work.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.