### PR TITLE
fix(apple): allow platform deployment target to be overridden

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -441,7 +441,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   Example-Tests: 01d78c8a632185acbdb2d5de901be86fc11494e5
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
@@ -453,7 +453,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
@@ -478,7 +478,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   ReactTestApp-DevSupport: ec05fb157fa71580397d7a6a9c3ee10202235c02
-  ReactTestApp-Resources: 15cdcdc66d0a6ef3e78dc2523a6bb6d0b88835ab
+  ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -385,7 +385,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: bfbdf6dbfc0d4f30345c69ed18b670a26ad9ad61
   ReactCommon: 94179103b7453e19658f3cbb4a8af974dde0b42a
   ReactTestApp-DevSupport: ec05fb157fa71580397d7a6a9c3ee10202235c02
-  ReactTestApp-Resources: 4791cb085c4a05930792ae7206240bcc6813e539
+  ReactTestApp-Resources: bb546b3a5dca4b7931bee423d4ef28cd94b346cf
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: f651917957f3ecdbbb7b27e63d0b77503eb9ad70
 

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -137,22 +137,20 @@ class TestTestApp < Minitest::Test
     end
 
     define_method("test_#{target}_resources_pod_returns_spec_path") do
-      assert_nil(resources_pod(Pathname.new('/'), target))
-      assert_nil(resources_pod(Pathname.new('.'), target))
+      platforms = { :ios => '14.0', :macos => '11.0' }
 
-      assert_equal('.', resources_pod(fixture_path('without_resources'), target))
-      assert_equal('..', resources_pod(fixture_path('without_resources', target.to_s), target))
+      assert_nil(resources_pod(Pathname.new('/'), target, platforms))
+      assert_nil(resources_pod(Pathname.new('.'), target, platforms))
 
-      assert_equal('.', resources_pod(fixture_path('without_platform_resources'), target))
-      assert_equal('..',
-                   resources_pod(fixture_path('without_platform_resources', target.to_s), target))
-
-      assert_equal('.', resources_pod(fixture_path('with_resources'), target))
-      assert_equal('..', resources_pod(fixture_path('with_resources', target.to_s), target))
-
-      assert_equal('.', resources_pod(fixture_path('with_platform_resources'), target))
-      assert_equal('..',
-                   resources_pod(fixture_path('with_platform_resources', target.to_s), target))
+      %w[
+        without_resources
+        without_platform_resources
+        with_resources
+        with_platform_resources
+      ].each do |fixture|
+        assert_equal('.', resources_pod(fixture_path(fixture), target, platforms))
+        assert_equal('..', resources_pod(fixture_path(fixture, target.to_s), target, platforms))
+      end
     end
 
     define_method("test_#{target}_resources_pod_writes_podspec") do
@@ -161,6 +159,7 @@ class TestTestApp < Minitest::Test
       # variances.
       GC.disable
 
+      platforms = { :ios => '14.0', :macos => '11.0' }
       resources = %w[app.json dist/assets dist/main.jsbundle]
       platform_resources = ['app.json', "dist-#{target}/assets", "dist-#{target}/main.jsbundle"]
 
@@ -174,7 +173,7 @@ class TestTestApp < Minitest::Test
         fixture_path('without_resources'),
         fixture_path('without_resources', target.to_s),
       ].each do |project_root|
-        podspec_path = resources_pod(project_root, target)
+        podspec_path = resources_pod(project_root, target, platforms)
         manifest_path = app_manifest_path(project_root, podspec_path)
         manifest = JSON.parse(File.read(manifest_path))
 


### PR DESCRIPTION
### Description

Allows users to override platform deployment target.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Specifying deployment target should not fail `pod install`:

```diff
diff --git a/example/ios/Podfile b/example/ios/Podfile
index 03911b5..f46ebe0 100644
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,3 +1,4 @@
+platform :ios, '14.0'
 require_relative '../node_modules/react-native-test-app/test_app'

 workspace 'Example.xcworkspace'
```