### PR TITLE
fix(macos): `react-native-macos` canary breaks `pod install`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,7 @@
   - ios/ReactTestApp/ReactTestApp-Bridging-Header.h
   - ios/ReactTestApp/Session.swift
   - ios/ReactTestApp/UIViewController+ReactTestApp.{h,m}
+  - ios/use_react_native-*.rb
   - macos/**/*
 "platform: Windows":
   - example/windows/**/*

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -20,5 +20,17 @@ def include_react_native!(options)
     return ->(installer) { react_native_post_install(installer) }
   end
 
+  return ->(installer) {
+    begin
+      flipper_post_install(installer)
+    rescue TypeError
+      # In https://github.com/microsoft/react-native-macos/pull/803,
+      # `flipper_post_install` assumes that the Xcode project file lives next to
+      # the `Podfile`. Since the script isn't really do anything that we aren't
+      # already handling, and it doesn't like the change exists upstream, we'll
+      # ignore the error for now.
+    end
+  } if target_platform == :macos
+
   ->(installer) { flipper_post_install(installer) }
 end

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -26,10 +26,10 @@ def include_react_native!(options)
         flipper_post_install(installer)
       rescue TypeError
         # In https://github.com/microsoft/react-native-macos/pull/803,
-        # `flipper_post_install` assumes that the Xcode project file lives next to
-        # the `Podfile`. Since the script isn't really do anything that we aren't
-        # already handling, and it doesn't like the change exists upstream, we'll
-        # ignore the error for now.
+        # `flipper_post_install` assumes that the Xcode project file lives next
+        # to the `Podfile`. Since the script isn't really do anything that we
+        # aren't already handling, and it doesn't look like the change exists
+        # upstream, we'll ignore the error for now.
       end
     }
   end

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -20,17 +20,19 @@ def include_react_native!(options)
     return ->(installer) { react_native_post_install(installer) }
   end
 
-  return ->(installer) {
-    begin
-      flipper_post_install(installer)
-    rescue TypeError
-      # In https://github.com/microsoft/react-native-macos/pull/803,
-      # `flipper_post_install` assumes that the Xcode project file lives next to
-      # the `Podfile`. Since the script isn't really do anything that we aren't
-      # already handling, and it doesn't like the change exists upstream, we'll
-      # ignore the error for now.
-    end
-  } if target_platform == :macos
+  if target_platform == :macos
+    return lambda { |installer|
+      begin
+        flipper_post_install(installer)
+      rescue TypeError
+        # In https://github.com/microsoft/react-native-macos/pull/803,
+        # `flipper_post_install` assumes that the Xcode project file lives next to
+        # the `Podfile`. Since the script isn't really do anything that we aren't
+        # already handling, and it doesn't like the change exists upstream, we'll
+        # ignore the error for now.
+      end
+    }
+  end
 
   ->(installer) { flipper_post_install(installer) }
 end


### PR DESCRIPTION
### Description

A recent change in `react-native-macos` is assuming that an Xcode project file lives next to the `Podfile`, causing `flipper_post_install` to fail. The script currently doesn't do anything that we aren't already handling, and it doesn't like the change exists upstream, we'll ignore the error for now.

See https://github.com/microsoft/react-native-test-app/runs/3130544686?check_suite_focus=true.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
yarn set-react-version canary-macos
cd example
yarn
pod install --project-directory=macos
```