### PR TITLE
fix(windows): fix error parsing Hermes engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     }
   },
   "jest": {
+    "collectCoverage": true,
     "roots": [
       "test"
     ]

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -71,15 +71,13 @@ module.exports = {
       name: "init-test-app",
       description: "Initializes a new test app project",
       func: (_argv, _config, { destination, name, platform }) => {
-        const {
-          configure,
-          getTargetReactNativeVersion,
-        } = require("./scripts/configure");
+        const { version: targetVersion } = require("react-native/package.json");
+        const { configure } = require("./scripts/configure");
         configure({
           name,
           packagePath: destination,
           testAppPath: __dirname,
-          targetVersion: getTargetReactNativeVersion(),
+          targetVersion,
           platforms: sanitizePlatformChoice(platform),
           flatten: true,
           force: true,

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -603,6 +603,7 @@ function gatherConfig(params) {
 
         const dependencies = getDependencies && getDependencies(params);
         if (!dependencies) {
+          /* istanbul ignore next */
           return config;
         }
 
@@ -665,16 +666,6 @@ function getAppName(packagePath) {
   }
 
   return "ReactTestApp";
-}
-
-/**
- * Retrieves the version of React Native to target.
- * @returns {string}
- */
-function getTargetReactNativeVersion() {
-  const manifestPath = require.resolve("react-native/package.json");
-  const { version } = readJSONFile(manifestPath);
-  return /** @type {string} */ (version);
 }
 
 /**
@@ -849,7 +840,7 @@ function configure(params) {
 if (require.main === module) {
   /** @type {Platform[]} */
   const platformChoices = ["android", "ios", "macos", "windows"];
-  const targetVersion = getTargetReactNativeVersion();
+  const { version: targetVersion } = require("react-native/package.json");
 
   require("yargs").usage(
     "$0 [options]",
@@ -916,7 +907,6 @@ exports.gatherConfig = gatherConfig;
 exports.getAppName = getAppName;
 exports.getConfig = getConfig;
 exports.getPlatformPackage = getPlatformPackage;
-exports.getTargetReactNativeVersion = getTargetReactNativeVersion;
 exports.isDestructive = isDestructive;
 exports.isInstalled = isInstalled;
 exports.join = join;

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -8,8 +8,8 @@
 // @ts-check
 
 (async () => {
-  const { configure, getTargetReactNativeVersion } = require("./configure");
-  const targetVersion = getTargetReactNativeVersion();
+  const { version: targetVersion } = require("react-native/package.json");
+  const { configure } = require("./configure");
 
   /**
    * @type {{

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -201,6 +201,166 @@ module.exports = {
 }
 `;
 
+exports[`gatherConfig() returns common configuration 1`] = `
+Object {
+  "dependencies": Object {},
+  "files": Object {
+    ".gitignore": Object {
+      "source": "example/.gitignore",
+    },
+    ".watchmanconfig": Object {
+      "source": "node_modules/react-native/template/_watchmanconfig",
+    },
+    "babel.config.js": Object {
+      "source": "node_modules/react-native/template/babel.config.js",
+    },
+    "common/.gitignore": Object {
+      "source": "example/.gitignore",
+    },
+    "common/.watchmanconfig": Object {
+      "source": "node_modules/react-native/template/_watchmanconfig",
+    },
+    "common/babel.config.js": Object {
+      "source": "node_modules/react-native/template/babel.config.js",
+    },
+    "common/metro.config.js": Object {
+      "source": "example/metro.config.js",
+    },
+    "common/react-native.config.js": "const fs = require(\\"fs\\");
+const path = require(\\"path\\");
+
+const windowsProjectFile = path.join(
+  \\"node_modules\\",
+  \\".generated\\",
+  \\"windows\\",
+  \\"ReactTestApp\\",
+  \\"ReactTestApp.vcxproj\\"
+);
+
+module.exports = {
+  project: {
+    android: {
+      sourceDir: \\"android\\",
+      manifestPath: path.relative(
+        path.join(__dirname, \\"android\\"),
+        path.join(
+          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
+          \\"android\\",
+          \\"app\\",
+          \\"src\\",
+          \\"main\\",
+          \\"AndroidManifest.xml\\"
+        )
+      ),
+    },
+    ios: {
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
+    },
+    windows: fs.existsSync(windowsProjectFile) && {
+      sourceDir: \\"windows\\",
+      solutionFile: \\"Test.sln\\",
+      project: {
+        projectFile: path.relative(
+          path.join(__dirname, \\"windows\\"),
+          windowsProjectFile
+        ),
+      },
+    },
+  },
+};
+",
+    "metro.config.js": Object {
+      "source": "example/metro.config.js",
+    },
+    "react-native.config.js": "const fs = require(\\"fs\\");
+const path = require(\\"path\\");
+
+const windowsProjectFile = path.join(
+  \\"node_modules\\",
+  \\".generated\\",
+  \\"windows\\",
+  \\"ReactTestApp\\",
+  \\"ReactTestApp.vcxproj\\"
+);
+
+module.exports = {
+  project: {
+    android: {
+      sourceDir: \\"android\\",
+      manifestPath: path.relative(
+        path.join(__dirname, \\"android\\"),
+        path.join(
+          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
+          \\"android\\",
+          \\"app\\",
+          \\"src\\",
+          \\"main\\",
+          \\"AndroidManifest.xml\\"
+        )
+      ),
+    },
+    ios: {
+      project: (() => {
+        const {
+          packageSatisfiesVersionRange,
+        } = require(\\"react-native-test-app/scripts/configure\\");
+        if (
+          packageSatisfiesVersionRange(
+            \\"@react-native-community/cli-platform-ios\\",
+            \\"<5.0.2\\"
+          )
+        ) {
+          // Prior to @react-native-community/cli-platform-ios v5.0.0,
+          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
+          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
+        }
+
+        // \`sourceDir\` and \`podfile\` detection was fixed in
+        // @react-native-community/cli-platform-ios v5.0.2 (see
+        // https://github.com/react-native-community/cli/pull/1444).
+        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
+      })(),
+    },
+    windows: fs.existsSync(windowsProjectFile) && {
+      sourceDir: \\"windows\\",
+      solutionFile: \\"Test.sln\\",
+      project: {
+        projectFile: path.relative(
+          path.join(__dirname, \\"windows\\"),
+          windowsProjectFile
+        ),
+      },
+    },
+  },
+};
+",
+  },
+  "oldFiles": Array [],
+  "scripts": Object {
+    "start": "react-native start",
+  },
+}
+`;
+
 exports[`gatherConfig() returns configuration for a single platform 1`] = `
 Object {
   "dependencies": Object {},

--- a/test/configure/gatherConfig.test.js
+++ b/test/configure/gatherConfig.test.js
@@ -14,6 +14,12 @@ describe("gatherConfig()", () => {
     expect(gatherConfig(mockParams())).toMatchSnapshot();
   });
 
+  test("returns common configuration", () => {
+    expect(
+      gatherConfig(mockParams({ platforms: ["common"] }))
+    ).toMatchSnapshot();
+  });
+
   test("returns configuration for a single platform", () => {
     expect(gatherConfig(mockParams({ platforms: ["ios"] }))).toMatchSnapshot();
   });

--- a/test/configure/packageSatisfiesVersionRange.test.js
+++ b/test/configure/packageSatisfiesVersionRange.test.js
@@ -1,0 +1,21 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// @ts-check
+
+describe("packageSatisfiesVersionRange()", () => {
+  const { packageSatisfiesVersionRange } = require("../../scripts/configure");
+
+  test("returns true when a package satisfies version range", () => {
+    expect(packageSatisfiesVersionRange("..", "^0.0.1-0")).toBe(true);
+    expect(packageSatisfiesVersionRange("..", "~0.0.1-0")).toBe(true);
+  });
+
+  test("returns false when a package does not satisfy version range", () => {
+    expect(packageSatisfiesVersionRange("..", ">=0.0.1")).toBe(false);
+    expect(packageSatisfiesVersionRange("..", "^0.0.0")).toBe(false);
+  });
+});

--- a/test/windows-test-app/getHermesVersion.test.js
+++ b/test/windows-test-app/getHermesVersion.test.js
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// @ts-check
+
+jest.mock("fs");
+
+/**
+ * Returns a property sheet with specified Hermes version.
+ * @param {string} version
+ * @returns {string}
+ */
+function jsEngineProps(version) {
+  return `
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">${version}</HermesVersion>
+  </PropertyGroup>
+</Project>
+`;
+}
+
+describe("getHermesVersion", () => {
+  const path = require("path");
+  const { mockFiles } = require("../mockFiles");
+  const { getHermesVersion } = require("../../windows/test-app");
+
+  afterEach(() => mockFiles());
+
+  test("returns the required Hermes version", () => {
+    ["0.7.2", "0.8.0-ms.0", "0.9.0-ms.1"].forEach((version) => {
+      mockFiles([
+        path.join("react-native-windows", "PropertySheets", "JSEngine.props"),
+        jsEngineProps(version),
+      ]);
+      expect(getHermesVersion("react-native-windows")).toBe(version);
+    });
+  });
+});

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -274,7 +274,7 @@ function getHermesVersion(rnwPath) {
     "JSEngine.props"
   );
   const props = fs.readFileSync(jsEnginePropsPath, textFileReadOptions);
-  const m = props.match(/<HermesVersion.*?>([.\w]+)<\/HermesVersion>/);
+  const m = props.match(/<HermesVersion.*?>(.+?)<\/HermesVersion>/);
   return m && m[1];
 }
 
@@ -602,14 +602,15 @@ if (require.main === module) {
     }
   ).argv;
 } else {
-  exports["copyAndReplace"] = copyAndReplace;
-  exports["findNearest"] = findNearest;
-  exports["findUserProjects"] = findUserProjects;
-  exports["generateSolution"] = generateSolution;
-  exports["getBundleResources"] = getBundleResources;
-  exports["getPackageVersion"] = getPackageVersion;
-  exports["getVersionNumber"] = getVersionNumber;
-  exports["parseResources"] = parseResources;
-  exports["replaceContent"] = replaceContent;
-  exports["toProjectEntry"] = toProjectEntry;
+  exports.copyAndReplace = copyAndReplace;
+  exports.findNearest = findNearest;
+  exports.findUserProjects = findUserProjects;
+  exports.generateSolution = generateSolution;
+  exports.getBundleResources = getBundleResources;
+  exports.getHermesVersion = getHermesVersion;
+  exports.getPackageVersion = getPackageVersion;
+  exports.getVersionNumber = getVersionNumber;
+  exports.parseResources = parseResources;
+  exports.replaceContent = replaceContent;
+  exports.toProjectEntry = toProjectEntry;
 }


### PR DESCRIPTION
### Description

The Hermes version scheme changed in 0.65, breaking the parser.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
yarn
cd example
yarn install-windows-test-app --use-hermes
yarn windows
```