### PR TITLE
chore(android): react-native@main bumped NDK to 21.4.7075529

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Uncomment the line below if building react-native from source
-#ANDROID_NDK_VERSION=20.1.5948944
+#ANDROID_NDK_VERSION=21.4.7075529

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -50,7 +50,6 @@ const profiles = {
     "hermes-engine": "~0.8.1",
     react: "17.0.2",
     "react-native": "^0.66.0-0",
-    "react-native-codegen": "0.0.7",
     "react-native-macos": undefined,
     "react-native-windows": undefined,
   },

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -46,6 +46,14 @@ const profiles = {
     "react-native-macos": undefined,
     "react-native-windows": undefined,
   },
+  0.66: {
+    "hermes-engine": "~0.8.1",
+    react: "17.0.2",
+    "react-native": "^0.66.0-0",
+    "react-native-codegen": "0.0.7",
+    "react-native-macos": undefined,
+    "react-native-windows": undefined,
+  },
   "canary-macos": {
     react: "16.13.1",
     "react-native": "^0.63.4",


### PR DESCRIPTION
### Description

See https://github.com/facebook/react-native/commit/aa43aab77c8571632a2b0913c80fbf822dac01bc.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Not much to test right now. This is mostly a preparatory change.