### PR TITLE
fix(apple): notify users when resources are missing

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -223,8 +223,8 @@
 		19ECD0CA232ED425003D8557 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
-				LastUpgradeCheck = 1230;
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					19ECD0D1232ED425003D8557 = {

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -6,8 +6,12 @@
 #
 
 def resolve_module(request)
+  @module_cache ||= {}
+  return @module_cache[request] if @module_cache.key?(request)
+
   script = "console.log(path.dirname(require.resolve('#{request}/package.json')));"
-  Pod::Executable.execute_command('node', ['-e', script], true).strip
+  path = Pod::Executable.execute_command('node', ['-e', script], true).strip
+  @module_cache[request] = path
 end
 
 def try_pod(name, podspec, project_root)

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -144,7 +144,16 @@ def resources_pod(project_root, target_platform)
   app_manifest = find_file('app.json', project_root)
   return if app_manifest.nil?
 
+  app_dir = File.dirname(app_manifest)
   resources = resolve_resources(app_manifest(project_root), target_platform)
+
+  if resources.any? { |r| !File.exist?(File.join(app_dir, r)) }
+    Pod::UI.notice(
+      'One or more resources were not found and will not be included in the project. ' \
+      'If they are found later and you want to include them, run `pod install` again.'
+    )
+  end
+
   spec = {
     'name' => 'ReactTestApp-Resources',
     'version' => '1.0.0-dev',
@@ -160,7 +169,6 @@ def resources_pod(project_root, target_platform)
     'resources' => ['app.json', *resources],
   }
 
-  app_dir = File.dirname(app_manifest)
   podspec_path = File.join(app_dir, 'ReactTestApp-Resources.podspec.json')
   File.open(podspec_path, 'w') do |f|
     # Under certain conditions, the file doesn't get written to disk before it

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -147,7 +147,7 @@ def resources_pod(project_root, target_platform)
   app_dir = File.dirname(app_manifest)
   resources = resolve_resources(app_manifest(project_root), target_platform)
 
-  if resources.any? { |r| !File.exist?(File.join(app_dir, r)) }
+  if !resources.nil? && resources.any? { |r| !File.exist?(File.join(app_dir, r)) }
     Pod::UI.notice(
       'One or more resources were not found and will not be included in the project. ' \
       'If they are found later and you want to include them, run `pod install` again.'
@@ -177,6 +177,7 @@ def resources_pod(project_root, target_platform)
     f.fsync
     ObjectSpace.define_finalizer(self, Remover.new(f))
   end
+
   Pathname.new(app_dir).relative_path_from(project_root).to_s
 end
 

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -214,8 +214,8 @@
 		193EF057247A736100BE8C79 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
-				LastUpgradeCheck = 1230;
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					193EF05E247A736100BE8C79 = {

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -9,6 +9,13 @@ require('minitest/autorun')
 
 require_relative('../ios/test_app')
 
+class Pod
+  class UI
+    def self.notice(message)
+    end
+  end
+end
+
 def app_manifest_path(project_root, podspec_path)
   File.join(project_root, podspec_path, 'ReactTestApp-Resources.podspec.json')
 end

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -11,8 +11,7 @@ require_relative('../ios/test_app')
 
 class Pod
   class UI
-    def self.notice(message)
-    end
+    def self.notice(message) end
   end
 end
 


### PR DESCRIPTION
### Description

Notify users when resources are missing and how they can add them later.

Initially, I thought of generating a warning/error in Xcode, but warnings get lost because RN outputs so many, and errors are a bit extreme since you could run everything off the dev server if you wanted to.

Resolves #281.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Run `pod install` immediately after `yarn` is finished:
   ```
   % cd example
   % yarn
   % pod install --project-directory=ios
   
   [!] One or more resources were not found and will not be included in the project. If they are found later and you want to include them, run `pod install` again.
   Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
   Analyzing dependencies
   Downloading dependencies
   Generating Pods project
   
   [!] `ReactTestApp.xcodeproj` was sourced from `react-native-test-app`. All modifications will be overwritten next time you run `pod install`.
   Integrating client project
   Pod installation complete! There are 52 dependencies from the Podfile and 43 total pods installed.
   ```
2. Build the JS bundle and run `pod install` again:
   ```
   % yarn build:ios
   % pod install --project-directory=ios
   Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
   Analyzing dependencies
   Downloading dependencies
   Generating Pods project
   
   [!] `ReactTestApp.xcodeproj` was sourced from `react-native-test-app`. All modifications will be overwritten next time you run `pod install`.
   Integrating client project
   Pod installation complete! There are 52 dependencies from the Podfile and 43 total pods installed.
   ```