### PR TITLE
ci: disable `yarn-lock-changes` due to reduced permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,14 @@ jobs:
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
       - name: /yarn.lock changes
-        if: ${{ github.event_name == 'pull_request' }}
+        # Disabled until this issue is resolved: https://github.com/Simek/yarn-lock-changes/issues/26
+        if: ${{ github.event_name == 'disabled' }}
         uses: Simek/yarn-lock-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: /example/yarn.lock changes
-        if: ${{ github.event_name == 'pull_request' }}
+        # Disabled until this issue is resolved: https://github.com/Simek/yarn-lock-changes/issues/26
+        if: ${{ github.event_name == 'disabled' }}
         uses: Simek/yarn-lock-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Dependabot PRs are now running with [reduced permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), making `yarn-lock-changes` fail.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Nothing to test.