### PR TITLE
fix(apple): avoid invoking Node for module resolution

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,13 +10,13 @@
 "platform: macOS":
   - ReactTestApp-DevSupport.podspec
   - example/macos/**/*
+  - ios/*.rb
   - ios/ReactTestApp/Manifest.swift
   - ios/ReactTestApp/React+Compatibility.{h,m}
   - ios/ReactTestApp/ReactInstance.swift
   - ios/ReactTestApp/ReactTestApp-Bridging-Header.h
   - ios/ReactTestApp/Session.swift
   - ios/ReactTestApp/UIViewController+ReactTestApp.{h,m}
-  - ios/use_react_native-*.rb
   - macos/**/*
 "platform: Windows":
   - example/windows/**/*

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -5,13 +5,23 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+def find_file(file_name, current_dir)
+  return if current_dir.expand_path.to_s == '/'
+
+  path = current_dir + file_name
+  return path if File.exist?(path)
+
+  find_file(file_name, current_dir.parent)
+end
+
 def resolve_module(request)
   @module_cache ||= {}
   return @module_cache[request] if @module_cache.key?(request)
 
-  script = "console.log(path.dirname(require.resolve('#{request}/package.json')));"
-  path = Pod::Executable.execute_command('node', ['-e', script], true).strip
-  @module_cache[request] = path
+  package_json = find_file("node_modules/#{request}/package.json", Pathname.pwd)
+  raise "Cannot find module '#{request}'" if package_json.nil?
+
+  @module_cache[request] = package_json.dirname.to_s
 end
 
 def try_pod(name, podspec, project_root)

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -64,15 +64,6 @@ def react_native_from_manifest(project_root, target_platform)
   return react_native_path if react_native_path.is_a? String
 end
 
-def find_file(file_name, current_dir)
-  return if current_dir.expand_path.to_s == '/'
-
-  path = current_dir + file_name
-  return path if File.exist?(path)
-
-  find_file(file_name, current_dir.parent)
-end
-
 def find_project_root
   podfile_path = Thread.current.backtrace_locations.find do |location|
     File.basename(location.absolute_path) == 'Podfile'


### PR DESCRIPTION
### Description

Avoids invoking Node for module resolution. We already have the same algorithm implemented in Ruby.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

CI should pass.