### PR TITLE
fix(macos): fix "no account for team" and missing provisioning profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org' do
   gem 'minitest'
   gem 'rubocop', require: false
   gem 'rubocop-minitest'
+  gem 'xcodeproj'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,14 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (3.0.4)
+      rexml
     ast (2.4.2)
+    atomos (0.1.3)
+    claide (1.0.3)
+    colored2 (3.1.2)
     minitest (5.14.4)
+    nanaimo (0.3.0)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -27,6 +33,13 @@ GEM
       rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.0.0)
+    xcodeproj (1.21.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
 
 PLATFORMS
   ruby
@@ -35,6 +48,7 @@ DEPENDENCIES
   minitest!
   rubocop!
   rubocop-minitest!
+  xcodeproj!
 
 BUNDLED WITH
-   2.2.15
+   2.2.22

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -56,11 +56,6 @@ def bundle_identifier(project_root, target_platform)
   @test_app_bundle_identifier
 end
 
-def react_native_from_manifest(project_root, target_platform)
-  react_native_path = platform_config('reactNativePath', project_root, target_platform)
-  return react_native_path if react_native_path.is_a? String
-end
-
 def find_project_root
   podfile_path = Thread.current.backtrace_locations.find do |location|
     File.basename(location.absolute_path) == 'Podfile'
@@ -95,8 +90,8 @@ def project_path(file, target_platform)
 end
 
 def react_native_path(project_root, target_platform)
-  react_native_path = react_native_from_manifest(project_root, target_platform)
-  return Pathname.new(resolve_module(react_native_path)) unless react_native_path.nil?
+  react_native_path = platform_config('reactNativePath', project_root, target_platform)
+  return Pathname.new(resolve_module(react_native_path)) if react_native_path.is_a? String
 
   react_native = case target_platform
                  when :ios then 'react-native'
@@ -282,8 +277,8 @@ def make_project!(xcodeproj, project_root, target_platform)
         "USE_FLIPPER=#{use_flipper ? 1 : 0}",
       ]
 
-      build_settings.each do |key, value|
-        config.build_settings[key] = value
+      build_settings.each do |setting, value|
+        config.build_settings[setting] = value
       end
 
       next unless use_flipper

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -379,10 +379,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ReactTestApp/ReactTestApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = UBF8T346G9;
 				INFOPLIST_FILE = ReactTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -401,7 +400,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ReactTestApp/ReactTestApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = ReactTestApp/Info.plist;

--- a/macos/ReactTestApp/ReactTestApp.entitlements
+++ b/macos/ReactTestApp/ReactTestApp.entitlements
@@ -8,9 +8,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)com.microsoft.identity.universalstorage</string>
-	</array>
 </dict>
 </plist>

--- a/test/__fixtures__/with_platform_resources/app.json
+++ b/test/__fixtures__/with_platform_resources/app.json
@@ -16,13 +16,13 @@
     "codeSignEntitlements": "codeSignEntitlements-ios",
     "codeSignIdentity": "codeSignIdentity-ios",
     "developmentTeam": "developmentTeam-ios",
-    "reactNativePath": "react-native-ios"
+    "reactNativePath": "reactNativePath-ios"
   },
   "macos": {
     "bundleIdentifier": "com.react.ReactTestApp-macos",
     "codeSignEntitlements": "codeSignEntitlements-macos",
     "codeSignIdentity": "codeSignIdentity-macos",
     "developmentTeam": "developmentTeam-macos",
-    "reactNativePath": "react-native-macos"
+    "reactNativePath": "reactNativePath-macos"
   }
 }

--- a/test/__fixtures__/with_platform_resources/app.json
+++ b/test/__fixtures__/with_platform_resources/app.json
@@ -13,10 +13,16 @@
   },
   "ios": {
     "bundleIdentifier": "com.react.ReactTestApp-ios",
+    "codeSignEntitlements": "codeSignEntitlements-ios",
+    "codeSignIdentity": "codeSignIdentity-ios",
+    "developmentTeam": "developmentTeam-ios",
     "reactNativePath": "react-native-ios"
   },
   "macos": {
     "bundleIdentifier": "com.react.ReactTestApp-macos",
+    "codeSignEntitlements": "codeSignEntitlements-macos",
+    "codeSignIdentity": "codeSignIdentity-macos",
+    "developmentTeam": "developmentTeam-macos",
     "reactNativePath": "react-native-macos"
   }
 }

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -127,26 +127,13 @@ class TestTestApp < Minitest::Test
       assert_nil(bundle_identifier(fixture_path('without_resources'), target))
     end
 
-    define_method("test_#{target}_code_sign_settings") do
-      %w[codeSignEntitlements codeSignIdentity developmentTeam].each do |setting|
+    define_method("test_#{target}_project_settings") do
+      %w[codeSignEntitlements codeSignIdentity developmentTeam reactNativePath].each do |setting|
         assert_equal("#{setting}-#{target}",
                      platform_config(setting, fixture_path('with_platform_resources'), target))
         assert_nil(platform_config(setting, fixture_path('without_platform_resources'), target))
         assert_nil(platform_config(setting, fixture_path('without_resources'), target))
       end
-    end
-
-    define_method("test_#{target}_react_native_path") do
-      assert_equal("react-native-#{target}",
-                   platform_config('reactNativePath',
-                                   fixture_path('with_platform_resources'),
-                                   target))
-      assert_nil(platform_config('reactNativePath',
-                                 fixture_path('without_platform_resources'),
-                                 target))
-      assert_nil(platform_config('reactNativePath',
-                                 fixture_path('without_resources'),
-                                 target))
     end
 
     define_method("test_#{target}_resources_pod_returns_spec_path") do

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -127,11 +127,26 @@ class TestTestApp < Minitest::Test
       assert_nil(bundle_identifier(fixture_path('without_resources'), target))
     end
 
+    define_method("test_#{target}_code_sign_settings") do
+      %w[codeSignEntitlements codeSignIdentity developmentTeam].each do |setting|
+        assert_equal("#{setting}-#{target}",
+                     platform_config(setting, fixture_path('with_platform_resources'), target))
+        assert_nil(platform_config(setting, fixture_path('without_platform_resources'), target))
+        assert_nil(platform_config(setting, fixture_path('without_resources'), target))
+      end
+    end
+
     define_method("test_#{target}_react_native_path") do
       assert_equal("react-native-#{target}",
-                   react_native_from_manifest(fixture_path('with_platform_resources'), target))
-      assert_nil(react_native_from_manifest(fixture_path('without_platform_resources'), target))
-      assert_nil(react_native_from_manifest(fixture_path('without_resources'), target))
+                   platform_config('reactNativePath',
+                                   fixture_path('with_platform_resources'),
+                                   target))
+      assert_nil(platform_config('reactNativePath',
+                                 fixture_path('without_platform_resources'),
+                                 target))
+      assert_nil(platform_config('reactNativePath',
+                                 fixture_path('without_resources'),
+                                 target))
     end
 
     define_method("test_#{target}_resources_pod_returns_spec_path") do

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -190,4 +190,19 @@ class TestTestApp < Minitest::Test
       GC.enable
     end
   end
+
+  def test_macos_project_cannot_set_development_team
+    # Xcode expects the development team used for code signing to exist when
+    # targeting macOS. Unlike when targeting iOS, the warnings are treated as
+    # errors.
+    require 'xcodeproj'
+
+    project = Xcodeproj::Project.open('macos/ReactTestApp.xcodeproj')
+    test_app = project.targets.detect { |target| target.name == 'ReactTestApp' }
+    assert(test_app)
+    test_app.build_configurations.each do |config|
+      assert_equal('-', config.build_settings['CODE_SIGN_IDENTITY'])
+      assert_nil(config.build_settings['DEVELOPMENT_TEAM'])
+    end
+  end
 end


### PR DESCRIPTION
### Description

macOS test app fails to build after #553:

- No account for team "UBF8T346G9". Add a new account in the Accounts preference pane or verify that your accounts have valid credentials.
- No profiles for 'com.microsoft.ReactTestApp' were found: Xcode couldn't find any Mac App Development provisioning profiles matching 'com.microsoft.ReactTestApp'.

Reverts the code signing changes made to the macOS Xcode project, and adds the ability to configure code signing from the app manifest.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. macOS test app should build again.
2. Signing should work if configured correctly, e.g.
   ```diff
   diff --git a/example/app.json b/example/app.json
   index 8463354..557e1f1 100644
   --- a/example/app.json
   +++ b/example/app.json
   @@ -12,6 +12,12 @@
          "presentationStyle": "modal"
        }
      ],
   +  "macos": {
   +    "bundleIdentifier": "com.contoso.ReactTestApp",
   +    "codeSignEntitlements": "macos/Example.entitlements",
   +    "codeSignIdentity": "Apple Development",
   +    "developmentTeam": "UBF8T346G9"
   +  },
      "resources": {
        "android": [
          "dist/res",
   ```
