### PR TITLE
Bump XAML version from 2.5.0 to 2.6.0

### DIFF
--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" / -->
   <!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" / -->
-  <!-- package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" / -->
+  <!-- package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" / -->
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native" / -->
   <package id="nlohmann.json" version="3.9.1" targetFramework="native" />

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -362,12 +362,12 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
             nuGetPackage("Microsoft.ReactNative", rnWindowsVersion),
           '<!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" / -->':
             nuGetPackage("Microsoft.ReactNative.Cxx", rnWindowsVersion),
-          '<!-- package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" / -->':
-            nuGetPackage("Microsoft.UI.Xaml", "2.5.0"),
+          '<!-- package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" / -->':
+            nuGetPackage("Microsoft.UI.Xaml", "2.6.0"),
           "<UseExperimentalNuget>false</UseExperimentalNuget>":
             "<UseExperimentalNuget>true</UseExperimentalNuget>",
           "<WinUI2xVersionDisabled />":
-            "<WinUI2xVersion>2.5.0</WinUI2xVersion>",
+            "<WinUI2xVersion>2.6.0</WinUI2xVersion>",
         }
       : undefined),
     "1000\\.0\\.0": rnWindowsVersion,


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->
Bump XAML version from 2.5.0 to 2.6.0 so that WinUI 2.6 controls can be accessed from the test app. I updated the corresponding NuGet packages to pull in the newer version.
<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->
Resolves #444.
### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Run windows app and ensure the correct version is used.

Currently adding a test page for a new Expander component to fluentui-react-native, and this component is backed by WinUI 2.6 Expander. 
<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
