### PR TITLE
chore: fix tests build failing due to symlink in node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ node_modules/
 !test/__fixtures__/**/node_modules/
 package-lock.json
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+template-example/
 xcuserdata/
 yarn-error.log*

--- a/example/Example-Tests.podspec
+++ b/example/Example-Tests.podspec
@@ -20,7 +20,6 @@ Pod::Spec.new do |s|
   s.framework             = 'XCTest'
   s.user_target_xcconfig  = { 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => '$(inherited)' }
 
-  s.source_files = 'ios/ExampleTests/**/*.{m,swift}',
-                   'node_modules/react-native-test-app/ios/ReactTestApp/Manifest.swift'
+  s.source_files = 'ios/ExampleTests/**/*.{m,swift}'
   s.osx.exclude_files = 'ios/ExampleTests/ReactNativePerformanceTests.m'
 end

--- a/example/ios/ExampleTests/Manifest.swift
+++ b/example/ios/ExampleTests/Manifest.swift
@@ -1,0 +1,1 @@
+../../../ios/ReactTestApp/Manifest.swift

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -440,7 +440,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
+  Example-Tests: 01d78c8a632185acbdb2d5de901be86fc11494e5
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.63.36)
-  - FBReactNativeSpec (0.63.36):
+  - FBLazyVector (0.63.37)
+  - FBReactNativeSpec (0.63.37):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.36)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
+    - RCTRequired (= 0.63.37)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -22,232 +22,232 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.36)
-  - RCTTypeSafety (0.63.36):
-    - FBLazyVector (= 0.63.36)
+  - RCTRequired (0.63.37)
+  - RCTTypeSafety (0.63.37):
+    - FBLazyVector (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.36)
-    - React-Core (= 0.63.36)
-  - React (0.63.36):
-    - React-Core (= 0.63.36)
-    - React-Core/DevSupport (= 0.63.36)
-    - React-Core/RCTWebSocket (= 0.63.36)
-    - React-RCTActionSheet (= 0.63.36)
-    - React-RCTAnimation (= 0.63.36)
-    - React-RCTBlob (= 0.63.36)
-    - React-RCTImage (= 0.63.36)
-    - React-RCTLinking (= 0.63.36)
-    - React-RCTNetwork (= 0.63.36)
-    - React-RCTSettings (= 0.63.36)
-    - React-RCTText (= 0.63.36)
-    - React-RCTVibration (= 0.63.36)
-  - React-callinvoker (0.63.36)
-  - React-Core (0.63.36):
+    - RCTRequired (= 0.63.37)
+    - React-Core (= 0.63.37)
+  - React (0.63.37):
+    - React-Core (= 0.63.37)
+    - React-Core/DevSupport (= 0.63.37)
+    - React-Core/RCTWebSocket (= 0.63.37)
+    - React-RCTActionSheet (= 0.63.37)
+    - React-RCTAnimation (= 0.63.37)
+    - React-RCTBlob (= 0.63.37)
+    - React-RCTImage (= 0.63.37)
+    - React-RCTLinking (= 0.63.37)
+    - React-RCTNetwork (= 0.63.37)
+    - React-RCTSettings (= 0.63.37)
+    - React-RCTText (= 0.63.37)
+    - React-RCTVibration (= 0.63.37)
+  - React-callinvoker (0.63.37)
+  - React-Core (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.36)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-Core/Default (= 0.63.37)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.63.36):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
-    - Yoga
-  - React-Core/Default (0.63.36):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
-    - Yoga
-  - React-Core/DevSupport (0.63.36):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.36)
-    - React-Core/RCTWebSocket (= 0.63.36)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
-    - React-jsinspector (= 0.63.36)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.36):
+  - React-Core/CoreModulesHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.36):
+  - React-Core/Default (0.63.37):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
+    - Yoga
+  - React-Core/DevSupport (0.63.37):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.37)
+    - React-Core/RCTWebSocket (= 0.63.37)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
+    - React-jsinspector (= 0.63.37)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.36):
+  - React-Core/RCTAnimationHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.36):
+  - React-Core/RCTBlobHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.36):
+  - React-Core/RCTImageHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.36):
+  - React-Core/RCTLinkingHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.36):
+  - React-Core/RCTNetworkHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.36):
+  - React-Core/RCTSettingsHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.36):
+  - React-Core/RCTTextHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.36):
+  - React-Core/RCTVibrationHeaders (0.63.37):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.36)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-jsiexecutor (= 0.63.36)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
     - Yoga
-  - React-CoreModules (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+  - React-Core/RCTWebSocket (0.63.37):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core/CoreModulesHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-RCTImage (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-cxxreact (0.63.36):
+    - React-Core/Default (= 0.63.37)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-jsiexecutor (= 0.63.37)
+    - Yoga
+  - React-CoreModules (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core/CoreModulesHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-RCTImage (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-cxxreact (0.63.37):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.36)
-    - React-jsinspector (= 0.63.36)
-  - React-jsi (0.63.36):
+    - React-callinvoker (= 0.63.37)
+    - React-jsinspector (= 0.63.37)
+  - React-jsi (0.63.37):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.36)
-  - React-jsi/Default (0.63.36):
+    - React-jsi/Default (= 0.63.37)
+  - React-jsi/Default (0.63.37):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.36):
+  - React-jsiexecutor (0.63.37):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
-  - React-jsinspector (0.63.36)
-  - React-RCTActionSheet (0.63.36):
-    - React-Core/RCTActionSheetHeaders (= 0.63.36)
-  - React-RCTAnimation (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
+  - React-jsinspector (0.63.37)
+  - React-RCTActionSheet (0.63.37):
+    - React-Core/RCTActionSheetHeaders (= 0.63.37)
+  - React-RCTAnimation (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core/RCTAnimationHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTBlob (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core/RCTAnimationHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTBlob (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.36)
-    - React-Core/RCTWebSocket (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-RCTNetwork (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTImage (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - React-Core/RCTBlobHeaders (= 0.63.37)
+    - React-Core/RCTWebSocket (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-RCTNetwork (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTImage (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core/RCTImageHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - React-RCTNetwork (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTLinking (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
-    - React-Core/RCTLinkingHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTNetwork (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core/RCTImageHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - React-RCTNetwork (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTLinking (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
+    - React-Core/RCTLinkingHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTNetwork (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core/RCTNetworkHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTSettings (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core/RCTNetworkHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTSettings (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.36)
-    - React-Core/RCTSettingsHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - React-RCTText (0.63.36):
-    - React-Core/RCTTextHeaders (= 0.63.36)
-  - React-RCTVibration (0.63.36):
-    - FBReactNativeSpec (= 0.63.36)
+    - RCTTypeSafety (= 0.63.37)
+    - React-Core/RCTSettingsHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - React-RCTText (0.63.37):
+    - React-Core/RCTTextHeaders (= 0.63.37)
+  - React-RCTVibration (0.63.37):
+    - FBReactNativeSpec (= 0.63.37)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.36)
-    - React-jsi (= 0.63.36)
-    - ReactCommon/turbomodule/core (= 0.63.36)
-  - ReactCommon/turbomodule/core (0.63.36):
+    - React-Core/RCTVibrationHeaders (= 0.63.37)
+    - React-jsi (= 0.63.37)
+    - ReactCommon/turbomodule/core (= 0.63.37)
+  - ReactCommon/turbomodule/core (0.63.37):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.36)
-    - React-Core (= 0.63.36)
-    - React-cxxreact (= 0.63.36)
-    - React-jsi (= 0.63.36)
+    - React-callinvoker (= 0.63.37)
+    - React-Core (= 0.63.37)
+    - React-cxxreact (= 0.63.37)
+    - React-jsi (= 0.63.37)
   - ReactTestApp-DevSupport (0.0.1-dev)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.43.1)
@@ -357,35 +357,35 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  Example-Tests: be97fa6a731d03f227b627d2d6788ea3f09a14ff
-  FBLazyVector: 0a9070829baaf7af315d4b85e992f24315ee0588
-  FBReactNativeSpec: e41705afe0a17d636081a7c077d34caf205ca13d
+  Example-Tests: 01d78c8a632185acbdb2d5de901be86fc11494e5
+  FBLazyVector: 9d69690b3a1ca272ca0c0cee76ffcb6cf36d77af
+  FBReactNativeSpec: 8b671febd2393669947b56e8d8f53a54185dd0b7
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: f84e12b899c38552d6a29f143cd45e2457d8b291
-  RCTTypeSafety: 8eeb4763b9abca903bee88705b1c9d49d1793751
-  React: 39d7e85e83660b53e35a0992b8c7e02069786df2
-  React-callinvoker: b17367fc9df0be66f294a7d9f216f6e7fee0bdc3
-  React-Core: 7d5192635b2a1e339ece8568f6d28822b5692b07
-  React-CoreModules: 743a1e48d6f4c122865ad4d5ef9e4d5b5c959b8f
-  React-cxxreact: 94f493f48dea13e07ffb8ea202db49adad4c15ac
-  React-jsi: 6b7c2a4bf424c349d54de60388f4df6f06b42b3b
-  React-jsiexecutor: f4b3fdea0937ad930eec939e49341a26ae181240
-  React-jsinspector: 7237cfc1cea329713ee5079d824f6f73d8a84c21
-  React-RCTActionSheet: 2590694b11874f5e4557925b44602944e57dbde0
-  React-RCTAnimation: 5b2544feae919c11a0979c08cd85cef00029073b
-  React-RCTBlob: 633728c1c1a88bfb9a940188077e58e6e8224d28
-  React-RCTImage: 6aa8710e711c564fa5753dafd04cfd2b41b98bc7
-  React-RCTLinking: cdcd75833512de57b527c15d4c0c0204d76071c8
-  React-RCTNetwork: 4b93b2006a32825cc80d7deda1f0c9454dcff921
-  React-RCTSettings: ff204d18857b0b8b8dd2f186db2ce2fead4a20d7
-  React-RCTText: b5613f3b26ce07497fbcb0f4c8496c1c4fcb3405
-  React-RCTVibration: e5464e5e9dd67b4f5c6983046be2e941708343f8
-  ReactCommon: 85b3897abcb25a478b26cda3154a51fb56f405d2
+  RCTRequired: 34869e88152b553afc0c7bde31b7b95f626ae367
+  RCTTypeSafety: a7e07dddefa291537fa86c996b19bbbeda9db88e
+  React: 4b1d4533300d5ffecadd5966efad43aae87d0dcb
+  React-callinvoker: f6cc4222b47cfbea310047e92fec23d454029595
+  React-Core: bf15e114c68922342fa1c77a7582458086931f50
+  React-CoreModules: 00bbdffe53f364828dcf56c0c8ed58502a67757a
+  React-cxxreact: a6ae61aee087fb51956642ec9e45f0f5cc50e488
+  React-jsi: 95337001f7c137cb7aa17b39a05b654b54ddcccb
+  React-jsiexecutor: 6dcf6fb045190e13ab29d5a3eed010aaecd934be
+  React-jsinspector: df2c5f97e26ffc68bea06c4aae11e4ce09e53e3e
+  React-RCTActionSheet: faf3d96046a0fa2b40c3c1bd0c36be860b42f2a1
+  React-RCTAnimation: 7e62b31253f45c752f7593cff24a8845557b4d13
+  React-RCTBlob: 8a1c648f7887d850972233f742589e67d52357bb
+  React-RCTImage: d40614e39fc3186a0b406ceb13fd1903880dec96
+  React-RCTLinking: a0906eb0f0169f881a0637cbb9999fb4881ee200
+  React-RCTNetwork: b1baf2d42aa5dc7157c57c7cc7ca548b9eeadaee
+  React-RCTSettings: a21555584a097f61277b9ed97c00091da9beaa61
+  React-RCTText: 2f9504b1157ccce317774eb3ca935a923ddc95d7
+  React-RCTVibration: db89493e2520ad419eeb59e40059e246d9e71607
+  ReactCommon: 014dd1ff02eab367fa6676b7b408d1a08893a98d
   ReactTestApp-DevSupport: 12e322d5ef4947012de09bf38580ee2ec385cc00
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Yoga: f2da5366fe2be821a64c84a2e455042eab763cf5
+  Yoga: 77d9987384e26b4aaf3e7a01808838cc2d4304f2
 
 PODFILE CHECKSUM: 3c90d49455189425443ac97fd0ecb40d4f3b6b78
 


### PR DESCRIPTION
### Description

CocoaPods will not include files that are outside the directory that the podspec lives in, but it will accept symlinks pointing to files.

For context, see #429.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

This only affects our internal tests. CI should pass.