### PR TITLE
ci: only run yarn-lock-changes on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,10 +110,12 @@ jobs:
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
       - name: /yarn.lock changes
+        if: ${{ github.event_name == 'pull_request' }}
         uses: Simek/yarn-lock-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: /example/yarn.lock changes
+        if: ${{ github.event_name == 'pull_request' }}
         uses: Simek/yarn-lock-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

... otherwise it will blow up.

```
Run Simek/yarn-lock-changes@main
  with:
    token: ***
    collapsibleThreshold: 25
    failOnDowngrade: false
    path: yarn.lock
    updateComment: true
Error: 💥 Cannot find the PR, aborting!
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Nothing to test.