### PR TITLE
feat(android): support starting activities

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -7,6 +7,8 @@
 
 package com.microsoft.reacttestapp
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.widget.TextView
@@ -48,8 +50,21 @@ class MainActivity : ReactActivity() {
                     .show(supportFragmentManager, ComponentBottomSheetDialogFragment.TAG)
             }
             else -> {
-                startActivity(ComponentActivity.newIntent(this, component))
+                findActivityClass(component.name)?.let {
+                    startActivity(Intent(this, it))
+                } ?: startActivity(ComponentActivity.newIntent(this, component))
             }
+        }
+    }
+
+    private fun findActivityClass(name: String): Class<*>? {
+        return try {
+            val result = Class.forName(name)
+            val isActivity = Activity::class.java.isAssignableFrom(result)
+
+            return if (isActivity) result else null
+        } catch (e: ClassNotFoundException) {
+            null
         }
     }
 


### PR DESCRIPTION
### Description

Up to now, RNTA has supported only Fragments as native components. This PR enables support for Activities as well.

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Manual validation and CI.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
