### PR TITLE
fix(windows): fix RedBox not appearing on error

### DIFF
--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -133,6 +133,12 @@ void ReactInstance::Reload()
 
     instanceSettings.EnableDeveloperMenu(!kUseCustomDeveloperMenu);
 
+#ifdef _DEBUG
+    instanceSettings.UseDeveloperSupport(true);
+#else
+    instanceSettings.UseDeveloperSupport(false);
+#endif
+
     reactNativeHost_.ReloadInstance();
 }
 


### PR DESCRIPTION
### Description

When encountering an error, a RedBox should be appearing but does not. Metro logs are also missing the error messages.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

| Before | After |
|:--:|:--:|
| ![image](https://user-images.githubusercontent.com/4123478/124979983-1af33600-e034-11eb-8110-778ba61e1e95.png) | ![image](https://user-images.githubusercontent.com/4123478/124979939-0a42c000-e034-11eb-8abf-722831174ff2.png) |