### PR TITLE
chore: use GitHub's form schema for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: "Bug report \U0001F41B"
+description: File a bug report
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen? Can you attach build logs? Can you attach screenshots?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of `react-native-test-app` are you using?
+      placeholder: "Example: 0.7.0"
+    validations:
+      required: true
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: What platforms are you seeing this issue on?
+      description: "Select all that apply:"
+      options:
+        - label: Android
+        - label: iOS
+        - label: macOS
+        - label: Windows
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Information
+      placeholder: Run `npx react-native info` and paste the output here.
+      render: true
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Tell us how to reproduce this issue, or provide a minimal demo where your issue can be easily reproduced.
+      placeholder: Tell us how to reproduce this issue.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/microsoft/react-native-test-app/blob/trunk/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: "Feature request \U0001F4A1"
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Provide a clear and concise description of your motivation for this proposal (e.g. \"I'm always frustrated when…\"), and what you want to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Provide a clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation Details
+      description: Provide a clear and concise description of how you think this could be implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/microsoft/react-native-test-app/blob/trunk/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
### Description

Adds [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) for a more streamlined issue creation experience.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

The best way to preview them is to view the file:
![image](https://user-images.githubusercontent.com/4123478/126215517-593f756e-0e8a-4917-a756-8dd79c347f5b.png)
