### PR TITLE
fix(macos): only link ReactTestAppShared if it doesn't exist

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.63.37)
-  - FBReactNativeSpec (0.63.37):
+  - FBLazyVector (0.63.40)
+  - FBReactNativeSpec (0.63.40):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.37)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
+    - RCTRequired (= 0.63.40)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -22,232 +22,232 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.37)
-  - RCTTypeSafety (0.63.37):
-    - FBLazyVector (= 0.63.37)
+  - RCTRequired (0.63.40)
+  - RCTTypeSafety (0.63.40):
+    - FBLazyVector (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.37)
-    - React-Core (= 0.63.37)
-  - React (0.63.37):
-    - React-Core (= 0.63.37)
-    - React-Core/DevSupport (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-RCTActionSheet (= 0.63.37)
-    - React-RCTAnimation (= 0.63.37)
-    - React-RCTBlob (= 0.63.37)
-    - React-RCTImage (= 0.63.37)
-    - React-RCTLinking (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - React-RCTSettings (= 0.63.37)
-    - React-RCTText (= 0.63.37)
-    - React-RCTVibration (= 0.63.37)
-  - React-callinvoker (0.63.37)
-  - React-Core (0.63.37):
+    - RCTRequired (= 0.63.40)
+    - React-Core (= 0.63.40)
+  - React (0.63.40):
+    - React-Core (= 0.63.40)
+    - React-Core/DevSupport (= 0.63.40)
+    - React-Core/RCTWebSocket (= 0.63.40)
+    - React-RCTActionSheet (= 0.63.40)
+    - React-RCTAnimation (= 0.63.40)
+    - React-RCTBlob (= 0.63.40)
+    - React-RCTImage (= 0.63.40)
+    - React-RCTLinking (= 0.63.40)
+    - React-RCTNetwork (= 0.63.40)
+    - React-RCTSettings (= 0.63.40)
+    - React-RCTText (= 0.63.40)
+    - React-RCTVibration (= 0.63.40)
+  - React-callinvoker (0.63.40)
+  - React-Core (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-Core/Default (= 0.63.40)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - Yoga
-  - React-Core/Default (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - Yoga
-  - React-Core/DevSupport (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - React-jsinspector (= 0.63.37)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.37):
+  - React-Core/CoreModulesHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.37):
+  - React-Core/Default (0.63.40):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
+    - Yoga
+  - React-Core/DevSupport (0.63.40):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.40)
+    - React-Core/RCTWebSocket (= 0.63.40)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
+    - React-jsinspector (= 0.63.40)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.37):
+  - React-Core/RCTAnimationHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.37):
+  - React-Core/RCTBlobHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.37):
+  - React-Core/RCTImageHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.37):
+  - React-Core/RCTLinkingHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.37):
+  - React-Core/RCTNetworkHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.37):
+  - React-Core/RCTSettingsHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.37):
+  - React-Core/RCTTextHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.37):
+  - React-Core/RCTVibrationHeaders (0.63.40):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
     - Yoga
-  - React-CoreModules (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+  - React-Core/RCTWebSocket (0.63.40):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/CoreModulesHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTImage (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-cxxreact (0.63.37):
+    - React-Core/Default (= 0.63.40)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-jsiexecutor (= 0.63.40)
+    - Yoga
+  - React-CoreModules (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core/CoreModulesHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-RCTImage (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-cxxreact (0.63.40):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.37)
-    - React-jsinspector (= 0.63.37)
-  - React-jsi (0.63.37):
+    - React-callinvoker (= 0.63.40)
+    - React-jsinspector (= 0.63.40)
+  - React-jsi (0.63.40):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.37)
-  - React-jsi/Default (0.63.37):
+    - React-jsi/Default (= 0.63.40)
+  - React-jsi/Default (0.63.40):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.37):
+  - React-jsiexecutor (0.63.40):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-  - React-jsinspector (0.63.37)
-  - React-RCTActionSheet (0.63.37):
-    - React-Core/RCTActionSheetHeaders (= 0.63.37)
-  - React-RCTAnimation (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
+  - React-jsinspector (0.63.40)
+  - React-RCTActionSheet (0.63.40):
+    - React-Core/RCTActionSheetHeaders (= 0.63.40)
+  - React-RCTAnimation (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTAnimationHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTBlob (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core/RCTAnimationHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTBlob (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTImage (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - React-Core/RCTBlobHeaders (= 0.63.40)
+    - React-Core/RCTWebSocket (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-RCTNetwork (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTImage (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTImageHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTLinking (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
-    - React-Core/RCTLinkingHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTNetwork (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core/RCTImageHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - React-RCTNetwork (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTLinking (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
+    - React-Core/RCTLinkingHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTNetwork (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTNetworkHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTSettings (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core/RCTNetworkHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTSettings (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTSettingsHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTText (0.63.37):
-    - React-Core/RCTTextHeaders (= 0.63.37)
-  - React-RCTVibration (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.40)
+    - React-Core/RCTSettingsHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - React-RCTText (0.63.40):
+    - React-Core/RCTTextHeaders (= 0.63.40)
+  - React-RCTVibration (0.63.40):
+    - FBReactNativeSpec (= 0.63.40)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - ReactCommon/turbomodule/core (0.63.37):
+    - React-Core/RCTVibrationHeaders (= 0.63.40)
+    - React-jsi (= 0.63.40)
+    - ReactCommon/turbomodule/core (= 0.63.40)
+  - ReactCommon/turbomodule/core (0.63.40):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.37)
-    - React-Core (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
+    - React-callinvoker (= 0.63.40)
+    - React-Core (= 0.63.40)
+    - React-cxxreact (= 0.63.40)
+    - React-jsi (= 0.63.40)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React
   - ReactTestApp-Resources (1.0.0-dev)
@@ -359,34 +359,34 @@ SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
   Example-Tests: 01d78c8a632185acbdb2d5de901be86fc11494e5
-  FBLazyVector: 9d69690b3a1ca272ca0c0cee76ffcb6cf36d77af
-  FBReactNativeSpec: 8b671febd2393669947b56e8d8f53a54185dd0b7
+  FBLazyVector: 83d50595f1485dc3eb9b21cb24e60a20c581872d
+  FBReactNativeSpec: d20b2fbbd0b237cecf876222c8b3f5cc30ff4a12
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 34869e88152b553afc0c7bde31b7b95f626ae367
-  RCTTypeSafety: a7e07dddefa291537fa86c996b19bbbeda9db88e
-  React: 4b1d4533300d5ffecadd5966efad43aae87d0dcb
-  React-callinvoker: f6cc4222b47cfbea310047e92fec23d454029595
-  React-Core: bf15e114c68922342fa1c77a7582458086931f50
-  React-CoreModules: 00bbdffe53f364828dcf56c0c8ed58502a67757a
-  React-cxxreact: a6ae61aee087fb51956642ec9e45f0f5cc50e488
-  React-jsi: 95337001f7c137cb7aa17b39a05b654b54ddcccb
-  React-jsiexecutor: 6dcf6fb045190e13ab29d5a3eed010aaecd934be
-  React-jsinspector: df2c5f97e26ffc68bea06c4aae11e4ce09e53e3e
-  React-RCTActionSheet: faf3d96046a0fa2b40c3c1bd0c36be860b42f2a1
-  React-RCTAnimation: 7e62b31253f45c752f7593cff24a8845557b4d13
-  React-RCTBlob: 8a1c648f7887d850972233f742589e67d52357bb
-  React-RCTImage: d40614e39fc3186a0b406ceb13fd1903880dec96
-  React-RCTLinking: a0906eb0f0169f881a0637cbb9999fb4881ee200
-  React-RCTNetwork: b1baf2d42aa5dc7157c57c7cc7ca548b9eeadaee
-  React-RCTSettings: a21555584a097f61277b9ed97c00091da9beaa61
-  React-RCTText: 2f9504b1157ccce317774eb3ca935a923ddc95d7
-  React-RCTVibration: db89493e2520ad419eeb59e40059e246d9e71607
-  ReactCommon: 014dd1ff02eab367fa6676b7b408d1a08893a98d
+  RCTRequired: 24583e8537590dbd180aee8ba1aca0ae718c6ffe
+  RCTTypeSafety: 7bfcb351d704576dfa7311962e268a37653a9610
+  React: 5945e4f4258e5d31fba04a476bec4fd1f281fd00
+  React-callinvoker: e00f7373578afb49210a517677f6a81b194ea7c5
+  React-Core: ae3d5918f1f1c6451c35e8cc0462085cd22a8478
+  React-CoreModules: f30146f9f4809220b2ec777e71831045096cc00b
+  React-cxxreact: aea4834a16e1c6b1bb814df98cffd1763a78c9e4
+  React-jsi: ca125e73896d7d5227d8c41d51f75afe253bb81a
+  React-jsiexecutor: 7b700911e2af02903114cc65636f3ab3b36a5812
+  React-jsinspector: b751e21fb78f5b0f503f7ddfe1e3d050cae4ddbe
+  React-RCTActionSheet: 912d37a9f916075d574863a234fa3e92a590a4ee
+  React-RCTAnimation: df7b3c07a9cabc7d7ff6aa5de0f6d3db1f35b434
+  React-RCTBlob: d2e3d16a13fd73f1c76d1dfac3bc6ed3db24fd09
+  React-RCTImage: 12c726abbf2b651c9e8f3df1cf41e634c6651687
+  React-RCTLinking: 92342ae49e4b64bebb71bbbc163e8c3da5f48864
+  React-RCTNetwork: 69a3996c5bdaf9db3b7528bf59987ae778092854
+  React-RCTSettings: 9ab03aac503defe0d5d495c7be5cb7b911dac1ce
+  React-RCTText: 164401df5a7d5fc175e4f9f8def62c6b1865ff0b
+  React-RCTVibration: bfbdf6dbfc0d4f30345c69ed18b670a26ad9ad61
+  ReactCommon: 94179103b7453e19658f3cbb4a8af974dde0b42a
   ReactTestApp-DevSupport: a9c0cd7cadda0121fc79703079f8b23a82a05dd1
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Yoga: 77d9987384e26b4aaf3e7a01808838cc2d4304f2
+  Yoga: f651917957f3ecdbbb7b27e63d0b77503eb9ad70
 
 PODFILE CHECKSUM: 3c90d49455189425443ac97fd0ecb40d4f3b6b78
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -236,7 +236,8 @@ def make_project!(xcodeproj, project_root, target_platform)
   # Shared code lives in `ios/ReactTestApp/`
   if target_platform != :ios
     source = File.expand_path('ReactTestApp', __dir__)
-    FileUtils.ln_sf(source, File.join(destination, 'ReactTestAppShared'))
+    shared_path = File.join(destination, 'ReactTestAppShared')
+    FileUtils.ln_sf(source, shared_path) unless File.exist?(shared_path)
   end
 
   react_native = react_native_path(project_root, target_platform)


### PR DESCRIPTION
### Description

An extraneous symlink is created in `ReactTestAppShared` the second time `pod install` is invoked.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
yarn
cd example
pod install --project-directory=macos
pod install --project-directory=macos  # This creates the second symlink
```

Before:
```
% git status
On branch tido/fix-double-link-shared

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	../ios/ReactTestApp/ReactTestApp

no changes added to commit (use "git add" and/or "git commit -a")
```

After:
```
% git status
On branch tido/fix-double-link-shared
Your branch is up to date with 'origin/tido/fix-double-link-shared'.

nothing to commit, working tree clean
```