### PR TITLE
chore: react-native is renaming its default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           # https://github.com/facebook/react-native/issues/30036 and
           # https://github.com/microsoft/react-native-macos/issues/620 for more
           # details.
-          yarn set-react-version master
+          yarn set-react-version main
       - name: Install
         run: |
           yarn ci

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -50,9 +50,9 @@ const profiles = {
     "react-native-macos": undefined,
     "react-native-windows": "canary",
   },
-  master: {
+  main: {
     react: "17.0.2",
-    "react-native": "facebook/react-native#master",
+    "react-native": "facebook/react-native",
     "react-native-macos": undefined,
     "react-native-windows": undefined,
   },


### PR DESCRIPTION
### Description

facebook/react-native is renaming its default branch to `main`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Nothing to test.