### PR TITLE
fix(apple): fails to build with `use_frameworks!`

### DIFF
--- a/ReactTestApp-DevSupport.podspec
+++ b/ReactTestApp-DevSupport.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
+  s.dependency 'React-jsi'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -299,7 +299,8 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - ReactTestApp-DevSupport (0.0.1-dev):
-    - React
+    - React-Core
+    - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.43.1)
   - Yoga (1.14.0)
@@ -476,7 +477,7 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  ReactTestApp-DevSupport: a9c0cd7cadda0121fc79703079f8b23a82a05dd1
+  ReactTestApp-DevSupport: ec05fb157fa71580397d7a6a9c3ee10202235c02
   ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -249,7 +249,8 @@ PODS:
     - React-cxxreact (= 0.63.40)
     - React-jsi (= 0.63.40)
   - ReactTestApp-DevSupport (0.0.1-dev):
-    - React
+    - React-Core
+    - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.43.1)
   - Yoga (1.14.0)
@@ -383,7 +384,7 @@ SPEC CHECKSUMS:
   React-RCTText: 164401df5a7d5fc175e4f9f8def62c6b1865ff0b
   React-RCTVibration: bfbdf6dbfc0d4f30345c69ed18b670a26ad9ad61
   ReactCommon: 94179103b7453e19658f3cbb4a8af974dde0b42a
-  ReactTestApp-DevSupport: a9c0cd7cadda0121fc79703079f8b23a82a05dd1
+  ReactTestApp-DevSupport: ec05fb157fa71580397d7a6a9c3ee10202235c02
   ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: f651917957f3ecdbbb7b27e63d0b77503eb9ad70

--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -19,7 +19,7 @@
 #import <React/RCTVersion.h>
 #pragma clang diagnostic pop
 
-#import <ReactTestApp-DevSupport/ReactTestApp-DevSupport.h>
+@import ReactTestApp_DevSupport;
 
 #if USE_FLIPPER
 #import <FlipperKit/FlipperClient.h>


### PR DESCRIPTION
### Description

`ReactTestApp-DevSupport` module fails to link if `use_frameworks!` is specified in `Podfile`.

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_RCTCxxBridge", referenced from:
      objc-class-ref in AppRegistryModule.o
  "_RCTRegisterModule", referenced from:
      +[RTAAppRegistryModule load] in AppRegistryModule.o
  "facebook::jsi::Object::getPropertyAsObject(facebook::jsi::Runtime&, char const*) const", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
  "_RCTJavaScriptDidLoadNotification", referenced from:
      -[RTAAppRegistryModule init] in AppRegistryModule.o
  "facebook::jsi::Value::~Value()", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
      facebook::jsi::Value facebook::jsi::Function::callWithThis<char const (&) [12]>(facebook::jsi::Runtime&, facebook::jsi::Object const&, char const (&) [12]) const in AppRegistry.o
      facebook::jsi::Function::callWithThis(facebook::jsi::Runtime&, facebook::jsi::Object const&, facebook::jsi::Value const*, unsigned long) const in AppRegistry.o
      facebook::jsi::Value::Value(facebook::jsi::Runtime&, facebook::jsi::Object const&) in AppRegistry.o
      facebook::jsi::Value::Value<facebook::jsi::String>(facebook::jsi::String&&) in AppRegistry.o
  "facebook::jsi::Value::toString(facebook::jsi::Runtime&) const", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
  "facebook::jsi::Object::asArray(facebook::jsi::Runtime&) &&", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
  "facebook::jsi::Object::getPropertyAsFunction(facebook::jsi::Runtime&, char const*) const", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
  "facebook::jsi::Value::asObject(facebook::jsi::Runtime&) &&", referenced from:
      ReactTestApp::GetAppKeys(facebook::jsi::Runtime&) in AppRegistry.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Add `use_frameworks!` to `Podfile`:
   ```diff
   diff --git a/example/ios/Podfile b/example/ios/Podfile
   index 03911b5..9df8133 100644
   --- a/example/ios/Podfile
   +++ b/example/ios/Podfile
   @@ -2,11 +2,8 @@ require_relative '../node_modules/react-native-test-app/test_app'
   
    workspace 'Example.xcworkspace'
   
   -use_flipper!({
   -               'Flipper' => '0.75.1',
   -               'Flipper-Folly' => '2.5.3',
   -               'Flipper-RSocket' => '1.3.1',
   -             })
   +use_frameworks!
   +use_flipper! false  # doesn't work with `use_frameworks!`
   
    use_test_app! :hermes_enabled => false do |target|
      target.tests do
   ```
2. Disable warnings since Swift seems to be ignoring the pragma to ignore `-Wnullability-completeness`:
   ```diff
   diff --git a/ios/ReactTestApp/ReactTestApp.common.xcconfig b/ios/ReactTestApp/ReactTestApp.common.xcconfig
   index 89a5e76..43f4dc3 100644
   --- a/ios/ReactTestApp/ReactTestApp.common.xcconfig
   +++ b/ios/ReactTestApp/ReactTestApp.common.xcconfig
   @@ -10,9 +10,9 @@ COPY_PHASE_STRIP = NO
    ENABLE_STRICT_OBJC_MSGSEND = YES
    GCC_C_LANGUAGE_STANDARD = gnu11
    GCC_NO_COMMON_BLOCKS = YES
   -GCC_TREAT_WARNINGS_AS_ERRORS = YES
   +GCC_TREAT_WARNINGS_AS_ERRORS = NO
    IPHONEOS_DEPLOYMENT_TARGET = 13.0
    MTL_FAST_MATH = YES
    SDKROOT = iphoneos
   -SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
   +SWIFT_TREAT_WARNINGS_AS_ERRORS = NO
    WARNING_CFLAGS = -Wall
   ```
3. `pod install --project-directory=ios`
4. Build the app