### PR TITLE
fix(ios): fix `run-ios` failing with `@react-native-community/cli` 5

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -26,7 +26,26 @@ module.exports = {
       ),
     },
     ios: {
-      project: "ios/ReactTestApp-Dummy.xcodeproj",
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require("react-native-test-app/scripts/configure");
+        if (
+          packageSatisfiesVersionRange(
+            "@react-native-community/cli-platform-ios",
+            "<5.0.2"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // `project` was only used to infer `sourceDir` and `podfile`.
+          return "ios/ReactTestApp-Dummy.xcodeproj";
+        }
+
+        // `sourceDir` and `podfile` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return "node_modules/.generated/ios/ReactTestApp.xcodeproj";
+      })(),
     },
     windows: fs.existsSync(windowsProjectFile) && {
       sourceDir: "windows",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -150,6 +150,17 @@ function readJSONFile(path) {
 }
 
 /**
+ * Returns whether installed package satisfies specified version range.
+ * @param {string} pkg
+ * @param {string} versionRange
+ * @returns {boolean}
+ */
+function packageSatisfiesVersionRange(pkg, versionRange) {
+  const { version } = require(`${pkg}/package.json`);
+  return semver.satisfies(version, versionRange);
+}
+
+/**
  * Converts an object or value to a pretty JSON string.
  * @param {Record<string, unknown>} obj
  * @return {string}
@@ -239,10 +250,18 @@ function reactNativeConfig({ name, testAppPath, platforms, flatten }) {
       case "macos":
       case "ios":
         return join(
+          "const {",
+          "  packageSatisfiesVersionRange,",
+          '} = require("react-native-test-app/scripts/configure");',
           "module.exports = {",
           "  project: {",
           "    ios: {",
-          `      project: "ReactTestApp-Dummy.xcodeproj"`,
+          "      project: packageSatisfiesVersionRange(",
+          '        "@react-native-community/cli-platform-ios",',
+          '        "<5.0.2"',
+          "      )",
+          '        ? "ReactTestApp-Dummy.xcodeproj"',
+          '        : "node_modules/.generated/ios/ReactTestApp.xcodeproj",',
           "    }",
           "  }",
           "};",
@@ -889,22 +908,23 @@ if (require.main === module) {
   ).argv;
 }
 
-exports["configure"] = configure;
-exports["error"] = error;
-exports["gatherConfig"] = gatherConfig;
-exports["getAppName"] = getAppName;
-exports["getConfig"] = getConfig;
-exports["getPlatformPackage"] = getPlatformPackage;
-exports["getTargetReactNativeVersion"] = getTargetReactNativeVersion;
-exports["isDestructive"] = isDestructive;
-exports["isInstalled"] = isInstalled;
-exports["join"] = join;
-exports["mergeConfig"] = mergeConfig;
-exports["projectRelativePath"] = projectRelativePath;
-exports["reactNativeConfig"] = reactNativeConfig;
-exports["readJSONFile"] = readJSONFile;
-exports["removeAllFiles"] = removeAllFiles;
-exports["sortByKeys"] = sortByKeys;
-exports["updatePackageManifest"] = updatePackageManifest;
-exports["warn"] = warn;
-exports["writeAllFiles"] = writeAllFiles;
+exports.configure = configure;
+exports.error = error;
+exports.gatherConfig = gatherConfig;
+exports.getAppName = getAppName;
+exports.getConfig = getConfig;
+exports.getPlatformPackage = getPlatformPackage;
+exports.getTargetReactNativeVersion = getTargetReactNativeVersion;
+exports.isDestructive = isDestructive;
+exports.isInstalled = isInstalled;
+exports.join = join;
+exports.mergeConfig = mergeConfig;
+exports.packageSatisfiesVersionRange = packageSatisfiesVersionRange;
+exports.projectRelativePath = projectRelativePath;
+exports.reactNativeConfig = reactNativeConfig;
+exports.readJSONFile = readJSONFile;
+exports.removeAllFiles = removeAllFiles;
+exports.sortByKeys = sortByKeys;
+exports.updatePackageManifest = updatePackageManifest;
+exports.warn = warn;
+exports.writeAllFiles = writeAllFiles;

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -24,10 +24,18 @@ use_test_app!
     "metro.config.js": Object {
       "source": "example/metro.config.js",
     },
-    "react-native.config.js": "module.exports = {
+    "react-native.config.js": "const {
+  packageSatisfiesVersionRange,
+} = require(\\"react-native-test-app/scripts/configure\\");
+module.exports = {
   project: {
     ios: {
-      project: \\"ReactTestApp-Dummy.xcodeproj\\"
+      project: packageSatisfiesVersionRange(
+        \\"@react-native-community/cli-platform-ios\\",
+        \\"<5.0.2\\"
+      )
+        ? \\"ReactTestApp-Dummy.xcodeproj\\"
+        : \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\",
     }
   }
 };
@@ -142,7 +150,26 @@ module.exports = {
       ),
     },
     ios: {
-      project: \\"ios/ReactTestApp-Dummy.xcodeproj\\",
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
     },
     windows: fs.existsSync(windowsProjectFile) && {
       sourceDir: \\"windows\\",
@@ -226,7 +253,26 @@ module.exports = {
       ),
     },
     ios: {
-      project: \\"ios/ReactTestApp-Dummy.xcodeproj\\",
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
     },
     windows: fs.existsSync(windowsProjectFile) && {
       sourceDir: \\"windows\\",
@@ -360,7 +406,26 @@ module.exports = {
       ),
     },
     ios: {
-      project: \\"ios/ReactTestApp-Dummy.xcodeproj\\",
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
     },
     windows: fs.existsSync(windowsProjectFile) && {
       sourceDir: \\"windows\\",
@@ -501,7 +566,26 @@ module.exports = {
       ),
     },
     ios: {
-      project: \\"ios/ReactTestApp-Dummy.xcodeproj\\",
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
     },
     windows: fs.existsSync(windowsProjectFile) && {
       sourceDir: \\"windows\\",


### PR DESCRIPTION
### Description

Fixes `run-ios` failing with `@react-native-community/cli` 5 and up.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```sh
yarn set-react-version 0.64
cd example
yarn
yarn ios
```