### PR TITLE
feat: add support for custom bundle root

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ IncludeCategories:
     Priority: 4
   - Regex: '^<React'
     Priority: 4
-  - Regex: '^<[.a-z]+>'
+  - Regex: '^<[._a-z]+>'
     Priority: 2
   - Regex: '^<'
     Priority: 3

--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -75,8 +75,6 @@ class MainActivity : ReactActivity() {
         didInitialNavigation = savedInstanceState?.getBoolean("didInitialNavigation", false) == true
 
         val (manifest, checksum) = testApp.manifestProvider.fromResources()
-            ?: throw IllegalStateException("app.json is not provided or TestApp is misconfigured")
-
         val index =
             if (manifest.components.count() == 1) 0 else session.lastOpenedComponent(checksum)
         index?.let {

--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -13,17 +13,19 @@ val Context.testApp: TestApp
     get() = applicationContext as TestApp
 
 class TestApp : Application(), ReactApplication {
+    private lateinit var manifestProviderInternal: ManifestProvider
     private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider
     private lateinit var reactNativeHostInternal: TestAppReactNativeHost
-    private lateinit var manifestProviderInternal: ManifestProvider
 
     override fun onCreate() {
         super.onCreate()
 
-        reactNativeBundleNameProvider = ReactBundleNameProvider(this)
+        manifestProviderInternal = ManifestProvider.create(this)
+        val (manifest, _) = manifestProvider.fromResources()
+
+        reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)
         reactNativeHostInternal =
             TestAppReactNativeHost(this, reactNativeBundleNameProvider)
-        manifestProviderInternal = ManifestProvider.create(this)
 
         val eventConsumers = PackageList(this).packages
             .filter { it is ReactTestAppLifecycleEvents }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
@@ -14,6 +14,7 @@ import com.squareup.moshi.JsonClass
 data class Manifest(
     val name: String,
     val displayName: String,
+    val bundleRoot: String?,
     val components: List<Component>
 )
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/ReactBundleNameProvider.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/ReactBundleNameProvider.kt
@@ -2,22 +2,34 @@ package com.microsoft.reacttestapp.react
 
 import android.content.Context
 
-class ReactBundleNameProvider(private val context: Context) {
+class ReactBundleNameProvider(private val context: Context, private val bundleRoot: String?) {
     val bundleName: String? by lazy {
-        val entryFileNames = listOf(
-            "index.android",
-            "main.android",
-            "index.mobile",
-            "main.mobile",
-            "index.native",
-            "main.native",
-            "index",
-            "main"
-        )
-        val possibleEntryFiles = entryFileNames.map { "$it.jsbundle" } +
-            entryFileNames.map { "$it.bundle" }
-
+        val possibleEntryFiles = getPossibleEntryFiles(bundleRoot)
         context.resources.assets.list("")
             ?.firstOrNull { possibleEntryFiles.contains(it) }
+    }
+
+    private fun getPossibleEntryFiles(bundleRoot: String?): List<String> {
+        val extensions = listOf(
+            ".android.bundle",
+            ".android.jsbundle",
+            ".mobile.bundle",
+            ".mobile.jsbundle",
+            ".native.bundle",
+            ".native.jsbundle",
+            ".bundle",
+            ".jsbundle",
+        )
+
+        if (bundleRoot == null) {
+            val candidates = mutableListOf<String>()
+            extensions.forEach {
+                candidates.add("index$it")
+                candidates.add("main$it")
+            }
+            return candidates
+        }
+
+        return extensions.map { bundleRoot + it }
     }
 }

--- a/example/ios/ExampleTests/ManifestTests.swift
+++ b/example/ios/ExampleTests/ManifestTests.swift
@@ -59,6 +59,7 @@ class ManifestTests: XCTestCase {
         let expected = Manifest(
             name: "Name",
             displayName: "Display Name",
+            bundleRoot: nil,
             components: expectedComponents
         )
 

--- a/example/windows/ReactTestAppTests/ManifestTests.cpp
+++ b/example/windows/ReactTestAppTests/ManifestTests.cpp
@@ -45,7 +45,7 @@ namespace ReactTestAppTests
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto&& [manifest, checksum] = result.value();
+            auto &manifest = result.value();
 
             Assert::AreEqual(manifest.name, {"Example"});
             Assert::AreEqual(manifest.displayName, {"Example"});
@@ -61,7 +61,7 @@ namespace ReactTestAppTests
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto&& [manifest, checksum] = result.value();
+            auto &manifest = result.value();
 
             Assert::AreEqual(manifest.name, {"Example"});
             Assert::AreEqual(manifest.displayName, {"Example"});
@@ -86,7 +86,7 @@ namespace ReactTestAppTests
                 Assert::Fail(L"Couldn't read manifest file");
             }
 
-            auto&& [manifest, checksum] = result.value();
+            auto &manifest = result.value();
 
             Assert::AreEqual(manifest.name, {"Name"});
             Assert::AreEqual(manifest.displayName, {"Display Name"});

--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -91,8 +91,9 @@ final class ContentViewController: UITableViewController {
 
         onComponentsRegistered(components, checksum: checksum)
 
+        let bundleRoot = manifest.bundleRoot
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            self?.reactInstance.initReact {
+            self?.reactInstance.initReact(bundleRoot: bundleRoot) {
                 if !components.isEmpty,
                    let index = components.count == 1 ? 0 : Session.lastOpenedComponent(checksum)
                 {

--- a/ios/ReactTestApp/Manifest.swift
+++ b/ios/ReactTestApp/Manifest.swift
@@ -54,6 +54,7 @@ struct Component: Decodable {
 struct Manifest: Decodable {
     let name: String
     let displayName: String
+    let bundleRoot: String?
     let components: [Component]?
 
     static func fromFile() -> (Manifest, String)? {

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -69,8 +69,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         onComponentsRegistered(components, enable: false)
 
+        let bundleRoot = manifest.bundleRoot
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            self?.reactInstance.initReact {
+            self?.reactInstance.initReact(bundleRoot: bundleRoot) {
                 DispatchQueue.main.async { [weak self] in
                     guard let strongSelf = self, !components.isEmpty else {
                         return

--- a/windows/.clang-format
+++ b/windows/.clang-format
@@ -16,7 +16,7 @@ IncludeCategories:
     Priority: 4
   - Regex: '^<React'
     Priority: 4
-  - Regex: '^<[.a-z]+>'
+  - Regex: '^<[._a-z]+>'
     Priority: 2
   - Regex: '^<'
     Priority: 3

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -55,7 +55,7 @@ namespace winrt::ReactTestApp::implementation
         std::string manifestChecksum_;
 
         void InitializeDebugMenu();
-        void InitializeReactMenu();
+        void InitializeReactMenu(std::optional<::ReactTestApp::Manifest>);
         void InitializeTitleBar();
 
         bool LoadJSBundleFrom(::ReactTestApp::JSBundleSource);

--- a/windows/ReactTestApp/Manifest.cpp
+++ b/windows/ReactTestApp/Manifest.cpp
@@ -110,11 +110,12 @@ namespace ReactTestApp
     {
         m.name = j.at("name");
         m.displayName = j.at("displayName");
+        m.bundleRoot = get_optional<std::string>(j, "bundleRoot");
         m.components = get_optional<std::vector<Component>>(j, "components")
                            .value_or(std::vector<Component>{});
     }
 
-    std::optional<std::pair<Manifest, std::string>> GetManifest(std::string const &filename)
+    std::optional<Manifest> GetManifest(std::string const &filename)
     {
         std::FILE *stream = nullptr;
         if (fopen_s(&stream, filename.c_str(), "rb") != 0) {
@@ -134,6 +135,8 @@ namespace ReactTestApp
             return std::nullopt;
         }
 
-        return std::make_pair(j.get<Manifest>(), checksum(json));
+        auto manifest = j.get<Manifest>();
+        manifest.checksum = checksum(json);
+        return manifest;
     }
 }  // namespace ReactTestApp

--- a/windows/ReactTestApp/Manifest.h
+++ b/windows/ReactTestApp/Manifest.h
@@ -11,7 +11,6 @@
 #include <map>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace ReactTestApp
@@ -26,9 +25,11 @@ namespace ReactTestApp
     struct Manifest {
         std::string name;
         std::string displayName;
+        std::optional<std::string> bundleRoot;
         std::vector<Component> components;
+        std::string checksum;
     };
 
-    std::optional<std::pair<Manifest, std::string>> GetManifest(std::string const &filename);
+    std::optional<Manifest> GetManifest(std::string const &filename);
 
 }  // namespace ReactTestApp

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <winrt/Microsoft.ReactNative.h>
@@ -19,7 +20,7 @@
 
 namespace ReactTestApp
 {
-    extern std::vector<std::wstring> const JSBundleNames;
+    extern std::vector<std::wstring_view> const JSBundleNames;
 
     enum class JSBundleSource {
         DevServer,
@@ -43,6 +44,16 @@ namespace ReactTestApp
 
         bool BreakOnFirstLine() const;
         void BreakOnFirstLine(bool);
+
+        auto const &BundleRoot() const
+        {
+            return bundleRoot_;
+        }
+
+        void BundleRoot(std::optional<winrt::hstring> bundleRoot)
+        {
+            bundleRoot_ = std::move(bundleRoot);
+        }
 
         bool IsFastRefreshAvailable() const
         {
@@ -76,11 +87,12 @@ namespace ReactTestApp
     private:
         winrt::Microsoft::ReactNative::ReactNativeHost reactNativeHost_;
         winrt::Microsoft::ReactNative::ReactContext context_;
+        std::optional<winrt::hstring> bundleRoot_;
         JSBundleSource source_ = JSBundleSource::DevServer;
         OnComponentsRegistered onComponentsRegistered_;
     };
 
-    std::optional<std::wstring> GetBundleName();
+    std::optional<winrt::hstring> GetBundleName(std::optional<winrt::hstring> const &bundleRoot);
     winrt::Windows::Foundation::IAsyncOperation<bool> IsDevServerRunning();
 
 }  // namespace ReactTestApp


### PR DESCRIPTION
### Description

Adds support for custom bundle root.

Resolves #525.

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

1. When `bundleRoot` is unset, test app should use `index` and `main` as bundle root.
2. When `bundleRoot` is set, test app should only use the set value as bundle root.