### PR TITLE
fix(windows): invariant violation when web debugging is enabled

### DIFF
--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -262,13 +262,13 @@ void MainPage::InitializeDebugMenu()
     }
 
     SetWebDebuggerMenuItem(WebDebuggerMenuItem(), reactInstance_.UseWebDebugger());
-    WebDebuggerMenuItem().IsEnabled(reactInstance_.isWebDebuggerAvailable());
+    WebDebuggerMenuItem().IsEnabled(reactInstance_.IsWebDebuggerAvailable());
 
     SetDirectDebuggerMenuItem(DirectDebuggingMenuItem(), reactInstance_.UseDirectDebugger());
     SetBreakOnFirstLineMenuItem(BreakOnFirstLineMenuItem(), reactInstance_.BreakOnFirstLine());
 
     SetFastRefreshMenuItem(FastRefreshMenuItem(), reactInstance_.UseFastRefresh());
-    FastRefreshMenuItem().IsEnabled(reactInstance_.isFastRefreshAvailable());
+    FastRefreshMenuItem().IsEnabled(reactInstance_.IsFastRefreshAvailable());
 
     DebugMenuBarItem().IsEnabled(true);
 }

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -21,6 +21,7 @@
 using ReactTestApp::ReactInstance;
 using winrt::ReactTestApp::implementation::ReactPackageProvider;
 using winrt::Windows::Foundation::IAsyncOperation;
+using winrt::Windows::Foundation::IInspectable;
 using winrt::Windows::Foundation::PropertyValue;
 using winrt::Windows::Foundation::Uri;
 using winrt::Windows::Storage::ApplicationData;
@@ -69,7 +70,7 @@ ReactInstance::ReactInstance()
 
 #if REACT_NATIVE_VERSION >= 6400
     reactNativeHost_.InstanceSettings().InstanceLoaded(
-        [this](winrt::IInspectable const & /*sender*/, InstanceLoadedEventArgs const &args) {
+        [this](IInspectable const & /*sender*/, InstanceLoadedEventArgs const &args) {
             context_ = args.Context();
         });
 #endif  // REACT_NATIVE_VERSION >= 6400

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -14,6 +14,8 @@
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.h>
 
+#include <ReactContext.h>
+
 namespace ReactTestApp
 {
     extern std::vector<std::wstring> const JSBundleNames;
@@ -39,12 +41,12 @@ namespace ReactTestApp
         bool BreakOnFirstLine() const;
         void BreakOnFirstLine(bool);
 
-        bool isFastRefreshAvailable() const
+        bool IsFastRefreshAvailable() const
         {
             return source_ == JSBundleSource::DevServer;
         }
 
-        bool isWebDebuggerAvailable() const
+        bool IsWebDebuggerAvailable() const
         {
             return source_ == JSBundleSource::DevServer;
         }
@@ -64,6 +66,7 @@ namespace ReactTestApp
 
     private:
         winrt::Microsoft::ReactNative::ReactNativeHost reactNativeHost_;
+        winrt::Microsoft::ReactNative::ReactContext context_;
         JSBundleSource source_ = JSBundleSource::DevServer;
     };
 


### PR DESCRIPTION
### Description

When web debugging is enabled, nothing works due to an invariant violation:

```
Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'DevSettings' could not be found. Verify that a module by this name is registered in the native binary. index.bundle:24051:28
    reactConsoleErrorHandler http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:24051
    reportException http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:23996
    handleException http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:24044
    handleError http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:23869
    reportFatalError http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:1238
    guardedLoadModule http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:165
    metroRequire http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:98
    <anonymous> http://localhost:8081/index.bundle?platform=windows&dev=true&hot=false&inlineSourceMap=true:106386
    executeApplicationScript http://localhost:8081/debugger-ui/debuggerWorker.aca173c4.js:4
    onmessage http://localhost:8081/debugger-ui/debuggerWorker.aca173c4.js:4
```

The cause of this is the `DevSettings` override that we use to fetch the `ReactContext` instance. By implementing `ReactInstanceSettings::InstanceLoaded` instead, we no longer need it, but it's not available till 0.64.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
cd example
yarn
yarn install-windows-test-app --use-nuget
yarn windows
```

| 0.63 | 0.64 |
| - | - |
| ![Screenshot 2021-09-15 094442](https://user-images.githubusercontent.com/4123478/133394220-e65a3c68-0d1d-4e56-a4cf-e79ae978778d.png) | ![Screenshot 2021-09-15 095458](https://user-images.githubusercontent.com/4123478/133394258-e11bcf1f-bc89-4d36-9a4a-f043b40791ae.png) |
