### PR TITLE
fix(windows): wildcards in project items are not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prompts": "^2.4.0",
     "rimraf": "^3.0.0",
     "semver": "^7.3.5",
+    "uuid": "^8.3.2",
     "yargs": "^16.0.0"
   },
   "peerDependencies": {
@@ -100,6 +101,7 @@
     "@types/prompts": "~2.0.0",
     "@types/rimraf": "^3.0.0",
     "@types/semver": "^7.3.6",
+    "@types/uuid": "^8.3.1",
     "eslint": "^8.0.0",
     "eslint-plugin-jest": "^25.0.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/test/__mocks__/fs.js
+++ b/test/__mocks__/fs.js
@@ -22,6 +22,7 @@ fs.copyFile = (...args) => vol.copyFile(...args);
 fs.existsSync = (...args) => vol.existsSync(...args);
 fs.lstat = (...args) => vol.lstat(...args);
 fs.mkdir = (...args) => vol.mkdir(...args);
+fs.readFile = (...args) => vol.readFile(...args);
 fs.readFileSync = (...args) => vol.readFileSync(...args);
 fs.readdirSync = (...args) => vol.readdirSync(...args);
 fs.statSync = (...args) => vol.statSync(...args);

--- a/test/windows-test-app/getBundleResources.test.js
+++ b/test/windows-test-app/getBundleResources.test.js
@@ -27,13 +27,31 @@ describe("getBundleResources", () => {
       [bundle]: "'use strict';",
     });
 
-    const { appName, appxManifest, bundleDirContent, bundleFileContent } =
-      getBundleResources("app.json", path.resolve(""));
+    const {
+      appName,
+      appxManifest,
+      assetItems,
+      assetItemFilters,
+      assetFilters,
+    } = getBundleResources("app.json", path.resolve(""));
 
     expect(appName).toBe("Example");
     expect(appxManifest).toBe("windows/Package.appxmanifest");
-    expect(bundleDirContent).toBe(`${assets}\\**\\*;`);
-    expect(bundleFileContent).toBe(`${bundle};`);
+    expect(assetItems).toMatchInlineSnapshot(`
+"<CopyFileToFolders Include=\\"$(ProjectRootDir)\\\\dist\\\\main.bundle\\">
+      <DestinationFolders>$(OutDir)\\\\Bundle</DestinationFolders>
+    </CopyFileToFolders>"
+`);
+    expect(assetItemFilters).toMatchInlineSnapshot(`
+"<CopyFileToFolders Include=\\"$(ProjectRootDir)\\\\dist\\\\main.bundle\\">
+      <Filter>Assets</Filter>
+    </CopyFileToFolders>"
+`);
+    expect(assetFilters).toEqual(
+      expect.stringMatching(
+        /^<Filter Include="Assets\\assets">\s+<UniqueIdentifier>{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}<\/UniqueIdentifier>\s+<\/Filter>$/
+      )
+    );
   });
 
   test("returns package manifest", () => {
@@ -45,25 +63,25 @@ describe("getBundleResources", () => {
       }),
     });
 
-    const { appName, appxManifest, bundleDirContent, bundleFileContent } =
-      getBundleResources("app.json", path.resolve(""));
-
-    expect(appName).toBe("ReactTestApp");
-    expect(appxManifest).toBe("windows/Example/Package.appxmanifest");
-    expect(bundleDirContent).toBe("");
-    expect(bundleFileContent).toBe("");
+    expect(getBundleResources("app.json", path.resolve(""))).toEqual({
+      appName: "ReactTestApp",
+      appxManifest: "windows/Example/Package.appxmanifest",
+      assetItems: "",
+      assetItemFilters: "",
+      assetFilters: "",
+    });
   });
 
   test("handles missing manifest", () => {
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 
-    const { appName, appxManifest, bundleDirContent, bundleFileContent } =
-      getBundleResources("", "");
-
-    expect(appName).toBe("ReactTestApp");
-    expect(appxManifest).toBe("windows/Package.appxmanifest");
-    expect(bundleDirContent).toBeFalsy();
-    expect(bundleFileContent).toBeFalsy();
+    expect(getBundleResources("", "")).toEqual({
+      appName: "ReactTestApp",
+      appxManifest: "windows/Package.appxmanifest",
+      assetItems: "",
+      assetItemFilters: "",
+      assetFilters: "",
+    });
 
     expect(warnSpy).toHaveBeenCalledWith("Could not find 'app.json' file.");
 
@@ -75,13 +93,13 @@ describe("getBundleResources", () => {
 
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 
-    const { appName, appxManifest, bundleDirContent, bundleFileContent } =
-      getBundleResources("app.json", path.resolve(""));
-
-    expect(appName).toBe("ReactTestApp");
-    expect(appxManifest).toBe("windows/Package.appxmanifest");
-    expect(bundleDirContent).toBeFalsy();
-    expect(bundleFileContent).toBeFalsy();
+    expect(getBundleResources("app.json", path.resolve(""))).toEqual({
+      appName: "ReactTestApp",
+      appxManifest: "windows/Package.appxmanifest",
+      assetItems: "",
+      assetItemFilters: "",
+      assetFilters: "",
+    });
 
     expect(warnSpy).toHaveBeenCalledWith(
       "Could not parse 'app.json':\nUnexpected end of JSON input"

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -1,262 +1,244 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(SolutionDir)ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)ExperimentalFeatures.props')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
-    <PropertyGroup Label="Globals">
-        <CppWinRTOptimized>true</CppWinRTOptimized>
-        <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-        <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
-        <MinimalCoreWin>true</MinimalCoreWin>
-        <ProjectGuid>{b44cead7-fbff-4a17-95ea-ff5434bbd79d}</ProjectGuid>
-        <ProjectName>ReactTestApp</ProjectName>
-        <RootNamespace>ReactTestApp</RootNamespace>
-        <DefaultLanguage>en-US</DefaultLanguage>
-        <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-        <AppContainerApplication>true</AppContainerApplication>
-        <ApplicationType>Windows Store</ApplicationType>
-        <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-        <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
-        <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
-        <PackageCertificateKeyFile>ReactTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
-        <PackageCertificateThumbprint>CF5E09A17EC338910A836B9975B2E95912A8D8F1</PackageCertificateThumbprint>
+  <Import Project="$(SolutionDir)ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)ExperimentalFeatures.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{b44cead7-fbff-4a17-95ea-ff5434bbd79d}</ProjectGuid>
+    <ProjectName>ReactTestApp</ProjectName>
+    <RootNamespace>ReactTestApp</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <PackageCertificateKeyFile>ReactTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>CF5E09A17EC338910A836B9975B2E95912A8D8F1</PackageCertificateThumbprint>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="ReactNativeWindowsProps">
+    <ProjectRootDir Condition="'$(ProjectRootDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'app.json'))</ProjectRootDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactTestAppDir Condition="'$(ReactTestAppDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows\ReactTestApp\</ReactTestAppDir>
+    <UseExperimentalNuget>false</UseExperimentalNuget>
+    <WinUI2xVersionDisabled />
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <ImportGroup Label="ReactNativeWindowsPropertySheets">
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" />
+    <Import Project="$(SolutionDir)packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)' != '' And Exists('$(SolutionDir)packages\$(WinUIPackageProps)')" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
+      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings></DisableSpecificWarnings>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;REACT_NATIVE_VERSION=10000000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>false</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>false</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="$(ReactTestAppDir)\pch.h" />
+    <ClInclude Include="$(ReactTestAppDir)\App.h">
+      <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="$(ReactTestAppDir)\..\..\common\AppRegistry.h" />
+    <ClInclude Include="$(ReactTestAppDir)\AutolinkedNativeModules.g.h" />
+    <ClInclude Include="$(ReactTestAppDir)\MainPage.h">
+      <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
+    <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
+    <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
+    <ClInclude Include="$(ReactTestAppDir)\Session.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml">
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="$(ReactTestAppDir)\MainPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" Condition="Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" Condition="!Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Assets\Square150x150Logo.scale-200.png" />
+    <Image Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Image Include="Assets\Square44x44Logo.scale-200.png" />
+    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+    <Image Include="Assets\SplashScreen.scale-200.png" />
+    <Image Include="Assets\StoreLogo.png" />
+    <Text Include="$(ProjectRootDir)\app.json" />
+    <!-- ReactTestApp asset items -->
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ReactTestApp_TemporaryKey.pfx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(ReactTestAppDir)\pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(ReactTestAppDir)\App.cpp">
+      <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(ReactTestAppDir)\..\..\common\AppRegistry.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="AutolinkedNativeModules.g.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp">
+      <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\ReactPackageProvider.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="$(ReactTestAppDir)\App.idl">
+      <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="$(ReactTestAppDir)\MainPage.idl">
+      <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
+    </Midl>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ReactNativeWindowsTargets">
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references targets in your node_modules\react-native-windows folder that are missing. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-    <PropertyGroup Label="ReactNativeWindowsProps">
-        <ProjectRootDir Condition="'$(ProjectRootDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'app.json'))</ProjectRootDir>
-        <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-        <ReactTestAppDir Condition="'$(ReactTestAppDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows\ReactTestApp\</ReactTestAppDir>
-        <UseExperimentalNuget>false</UseExperimentalNuget>
-        <WinUI2xVersionDisabled />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
+  </Target>
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets')" />
+    <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)' == 'true'" />
+    <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+    <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <ItemGroup Label="ProjectConfigurations">
-        <ProjectConfiguration Include="Debug|ARM">
-            <Configuration>Debug</Configuration>
-            <Platform>ARM</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|ARM64">
-            <Configuration>Debug</Configuration>
-            <Platform>ARM64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|Win32">
-            <Configuration>Debug</Configuration>
-            <Platform>Win32</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|x64">
-            <Configuration>Debug</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|ARM">
-            <Configuration>Release</Configuration>
-            <Platform>ARM</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|ARM64">
-            <Configuration>Release</Configuration>
-            <Platform>ARM64</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|Win32">
-            <Configuration>Release</Configuration>
-            <Platform>Win32</Platform>
-        </ProjectConfiguration>
-        <ProjectConfiguration Include="Release|x64">
-            <Configuration>Release</Configuration>
-            <Platform>x64</Platform>
-        </ProjectConfiguration>
-    </ItemGroup>
-    <PropertyGroup Label="Configuration">
-        <ConfigurationType>Application</ConfigurationType>
-        <PlatformToolset>v142</PlatformToolset>
-        <CharacterSet>Unicode</CharacterSet>
-        <BundleDirAssets>$(BundleDirContentPaths)</BundleDirAssets>
-        <BundleFileAssets>$(BundleFileContentPaths)</BundleFileAssets>
-        <AssetsContentRoot>$(ReactTestAppDir)\Assets</AssetsContentRoot>
-        <AssetsContent>$(AssetsContentRoot)\**\*</AssetsContent>
-        <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-        <UseDebugLibraries>true</UseDebugLibraries>
-        <LinkIncremental>true</LinkIncremental>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
-        <UseDebugLibraries>false</UseDebugLibraries>
-        <WholeProgramOptimization>true</WholeProgramOptimization>
-        <LinkIncremental>false</LinkIncremental>
-    </PropertyGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-    <ImportGroup Label="ExtensionSettings">
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets">
-        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets">
-        <Import Project="PropertySheet.props" />
-    </ImportGroup>
-    <ImportGroup Label="ReactNativeWindowsPropertySheets">
-        <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" />
-        <Import Project="$(SolutionDir)packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)' != '' And Exists('$(SolutionDir)packages\$(WinUIPackageProps)')" />
-    </ImportGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-        <IncludePath>$(ReactTestAppDir);$(ReactTestAppDir)\..\..\common;$(IncludePath)</IncludePath>
-    </PropertyGroup>
-    <ItemDefinitionGroup>
-        <ClCompile>
-            <PrecompiledHeader>Use</PrecompiledHeader>
-            <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-            <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
-            <WarningLevel>Level4</WarningLevel>
-            <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-            <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-            <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
-            <DisableSpecificWarnings></DisableSpecificWarnings>
-            <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;REACT_NATIVE_VERSION=10000000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
-        <ClCompile>
-            <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError>false</TreatWarningAsError>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
-        <ClCompile>
-            <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-            <TreatWarningAsError>false</TreatWarningAsError>
-        </ClCompile>
-    </ItemDefinitionGroup>
-    <ItemGroup>
-        <ClInclude Include="$(ReactTestAppDir)\pch.h" />
-        <ClInclude Include="$(ReactTestAppDir)\App.h">
-            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
-        </ClInclude>
-        <ClInclude Include="$(ReactTestAppDir)\..\..\common\AppRegistry.h" />
-        <ClInclude Include="$(ReactTestAppDir)\AutolinkedNativeModules.g.h" />
-        <ClInclude Include="$(ReactTestAppDir)\MainPage.h">
-            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
-        </ClInclude>
-        <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
-        <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
-        <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
-        <ClInclude Include="$(ReactTestAppDir)\Session.h" />
-    </ItemGroup>
-    <ItemGroup>
-        <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml">
-            <SubType>Designer</SubType>
-        </ApplicationDefinition>
-        <Page Include="$(ReactTestAppDir)\MainPage.xaml">
-            <SubType>Designer</SubType>
-        </Page>
-    </ItemGroup>
-    <ItemGroup>
-        <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" Condition="Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
-            <SubType>Designer</SubType>
-        </AppxManifest>
-        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" Condition="!Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
-            <SubType>Designer</SubType>
-        </AppxManifest>
-    </ItemGroup>
-    <ItemGroup>
-        <Text Include="$(ProjectRootDir)\app.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <BundleDirContentToBePackaged Include="$(BundleDirAssets)" />
-        <None Include="@(BundleDirContentToBePackaged)">
-            <DirNameFullPath>$([MSBuild]::ValueOrDefault('%(FullPath)', '').Remove($([MSBuild]::ValueOrDefault(%(FullPath), '').LastIndexOf(\%(RecursiveDir)%(Filename)%(Extension)))))</DirNameFullPath>
-            <DirName Condition="'%(DirNameFullPath)' != ''">$([MSBuild]::ValueOrDefault(%(DirNameFullPath), '').Substring($([MSBuild]::ValueOrDefault(%(DirNameFullPath), '').LastIndexOf('\'))))</DirName>
-            <Link>$([MSBuild]::MakeRelative($(ProjectDir),'Bundle%(DirName)\%(RecursiveDir)%(Filename)%(Extension)'))</Link>
-            <DeploymentContent>true</DeploymentContent>
-        </None>
-        <None Include="ReactTestApp_TemporaryKey.pfx" />
-    </ItemGroup>
-    <ItemGroup>
-        <BundleFileContentToBePackaged Include="$(BundleFileAssets)" />
-        <None Include="@(BundleFileContentToBePackaged)">
-            <Link>$([MSBuild]::MakeRelative($(ProjectDir),'Bundle\%(RecursiveDir)%(Filename)%(Extension)'))</Link>
-            <DeploymentContent>true</DeploymentContent>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <AssetsToBePackaged Include="$(AssetsContent)" />
-        <None Include="@(AssetsToBePackaged)">
-            <Link>$([MSBuild]::MakeRelative($(ProjectDir),'Assets\%(RecursiveDir)%(Filename)%(Extension)'))</Link>
-            <DeploymentContent>true</DeploymentContent>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="$(ReactTestAppDir)\pch.cpp">
-            <PrecompiledHeader>Create</PrecompiledHeader>
-        </ClCompile>
-        <ClCompile Include="$(ReactTestAppDir)\App.cpp">
-            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="$(ReactTestAppDir)\..\..\common\AppRegistry.cpp">
-            <PrecompiledHeader>NotUsing</PrecompiledHeader>
-        </ClCompile>
-        <ClCompile Include="AutolinkedNativeModules.g.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp">
-            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
-        </ClCompile>
-        <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
-        <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\ReactPackageProvider.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Midl Include="$(ReactTestAppDir)\App.idl">
-            <DependentUpon>$(ReactTestAppDir)\App.xaml</DependentUpon>
-        </Midl>
-        <Midl Include="$(ReactTestAppDir)\MainPage.idl">
-            <DependentUpon>$(ReactTestAppDir)\MainPage.xaml</DependentUpon>
-        </Midl>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-        <None Include="PropertySheet.props" />
-    </ItemGroup>
-    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-    <ImportGroup Label="ReactNativeWindowsTargets">
-        <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references targets in your node_modules\react-native-windows folder that are missing. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props'))" />
-        <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
-    </Target>
-    <ImportGroup Label="ExtensionTargets">
-        <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
-        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets')" />
-        <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets')" />
-        <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)' == 'true'" />
-        <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
-        <Import Project="$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" />
-    </ImportGroup>
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets'))" />
-    </Target>
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.9.1\build\native\nlohmann.json.targets'))" />
+  </Target>
 </Project>

--- a/windows/ReactTestApp/ReactTestApp.vcxproj.filters
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj.filters
@@ -1,54 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>
-        <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Page Include="$(ReactTestAppDir)\MainPage.xaml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Midl Include="$(ReactTestAppDir)\App.idl" />
-        <Midl Include="$(ReactTestAppDir)\MainPage.idl" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClCompile Include="$(ReactTestAppDir)\pch.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\App.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\..\..\common\AppRegistry.cpp" />
-        <ClCompile Include="$(ProjectDir)\AutolinkedNativeModules.g.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
-        <ClCompile Include="$(ReactTestAppDir)\ReactPackageProvider.cpp" />
-        <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-    </ItemGroup>
-    <ItemGroup>
-        <ClInclude Include="$(ReactTestAppDir)\pch.h" />
-        <ClInclude Include="$(ReactTestAppDir)\App.h" />
-        <ClInclude Include="$(ReactTestAppDir)\..\..\common\AppRegistry.h" />
-        <ClInclude Include="$(ReactTestAppDir)\AutolinkedNativeModules.g.h" />
-        <ClInclude Include="$(ReactTestAppDir)\MainPage.h" />
-        <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
-        <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
-        <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
-        <ClInclude Include="$(ReactTestAppDir)\Session.h" />
-    </ItemGroup>
-    <ItemGroup>
-        <Text Include="$(ProjectRootDir)\app.json">
-            <Filter>Assets</Filter>
-        </Text>
-    </ItemGroup>
-    <ItemGroup>
-        <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" />
-        <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" />
-    </ItemGroup>
-    <ItemGroup>
-        <Filter Include="Assets">
-            <UniqueIdentifier>{e48dc53e-40b1-40cb-970a-f89935452892}</UniqueIdentifier>
-        </Filter>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="PropertySheet.props" />
-        <None Include="packages.config" />
-        <None Include="ReactTestApp_TemporaryKey.pfx" />
-    </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="$(ReactTestAppDir)\App.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="$(ReactTestAppDir)\MainPage.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="$(ReactTestAppDir)\App.idl" />
+    <Midl Include="$(ReactTestAppDir)\MainPage.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(ReactTestAppDir)\pch.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\App.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\..\..\common\AppRegistry.cpp" />
+    <ClCompile Include="$(ProjectDir)\AutolinkedNativeModules.g.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\MainPage.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\Manifest.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\ReactInstance.cpp" />
+    <ClCompile Include="$(ReactTestAppDir)\ReactPackageProvider.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(ReactTestAppDir)\pch.h" />
+    <ClInclude Include="$(ReactTestAppDir)\App.h" />
+    <ClInclude Include="$(ReactTestAppDir)\..\..\common\AppRegistry.h" />
+    <ClInclude Include="$(ReactTestAppDir)\AutolinkedNativeModules.g.h" />
+    <ClInclude Include="$(ReactTestAppDir)\MainPage.h" />
+    <ClInclude Include="$(ReactTestAppDir)\Manifest.h" />
+    <ClInclude Include="$(ReactTestAppDir)\ReactInstance.h" />
+    <ClInclude Include="$(ReactTestAppDir)\ReactPackageProvider.h" />
+    <ClInclude Include="$(ReactTestAppDir)\Session.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Assets\Square150x150Logo.scale-200.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\Wide310x150Logo.scale-200.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\Square44x44Logo.scale-200.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\SplashScreen.scale-200.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\StoreLogo.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Text Include="$(ProjectRootDir)\app.json">
+      <Filter>Assets</Filter>
+    </Text>
+    <!-- ReactTestApp asset item filters -->
+  </ItemGroup>
+  <ItemGroup>
+    <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" />
+    <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Assets">
+      <UniqueIdentifier>{e48dc53e-40b1-40cb-970a-f89935452892}</UniqueIdentifier>
+    </Filter>
+    <!-- ReactTestApp asset filters -->
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+    <None Include="packages.config" />
+    <None Include="ReactTestApp_TemporaryKey.pfx" />
+  </ItemGroup>
 </Project>

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -339,7 +339,7 @@ function copyAndReplace(
     // Treat as text file
     fs.readFile(srcPath, textFileReadOptions, (err, data) => {
       if (err) {
-        callback(err)
+        callback(err);
         return;
       }
 

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -338,7 +338,11 @@ function copyAndReplace(
   } else {
     // Treat as text file
     fs.readFile(srcPath, textFileReadOptions, (err, data) => {
-      rethrow(err);
+      if (err) {
+        callback(err)
+        return;
+      }
+
       fs.writeFile(
         destPath,
         replaceContent(data, replacements),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,6 +2423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^8.3.1":
+  version: 8.3.1
+  resolution: "@types/uuid@npm:8.3.1"
+  checksum: b41bdc5e86c6f0f1899306be10455636da0f2168c9489b869edd6837ddeb7c0e501b1ff7d857402462986bada2a379125743dd895fa801d03437cd632116a373
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 20.2.1
   resolution: "@types/yargs-parser@npm:20.2.1"
@@ -10490,6 +10497,7 @@ fsevents@^2.3.2:
     "@types/prompts": ~2.0.0
     "@types/rimraf": ^3.0.0
     "@types/semver": ^7.3.6
+    "@types/uuid": ^8.3.1
     chalk: ^4.1.0
     eslint: ^8.0.0
     eslint-plugin-jest: ^25.0.0
@@ -10508,6 +10516,7 @@ fsevents@^2.3.2:
     semver: ^7.3.5
     suggestion-bot: ^1.0.0
     typescript: ^4.0.0
+    uuid: ^8.3.2
     yargs: ^16.0.0
   peerDependencies:
     "@react-native-community/cli": ">=4.10.0"
@@ -12762,6 +12771,15 @@ resolve@^2.0.0-next.3:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

It doesn't look like wildcards are properly supported in Visual Studio. Converted to generating entries for all resources.

Resolves #484.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

1. Test app should work with dev server:
   ```
   yarn install-windows-test-app --use-nuget
   yarn windows
   ```
2. Test app should work with JS bundle, without dev server:
   ```
   # terminate dev server
   yarn build:windows
   yarn install-windows-test-app --use-nuget
   yarn windows
   ```

`Assets` used to be empty before, but should be populated properly now:
![Screenshot 2021-10-11 132125](https://user-images.githubusercontent.com/4123478/136782103-9b56567a-1c12-4441-b447-276226a140b8.png)