### PR TITLE
fix: add support for react-native 0.67

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -323,7 +323,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.44.0)
+  - SwiftLint (0.45.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -505,7 +505,7 @@ SPEC CHECKSUMS:
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
   ReactTestApp-DevSupport: 84b7cc35cf707c9ceb3aae756f098354f5641cd8
   ReactTestApp-Resources: 74a1cf509f4e7962b16361ea4e73cba3648fff5d
-  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.44.0)
+  - SwiftLint (0.45.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -416,7 +416,7 @@ SPEC CHECKSUMS:
   ReactCommon: c710dabcfbc8f09c20e98aa03e8a98965b88f6dd
   ReactTestApp-DevSupport: 84b7cc35cf707c9ceb3aae756f098354f5641cd8
   ReactTestApp-Resources: bb546b3a5dca4b7931bee423d4ef28cd94b346cf
-  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   Yoga: 3b0ecc1a0ddf03b4363ea73cc42e10d76b052007
 
 PODFILE CHECKSUM: 39314e677d5ddf7e1e4c81e5e81f66cddabd661a

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     "@react-native-community/cli-platform-ios": ">=4.10.0",
     "mustache": "^4.0.0",
     "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
-    "react-native": "^0.0.0-0 || ^0.60 || ^0.61 || ^0.62 || ^0.63 || ^0.64 || ^0.65 || ^0.66 || 1000.0.0",
-    "react-native-macos": "^0.0.0-0 || ^0.60 || ^0.61 || ^0.62 || ^0.63 || ^0.64",
-    "react-native-windows": "^0.0.0-0 || ^0.62 || ^0.63 || ^0.64 || ^0.65 || ^0.66"
+    "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0",
+    "react-native-macos": "^0.0.0-0 || 0.60 - 0.64",
+    "react-native-windows": "^0.0.0-0 || 0.62 - 0.67"
   },
   "peerDependenciesMeta": {
     "@react-native-community/cli": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10509,9 +10509,9 @@ __metadata:
     "@react-native-community/cli-platform-ios": ">=4.10.0"
     mustache: ^4.0.0
     react: ~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2
-    react-native: ^0.0.0-0 || ^0.60 || ^0.61 || ^0.62 || ^0.63 || ^0.64 || ^0.65 || ^0.66 || 1000.0.0
-    react-native-macos: ^0.0.0-0 || ^0.60 || ^0.61 || ^0.62 || ^0.63 || ^0.64
-    react-native-windows: ^0.0.0-0 || ^0.62 || ^0.63 || ^0.64 || ^0.65 || ^0.66
+    react-native: ^0.0.0-0 || 0.60 - 0.67 || 1000.0.0
+    react-native-macos: ^0.0.0-0 || 0.60 - 0.64
+    react-native-windows: ^0.0.0-0 || 0.62 - 0.67
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true


### PR DESCRIPTION
### Description

Add support for react-native 0.67

Discussion: https://github.com/reactwg/react-native-releases/discussions/1

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [x] Windows

### Test plan

1. Set react-native version: `npm run set-react-version 0.67`
2. Run `yarn`
3. Ensure that the test apps build and run
   - [x] Android
   - [x] iOS (Hermes)
   - [x] iOS (JSC)
   - [x] Windows

| Platform | Home | App |
| :-: | :-: | :-: |
| Android | ![Screenshot_1634754984](https://user-images.githubusercontent.com/4123478/138151760-f1352ec2-a8e2-4b97-908d-19f28a457e28.png) | ![Screenshot_1634754989](https://user-images.githubusercontent.com/4123478/138151772-67d3590c-5d4f-4df0-8c4c-43a69c3269d2.png) |
| iOS (Hermes) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-10-19 at 13 06 04](https://user-images.githubusercontent.com/4123478/137897596-703e8999-91f8-43d7-991c-00ae9669124e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-10-19 at 13 06 06](https://user-images.githubusercontent.com/4123478/137897609-cfc0c02f-9ba8-4d7a-b37b-3e222df80c76.png) |
| iOS (JSC) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-10-19 at 13 00 11](https://user-images.githubusercontent.com/4123478/137896846-033e77ab-6590-4c89-ae37-87fd6a2f6c64.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-10-19 at 13 00 12](https://user-images.githubusercontent.com/4123478/137896893-36987060-9bb4-4df3-8666-a79934de42d3.png) |
| Windows | n/a | ![image](https://user-images.githubusercontent.com/4123478/138865825-52bdef79-0c2d-4e34-93be-1fe830cb2a88.png) |