### PR TITLE
fix(apple): reduce build noise from Flipper and dependencies

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -223,8 +223,8 @@
 		19ECD0CA232ED425003D8557 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1250;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					19ECD0D1232ED425003D8557 = {

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -332,6 +332,11 @@ def use_test_app_internal!(target_platform, options)
           config.build_settings.delete('IPHONEOS_DEPLOYMENT_TARGET')
           config.build_settings.delete('MACOSX_DEPLOYMENT_TARGET')
         end
+      when /\AFlipper/, 'libevent'
+        target.build_configurations.each do |config|
+          # Flipper and its dependencies log too many warnings
+          config.build_settings['WARNING_CFLAGS'] ||= ['"-w"']
+        end
       when /\AReact/
         target.build_configurations.each do |config|
           # Xcode 10.2 requires suppression of nullability for React

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -214,8 +214,8 @@
 		193EF057247A736100BE8C79 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1250;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					193EF05E247A736100BE8C79 = {


### PR DESCRIPTION
### Description

Warnings were disabled for Flipper and its dependencies because there are too many, making it difficult to see real issues.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Green CI.