### PR TITLE
fix(windows): present React menu if no React view is loaded

### DIFF
--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -58,6 +58,8 @@ namespace winrt::ReactTestApp::implementation
         void InitializeReactMenu();
         void InitializeTitleBar();
 
+        bool IsPresenting();
+
         bool LoadJSBundleFrom(::ReactTestApp::JSBundleSource);
         void LoadReactComponent(::ReactTestApp::Component const &);
 
@@ -66,6 +68,8 @@ namespace winrt::ReactTestApp::implementation
         void OnCoreTitleBarLayoutMetricsChanged(
             Windows::ApplicationModel::Core::CoreApplicationViewTitleBar const &,
             Windows::Foundation::IInspectable const &);
+
+        void PresentReactMenu();
     };
 }  // namespace winrt::ReactTestApp::implementation
 


### PR DESCRIPTION
### Description

Present "React" menu if no React view is currently loaded to educate users where to find apps.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
yarn
cd example
yarn install-windows-test-app --use-nuget
yarn windows
```

The test app should open the "React" menu when it starts up. Make sure the menu does not open when a view is opened on startup.