### PR TITLE
test: use `memfs` to mock file system operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.21.0",
     "jest": "^27.0.0",
+    "memfs": "^3.3.0",
     "prettier": "^2.3.1",
     "react": "16.13.1",
     "react-native": "^0.63.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format:js": "prettier --write $(git ls-files '*.js' '*.yml' 'test/**/*.json')",
     "format:swift": "swiftformat --swiftversion 5.3 ios macos",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | commitlint",
-    "lint:js": "eslint $(git ls-files '*.js') && yarn tsc",
+    "lint:js": "eslint $(git ls-files '*.js') && tsc",
     "lint:kt": "ktlint --relative --verbose 'android/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -662,9 +662,10 @@ function getAppName(packagePath) {
       return name;
     }
   } catch (_) {
-    warn("Could not determine app name; using 'ReactTestApp'");
+    // No name? Use fallback.
   }
 
+  warn("Could not determine app name; using 'ReactTestApp'");
   return "ReactTestApp";
 }
 
@@ -715,14 +716,20 @@ function isDestructive(packagePath, { files, oldFiles }) {
 function removeAllFiles(files, destination) {
   /** @type {(p: string, cb: (error?: Error | null) => void) => void} */
   const rimraf = require("rimraf");
-
-  const rethrow = (/** @type {Error | null | undefined} */ error) => {
-    if (error) {
-      throw error;
-    }
-  };
   return Promise.all(
-    files.map((filename) => rimraf(path.join(destination, filename), rethrow))
+    files.map(
+      /** @type {(filename: string) => Promise<void>} */
+      (filename) =>
+        new Promise((resolve, reject) => {
+          rimraf(path.join(destination, filename), (error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        })
+    )
   );
 }
 

--- a/test/__mocks__/fs.js
+++ b/test/__mocks__/fs.js
@@ -6,13 +6,6 @@
 //
 "use strict";
 
-/**
- * @typedef {import("fs").MakeDirectoryOptions} MakeDirectoryOptions
- * @typedef {import("fs").NoParamCallback} NoParamCallback
- * @typedef {import("fs").PathLike} PathLike
- * @typedef {import("fs").Stats} Stats
- * @typedef {import("fs").WriteFileOptions} WriteFileOptions
- */
 const fs = jest.createMockFromModule("fs");
 
 const { vol } = require("memfs");

--- a/test/__mocks__/fs.js
+++ b/test/__mocks__/fs.js
@@ -15,71 +15,24 @@
  */
 const fs = jest.createMockFromModule("fs");
 
-/** @type {{ [filename: string]: string } | undefined} */
-let mockFiles = Object.create(null);
+const { vol } = require("memfs");
 
 /** @type {(newMockFiles: { [filename: string]: string }) => void} */
-fs.__setMockFiles = (newMockFiles) => {
-  mockFiles = Object.create(null);
-  for (const path in newMockFiles) {
-    mockFiles[path] = newMockFiles[path];
-  }
+fs.__setMockFiles = (files) => {
+  vol.reset();
+  vol.fromJSON(files);
 };
 
-/** @type {(src: PathLike, dest: PathLike, callback: NoParamCallback) => void} */
-fs.copyFile = (src, dest, callback) => {
-  if (!(src in mockFiles) || !dest) {
-    callback(new Error("copyFile() error"));
-  } else {
-    mockFiles[dest] = mockFiles[src];
-    callback(null);
-  }
-};
+fs.__toJSON = () => vol.toJSON();
 
-/** @type {(path: PathLike | number) => boolean} */
-fs.existsSync = (path) =>
-  mockFiles ? path in mockFiles : jest.requireActual("fs").existsSync(path);
-
-/** @type {(path: PathLike | number, callback: NoParamCallback) => void} */
-fs.lstat = (path, callback) => callback();
-
-/** @type {(path: PathLike | number, options: NoParamCallback, callback: NoParamCallback) => void} */
-fs.mkdir = (path, options, callback) => callback();
-
-/** @type {(path: PathLike | number) => string} */
-fs.readFileSync = (path) => mockFiles[path];
-
-/** @type {(path: PathLike) => Stats} */
-fs.statSync = (path) => ({
-  isDirectory: () => mockFiles[path] === "directory",
-  mode: 644,
-});
-
-/** @type {(path: PathLike | number, callback: NoParamCallback) => void} */
-fs.unlink = (path, callback) => {
-  if (path in mockFiles) {
-    delete mockFiles[path];
-    callback(null);
-  } else {
-    const error = new Error(`no such file or directory, unlink '${path}'`);
-    error.code = "ENOENT";
-    callback(error);
-  }
-};
-
-/** @type {(path: PathLike | number, data: string, optionsOrCallback: WriteFileOptions | NoParamCallback, callback: NoParamCallback) => void} */
-fs.writeFile = (
-  path,
-  data,
-  optionsOrCallback,
-  callback = optionsOrCallback
-) => {
-  if (!path || path === ".") {
-    callback(new Error("writeFile() error"));
-  } else {
-    mockFiles[path] = data;
-    callback(null);
-  }
-};
+fs.copyFile = (...args) => vol.copyFile(...args);
+fs.existsSync = (...args) => vol.existsSync(...args);
+fs.lstat = (...args) => vol.lstat(...args);
+fs.mkdir = (...args) => vol.mkdir(...args);
+fs.readFileSync = (...args) => vol.readFileSync(...args);
+fs.readdirSync = (...args) => vol.readdirSync(...args);
+fs.statSync = (...args) => vol.statSync(...args);
+fs.unlink = (...args) => vol.unlink(...args);
+fs.writeFile = (...args) => vol.writeFile(...args);
 
 module.exports = fs;

--- a/test/configure/getAppName.test.js
+++ b/test/configure/getAppName.test.js
@@ -24,19 +24,21 @@ describe("getAppName()", () => {
   });
 
   test("retrieves name from the app manifest", () => {
-    mockFiles(["app.json", { name: "Example" }]);
+    mockFiles({ "app.json": `{ "name": "Example" }` });
     expect(getAppName(".")).toBe("Example");
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
   test("falls back to 'ReactTestApp' if `name` is missing or empty", () => {
-    mockFiles(["app.json", {}]);
+    mockFiles({ "app.json": "{}" });
     expect(getAppName(".")).toBe("ReactTestApp");
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
 
-    mockFiles(["app.json", { name: "" }]);
+    consoleSpy.mockReset();
+
+    mockFiles({ "app.json": `{ name: "" }` });
     expect(getAppName(".")).toBe("ReactTestApp");
-
-    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
   });
 
   test("falls back to 'ReactTestApp' if the app manifest is missing", () => {

--- a/test/configure/isDestructive.test.js
+++ b/test/configure/isDestructive.test.js
@@ -68,7 +68,7 @@ describe("isDestructive()", () => {
     expect(isDestructive(".", config)).toBe(false);
     expect(consoleSpy).toHaveBeenCalledTimes(0);
 
-    mockFiles(["metro.config.js", ""]);
+    mockFiles({ "metro.config.js": "" });
 
     expect(isDestructive(".", config)).toBe(true);
     expect(consoleSpy).toHaveBeenCalledTimes(2);
@@ -87,7 +87,7 @@ describe("isDestructive()", () => {
     expect(isDestructive(".", config)).toBe(false);
     expect(consoleSpy).toHaveBeenCalledTimes(0);
 
-    mockFiles(["Podfile.lock", ""]);
+    mockFiles({ "Podfile.lock": "" });
 
     expect(isDestructive(".", config)).toBe(true);
     expect(consoleSpy).toHaveBeenCalledTimes(2);
@@ -108,11 +108,11 @@ describe("isDestructive()", () => {
     expect(isDestructive(".", config)).toBe(false);
     expect(consoleSpy).toHaveBeenCalledTimes(0);
 
-    mockFiles(
-      ["Podfile.lock", ""],
-      ["babel.config.js", ""],
-      ["metro.config.js", ""]
-    );
+    mockFiles({
+      "Podfile.lock": "",
+      "babel.config.js": "",
+      "metro.config.js": "",
+    });
 
     expect(isDestructive(".", config)).toBe(true);
     expect(consoleSpy).toHaveBeenCalledTimes(5);

--- a/test/configure/removeAllFiles.test.js
+++ b/test/configure/removeAllFiles.test.js
@@ -15,21 +15,33 @@ describe("removeAllFiles()", () => {
   const { removeAllFiles } = require("../../scripts/configure");
 
   beforeEach(() => {
-    mockFiles(
-      ["babel.config.js", "module.exports = {};"],
-      ["metro.config.js", "module.exports = {};"]
-    );
+    mockFiles({
+      "babel.config.js": "module.exports = {};",
+      "metro.config.js": "module.exports = {};",
+    });
   });
 
-  test("removes all specified files", () => {
-    removeAllFiles(["babel.config.js", "metro.config.js"], ".");
-    expect(fs.readFileSync("babel.config.js")).toBeUndefined();
-    expect(fs.readFileSync("metro.config.js")).toBeUndefined();
+  afterAll(() => {
+    mockFiles();
   });
 
-  test("ignores non-existent files", () => {
-    removeAllFiles(["babel.config.js", "react-native.config.js"], ".");
-    expect(fs.readFileSync("babel.config.js")).toBeUndefined();
-    expect(fs.readFileSync("metro.config.js")).toBeDefined();
+  test("removes all specified files", async () => {
+    expect(fs.existsSync("babel.config.js")).toBe(true);
+    expect(fs.existsSync("metro.config.js")).toBe(true);
+
+    await removeAllFiles(["babel.config.js", "metro.config.js"], ".");
+
+    expect(fs.existsSync("babel.config.js")).toBe(false);
+    expect(fs.existsSync("metro.config.js")).toBe(false);
+  });
+
+  test("ignores non-existent files", async () => {
+    expect(fs.existsSync("babel.config.js")).toBe(true);
+    expect(fs.existsSync("metro.config.js")).toBe(true);
+
+    await removeAllFiles(["babel.config.js", "react-native.config.js"], ".");
+
+    expect(fs.existsSync("babel.config.js")).toBe(false);
+    expect(fs.existsSync("metro.config.js")).toBe(true);
   });
 });

--- a/test/configure/updatePackageManifest.test.js
+++ b/test/configure/updatePackageManifest.test.js
@@ -15,7 +15,7 @@ describe("updatePackageManifest()", () => {
   afterEach(() => mockFiles());
 
   test("adds `scripts` field if missing", () => {
-    mockFiles(["package.json", { key: "value" }]);
+    mockFiles({ "package.json": `{ "key": "value" }` });
 
     const config = {
       scripts: {
@@ -40,15 +40,14 @@ describe("updatePackageManifest()", () => {
   });
 
   test("adds to existing `scripts` field", () => {
-    mockFiles([
-      "package.json",
-      {
+    mockFiles({
+      "package.json": JSON.stringify({
         key: "value",
         scripts: {
           test: "jest",
         },
-      },
-    ]);
+      }),
+    });
 
     const config = {
       scripts: {

--- a/test/configure/writeAllFiles.test.js
+++ b/test/configure/writeAllFiles.test.js
@@ -20,7 +20,7 @@ describe("writeAllFiles()", () => {
   });
 
   test("writes all files to disk", async () => {
-    mockFiles(["file-on-disk", 0]);
+    mockFiles({ "file-on-disk": "0" });
     await writeAllFiles(
       {
         file0: { source: "file-on-disk" },
@@ -30,9 +30,9 @@ describe("writeAllFiles()", () => {
       "test"
     );
 
-    expect(fs.readFileSync(path.join("test", "file0"))).toBe("0");
-    expect(fs.readFileSync(path.join("test", "file1"))).toBe("1");
-    expect(fs.readFileSync(path.join("test", "file2"))).toBe("2");
+    expect(fs.readFileSync(path.join("test", "file0"), "utf-8")).toBe("0");
+    expect(fs.readFileSync(path.join("test", "file1"), "utf-8")).toBe("1");
+    expect(fs.readFileSync(path.join("test", "file2"), "utf-8")).toBe("2");
   });
 
   test("ignores files with no content", async () => {
@@ -45,9 +45,9 @@ describe("writeAllFiles()", () => {
       "."
     );
 
-    expect(fs.readFileSync("file1")).toBe("1");
-    expect(fs.readFileSync("file2")).toBe("2");
-    expect(fs.readFileSync("file3")).toBeUndefined();
+    expect(fs.readFileSync("file1", "utf-8")).toBe("1");
+    expect(fs.readFileSync("file2", "utf-8")).toBe("2");
+    expect(() => fs.readFileSync("file3")).toThrowError("ENOENT");
   });
 
   test("rethrows write exceptions", async () => {
@@ -76,8 +76,8 @@ describe("writeAllFiles()", () => {
       )
     ).rejects.toThrow();
 
-    expect(fs.readFileSync("file1")).toBe("1");
-    expect(fs.readFileSync("file2")).toBe("2");
-    expect(fs.readFileSync("")).toBeUndefined();
+    expect(fs.readFileSync("file1", "utf-8")).toBe("1");
+    expect(fs.readFileSync("file2", "utf-8")).toBe("2");
+    expect(() => fs.readFileSync("")).toThrowError("EISDIR");
   });
 });

--- a/test/configure/writeAllFiles.test.js
+++ b/test/configure/writeAllFiles.test.js
@@ -47,7 +47,7 @@ describe("writeAllFiles()", () => {
 
     expect(fs.readFileSync("file1", "utf-8")).toBe("1");
     expect(fs.readFileSync("file2", "utf-8")).toBe("2");
-    expect(() => fs.readFileSync("file3")).toThrowError("ENOENT");
+    expect(() => fs.readFileSync("file3")).toThrow("ENOENT");
   });
 
   test("rethrows write exceptions", async () => {
@@ -78,6 +78,6 @@ describe("writeAllFiles()", () => {
 
     expect(fs.readFileSync("file1", "utf-8")).toBe("1");
     expect(fs.readFileSync("file2", "utf-8")).toBe("2");
-    expect(() => fs.readFileSync("")).toThrowError("EISDIR");
+    expect(() => fs.readFileSync("")).toThrow("EISDIR");
   });
 });

--- a/test/mockFiles.js
+++ b/test/mockFiles.js
@@ -13,18 +13,11 @@ const fs = require("fs");
 
 /**
  * Adds mock files.
- * @param {...[string, unknown]} files
+ * @param {Record<string, string>} files
  */
-function mockFiles(...files) {
+function mockFiles(files = {}) {
   // @ts-ignore `__setMockFiles`
-  fs.__setMockFiles(
-    Object.fromEntries(
-      files.map(([filename, content]) => [
-        filename,
-        typeof content === "string" ? content : JSON.stringify(content),
-      ])
-    )
-  );
+  fs.__setMockFiles(files);
 }
 
 exports.mockFiles = mockFiles;

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -43,7 +43,7 @@ describe("generateSolution", () => {
   });
 
   test("exits if 'react-native-windows' folder cannot be found", () => {
-    mockFiles([path.resolve("", "node_modules"), "directory"]);
+    mockFiles({ [path.resolve("", "node_modules", ".bin")]: "directory" });
 
     expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-windows'"
@@ -51,10 +51,14 @@ describe("generateSolution", () => {
   });
 
   test("exits if 'react-native-test-app' folder cannot be found", () => {
-    mockFiles(
-      [path.resolve("", "node_modules"), "directory"],
-      [path.resolve("", "node_modules", "react-native-windows"), "directory"]
-    );
+    mockFiles({
+      [path.resolve(
+        "",
+        "node_modules",
+        "react-native-windows",
+        "package.json"
+      )]: "{}",
+    });
 
     expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-test-app'"

--- a/test/windows-test-app/getBundleResources.test.js
+++ b/test/windows-test-app/getBundleResources.test.js
@@ -18,17 +18,14 @@ describe("getBundleResources", () => {
   test("returns app name and bundle resources", () => {
     const assets = path.join("dist", "assets");
     const bundle = path.join("dist", "main.bundle");
-    mockFiles(
-      [
-        "app.json",
-        {
-          name: "Example",
-          resources: [assets, bundle],
-        },
-      ],
-      [assets, "directory"],
-      [bundle, "text"]
-    );
+    mockFiles({
+      "app.json": JSON.stringify({
+        name: "Example",
+        resources: [assets, bundle],
+      }),
+      [path.join(assets, "app.json")]: "{}",
+      [bundle]: "'use strict';",
+    });
 
     const { appName, appxManifest, bundleDirContent, bundleFileContent } =
       getBundleResources("app.json", path.resolve(""));
@@ -40,14 +37,13 @@ describe("getBundleResources", () => {
   });
 
   test("returns package manifest", () => {
-    mockFiles([
-      "app.json",
-      {
+    mockFiles({
+      "app.json": JSON.stringify({
         windows: {
           appxManifest: "windows/Example/Package.appxmanifest",
         },
-      },
-    ]);
+      }),
+    });
 
     const { appName, appxManifest, bundleDirContent, bundleFileContent } =
       getBundleResources("app.json", path.resolve(""));
@@ -75,7 +71,7 @@ describe("getBundleResources", () => {
   });
 
   test("handles invalid manifest", () => {
-    mockFiles(["app.json", "-"]);
+    mockFiles({ "app.json": "-" });
 
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 

--- a/test/windows-test-app/getHermesVersion.test.js
+++ b/test/windows-test-app/getHermesVersion.test.js
@@ -33,10 +33,10 @@ describe("getHermesVersion", () => {
 
   test("returns the required Hermes version", () => {
     ["0.7.2", "0.8.0-ms.0", "0.9.0-ms.1"].forEach((version) => {
-      mockFiles([
-        path.join("react-native-windows", "PropertySheets", "JSEngine.props"),
-        jsEngineProps(version),
-      ]);
+      mockFiles({
+        [path.join("react-native-windows", "PropertySheets", "JSEngine.props")]:
+          jsEngineProps(version),
+      });
       expect(getHermesVersion("react-native-windows")).toBe(version);
     });
   });

--- a/test/windows-test-app/parseResources.test.js
+++ b/test/windows-test-app/parseResources.test.js
@@ -22,7 +22,10 @@ describe("parseResources", () => {
   });
 
   test("returns references to existing assets", () => {
-    mockFiles(["dist/assets", "directory"], ["dist/main.jsbundle", "text"]);
+    mockFiles({
+      "dist/assets/app.json": "{}",
+      "dist/main.jsbundle": "'use strict';",
+    });
 
     expect(
       parseResources(

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -186,12 +186,18 @@ function toProjectEntry(project, destPath) {
  * Copies a file to given destination, replacing parts of its contents.
  * @param {string} srcPath Path to the file to be copied.
  * @param {string} destPath Destination path.
- * @param {{ [pattern: string]: string }=} replacements e.g. {'TextToBeReplaced': 'Replacement'}
+ * @param {{ [pattern: string]: string }} replacements e.g. {'TextToBeReplaced': 'Replacement'}
+ * @param {(error: Error | null) => void} callback Callback for when the copy operation is done.
  */
-function copyAndReplace(srcPath, destPath, replacements = {}) {
+function copyAndReplace(
+  srcPath,
+  destPath,
+  replacements = {},
+  callback = rethrow
+) {
   if (binaryExtensions.includes(path.extname(srcPath))) {
     // Binary file
-    return fs.copyFile(srcPath, destPath, rethrow);
+    return fs.copyFile(srcPath, destPath, callback);
   } else {
     // Text file
     return fs.writeFile(
@@ -204,7 +210,7 @@ function copyAndReplace(srcPath, destPath, replacements = {}) {
         encoding: "utf-8",
         mode: fs.statSync(srcPath).mode,
       },
-      rethrow
+      callback
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5688,6 +5688,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-monkey@npm:1.0.3":
+  version: 1.0.3
+  resolution: "fs-monkey@npm:1.0.3"
+  checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
+  languageName: node
+  linkType: hard
+
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
@@ -8376,6 +8383,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"memfs@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "memfs@npm:3.3.0"
+  dependencies:
+    fs-monkey: 1.0.3
+  checksum: 9e9eb71cfc077fd5e14ad2f497f5a8791689b64f307cf379ed6737c5781652a7af0509395c0dfba43c4e413dbc7cd7010e9ca002168ec329e6df178414b96268
+  languageName: node
+  linkType: hard
+
 "meow@npm:^8.0.0":
   version: 8.1.2
   resolution: "meow@npm:8.1.2"
@@ -10445,6 +10461,7 @@ fsevents@^2.3.2:
     eslint-plugin-prettier: ^4.0.0
     eslint-plugin-react: ^7.21.0
     jest: ^27.0.0
+    memfs: ^3.3.0
     prettier: ^2.3.1
     prompts: ^2.4.0
     react: 16.13.1


### PR DESCRIPTION
### Description

Re-implements our `fs` mock using [memfs](https://github.com/streamich/memfs). This allows us to test more complex functions that require more file system access.

This will also unblock the incoming fix for #484.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

All tests should pass.