### PR TITLE
fix(android): throw an error when `hermes-engine` is missing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,10 +4,6 @@
 buildDir = "$rootDir/$name/build"
 
 def reactNativeDir = findNodeModulesPath(rootDir, "react-native")
-def hermesEngineDir =
-    findNodeModulesPath(file(reactNativeDir), "hermes-engine")
-        ?: findNodeModulesPath(file(reactNativeDir), "hermesvm")
-def hermesAndroidDir = "$hermesEngineDir/android"
 
 buildscript {
     def androidDir = "${buildscript.sourceFile.getParent()}/../"
@@ -112,8 +108,18 @@ android {
 dependencies {
     implementation project(":support")
 
-    releaseImplementation files("$hermesAndroidDir/hermes-release.aar")
-    debugImplementation files("$hermesAndroidDir/hermes-debug.aar")
+    if (project.ext.react.enableHermes) {
+        def hermesEngineDir =
+            findNodeModulesPath(file(reactNativeDir), "hermes-engine")
+                ?: findNodeModulesPath(file(reactNativeDir), "hermesvm")
+        if (hermesEngineDir == null) {
+            throw new GradleException("Could not find 'hermes-engine'. Please make sure you've added it to 'package.json'.")
+        }
+
+        def hermesAndroidDir = "$hermesEngineDir/android"
+        releaseImplementation files("$hermesAndroidDir/hermes-release.aar")
+        debugImplementation files("$hermesAndroidDir/hermes-debug.aar")
+    }
 
     if (buildReactNativeFromSource(rootDir)) {
         implementation project(':ReactAndroid')


### PR DESCRIPTION
### Description

Throw a friendler error when `hermes-engine` cannot be found.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
yarn
rm -r node_modules/hermes-engine example/node_modules/hermes-engine
cd example/android
./gradlew clean build
```

Before:
```
% ./gradlew clean build
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:lintVitalRelease'.
> Could not resolve all artifacts for configuration ':app:debugCompileClasspath'.
   > Failed to transform hermes-debug.aar to match attributes {artifactType=android-manifest}.
      > Execution failed for JetifyTransform: /~/react-native-test-app/example/node_modules/react-native-test-app/android/app/null/android/hermes-debug.aar.
         > Transform's input file does not exist: /~/react-native-test-app/example/node_modules/react-native-test-app/android/app/null/android/hermes-debug.aar. (See https://issuetracker.google.com/issues/158753935)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 2s
```

After:
```
% ./gradlew clean build
FAILURE: Build failed with an exception.

* Where:
Build file '/~/react-native-test-app/example/node_modules/react-native-test-app/android/app/build.gradle' line: 116

* What went wrong:
A problem occurred evaluating project ':app'.
> Could not find 'hermes-engine'. Please make sure you've added it to 'package.json'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 1s
```