### PR TITLE
ci: work around Android emulator time-out issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
           working-directory: android
           script: ./gradlew clean build connectedCheck
   android-template:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
+          target: google_apis # https://github.com/ReactiveCircus/android-emulator-runner/issues/168
           working-directory: android
           script: ./gradlew clean build connectedCheck
   android-template:


### PR DESCRIPTION
### Description

`android-emulator-runner` is timing out on CI. For some reason, switching to `google_apis` works.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Android CI job running instrumented tests should pass.