### PR TITLE
chore(android): move dependencies to `dependencies.gradle` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "gradle"
-    directory: "/android/app"
+    directory: "/android"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -121,19 +121,19 @@ dependencies {
         implementation "com.facebook.react:react-native:+"
     }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:1.3.0"
-    implementation "androidx.core:core-ktx:1.5.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.1"
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation "com.google.android.material:material:1.3.0"
+    implementation libraries.kotlinStdlibJdk7
+    implementation libraries.androidAppCompat
+    implementation libraries.androidCoreKtx
+    implementation libraries.androidRecyclerView
+    implementation libraries.androidSwipeRefreshLayout
+    implementation libraries.materialComponents
 
-    implementation("com.squareup.moshi:moshi-kotlin:1.12.0")
-    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
+    implementation libraries.moshiKotlin
+    kapt libraries.moshiKotlinCodegen
 
-    testImplementation "junit:junit:4.13.2"
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
+    testImplementation libraries.junit
+    androidTestImplementation libraries.androidJUnit
+    androidTestImplementation libraries.androidEspressoCore
 
     if (project.ext.react.enableFlipper) {
         def flipperVersion = project.ext.react.enableFlipper

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,7 +123,7 @@ dependencies {
 
     implementation libraries.kotlinStdlibJdk7
     implementation libraries.androidAppCompat
-    implementation libraries.androidCoreKtx
+    implementation libraries.androidCoreKotlinExtensions
     implementation libraries.androidRecyclerView
     implementation libraries.androidSwipeRefreshLayout
     implementation libraries.materialComponents

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -22,17 +22,17 @@ ext {
      * See https://github.com/dependabot/feedback/issues/345.
      */
     libraries = [
-        androidAppCompat         : "androidx.appcompat:appcompat:1.3.0",
-        androidCoreKtx           : "androidx.core:core-ktx:1.5.0",
-        androidEspressoCore      : "androidx.test.espresso:espresso-core:3.3.0",
-        androidJUnit             : "androidx.test.ext:junit:1.1.2",
-        androidRecyclerView      : "androidx.recyclerview:recyclerview:1.2.1",
-        androidSwipeRefreshLayout: "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
-        junit                    : "junit:junit:4.13.2",
-        kotlinStdlibJdk7         : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31",
-        materialComponents       : "com.google.android.material:material:1.3.0",
-        moshiKotlin              : "com.squareup.moshi:moshi-kotlin:1.12.0",
-        moshiKotlinCodegen       : "com.squareup.moshi:moshi-kotlin-codegen:1.12.0",
+        androidAppCompat           : "androidx.appcompat:appcompat:1.3.0",
+        androidCoreKotlinExtensions: "androidx.core:core-ktx:1.5.0",
+        androidEspressoCore        : "androidx.test.espresso:espresso-core:3.3.0",
+        androidJUnit               : "androidx.test.ext:junit:1.1.2",
+        androidRecyclerView        : "androidx.recyclerview:recyclerview:1.2.1",
+        androidSwipeRefreshLayout  : "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+        junit                      : "junit:junit:4.13.2",
+        kotlinStdlibJdk7           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31",
+        materialComponents         : "com.google.android.material:material:1.3.0",
+        moshiKotlin                : "com.squareup.moshi:moshi-kotlin:1.12.0",
+        moshiKotlinCodegen         : "com.squareup.moshi:moshi-kotlin-codegen:1.12.0",
     ]
 
     androidPluginVersion = "4.2.0"

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,7 +1,8 @@
-ext {
-    androidPluginVersion = "4.2.0"
-    kotlinVersion = "1.4.31"
+static String versionOf(String spec) {
+    return spec.split(":").last()
+}
 
+ext {
     reactTestApp = [
         versionCode: 1,
         versionName: "1.0"
@@ -12,4 +13,28 @@ ext {
         minVersion       : 21,
         buildToolsVersion: "30.0.3"
     ]
+
+    /**
+     * Dependabot requires a `dependencies.gradle` to evaluate Java
+     * dependencies. It is also very particular about the formatting and cannot
+     * evaluate string literals.
+     *
+     * See https://github.com/dependabot/feedback/issues/345.
+     */
+    libraries = [
+        androidAppCompat         : "androidx.appcompat:appcompat:1.3.0",
+        androidCoreKtx           : "androidx.core:core-ktx:1.5.0",
+        androidEspressoCore      : "androidx.test.espresso:espresso-core:3.3.0",
+        androidJUnit             : "androidx.test.ext:junit:1.1.2",
+        androidRecyclerView      : "androidx.recyclerview:recyclerview:1.2.1",
+        androidSwipeRefreshLayout: "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+        junit                    : "junit:junit:4.13.2",
+        kotlinStdlibJdk7         : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31",
+        materialComponents       : "com.google.android.material:material:1.3.0",
+        moshiKotlin              : "com.squareup.moshi:moshi-kotlin:1.12.0",
+        moshiKotlinCodegen       : "com.squareup.moshi:moshi-kotlin-codegen:1.12.0",
+    ]
+
+    androidPluginVersion = "4.2.0"
+    kotlinVersion = versionOf(libraries.kotlinStdlibJdk7)
 }


### PR DESCRIPTION
### Description

Dependabot looks for a very specific file and needs it to be in a specific format. This doesn't seem to be documented anywhere (I didn't manage to find anything), but I found some old issues where the format is described.

Found this by chance when I looked at Insights > Dependency graph > Dependabot.

![image](https://user-images.githubusercontent.com/4123478/132197537-7e7ae7ad-07d4-4484-9f9c-95366a9bb7bd.png)

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

This isn't testable by normal means.