### PR TITLE
chore: fix `install-windows-test-app` failing with `yarn link`

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -40,8 +40,6 @@ describe("react-native config", () => {
           folder: expect.stringContaining(exampleRoot),
           manifestPath: expect.stringContaining(
             path.join(
-              exampleRoot,
-              "node_modules",
               "react-native-test-app",
               "android",
               "app",

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -547,12 +547,12 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
 }
 
 if (require.main === module) {
-  // Add the `node_modules` path whence the script was invoked. Without it, this
-  // script will fail to resolve any packages when `react-native-test-app` was
-  // linked using npm or yarn link.
-  const nodeModulesDir = process.argv[1].match(/(.*?[/\\]node_modules)[/\\]/);
-  if (nodeModulesDir) {
-    module.paths.push(nodeModulesDir[1]);
+  const localNodeModulesPath = path.join(process.cwd(), "node_modules");
+  if (!module.paths.includes(localNodeModulesPath)) {
+    // Add the `node_modules` path whence the script was invoked. Without it,
+    // this script will fail to resolve any packages when
+    // `react-native-test-app` was linked using npm or yarn link.
+    module.paths.push(localNodeModulesPath);
   }
 
   require("yargs").usage(


### PR DESCRIPTION
### Description

The symlink pointing to `react-native-test-app` may not always point to a path that includes `/node_modules/` (e.g. in a monorepo setup).

For context, see #429.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

This doesn't affect real consumers. To test this, run:

```sh
cd example
yarn
yarn link react-native-test-app
yarn install-windows-test-app
```

If you're on a Mac, add `--no-autolink` to skip the Windows-specific operations.