### PR TITLE
test(android): run unit tests locally to speed up Android CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
     strategy:
       matrix:
         template: [all, android]
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'schedule' && !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
     name: "Android"
     strategy:
       matrix:
-        os: [macos-11, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'schedule' && !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
@@ -232,7 +232,7 @@ jobs:
         run: |
           yarn jest
         working-directory: example
-      - name: Build
+      - name: Build + Test
         run: |
           set -eo pipefail
           yarn build:android || yarn build:android
@@ -240,15 +240,6 @@ jobs:
           ./gradlew clean build check test
         shell: bash
         working-directory: example
-      - name: Run instrumented tests
-        if: ${{ matrix.os == 'macos-11' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          target: google_apis # https://github.com/ReactiveCircus/android-emulator-runner/issues/168
-          working-directory: android
-          script: ./gradlew clean build connectedCheck
-        continue-on-error: true
   android-template:
     name: "Android [template]"
     strategy:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     }
 
     implementation libraries.kotlinStdlibJdk7
+    implementation libraries.kotlinStdlibJdk8
     implementation libraries.kotlinReflect
     implementation libraries.androidAppCompat
     implementation libraries.androidCoreKotlinExtensions
@@ -139,6 +140,8 @@ dependencies {
     kapt libraries.moshiKotlinCodegen
 
     testImplementation libraries.junit
+    testImplementation libraries.androidJUnitKotlinExtensions
+    testImplementation libraries.mockitoInline
     androidTestImplementation libraries.androidJUnit
     androidTestImplementation libraries.androidEspressoCore
 

--- a/android/app/src/test/java/com/microsoft/reacttestapp/ManifestTest.kt
+++ b/android/app/src/test/java/com/microsoft/reacttestapp/ManifestTest.kt
@@ -1,5 +1,11 @@
 package com.microsoft.reacttestapp
 
+import android.os.Bundle
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
 import com.microsoft.reacttestapp.manifest.Manifest
 import com.microsoft.reacttestapp.manifest.ManifestJsonAdapter
 import com.microsoft.reacttestapp.manifest.MoshiBundleAdapter
@@ -9,7 +15,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockedConstruction
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
 
+@RunWith(MockitoJUnitRunner::class)
 class ManifestTest {
     private lateinit var adapter: JsonAdapter<Manifest>
 
@@ -43,6 +55,9 @@ class ManifestTest {
             }
         """
 
+        val mockedBundle = mockBundle()
+        val mockedArguments = mockArguments()
+
         val manifest = adapter.fromJson(json)
         assertNotNull(manifest)
 
@@ -64,6 +79,39 @@ class ManifestTest {
             val propsTwo = componentTwo.initialProperties
             assertNotNull(propsTwo)
             assertEquals("value_2", propsTwo?.get("prop_2").toString())
+        }
+
+        mockedArguments.close()
+        mockedBundle.close()
+    }
+
+    private fun mockArguments(): MockedStatic<Arguments> {
+        val mockedArguments = Mockito.mockStatic(Arguments::class.java)
+        mockedArguments
+            .`when`<WritableArray> { Arguments.createArray() }
+            .thenReturn(JavaOnlyArray())
+        mockedArguments
+            .`when`<WritableMap> { Arguments.createMap() }
+            .thenReturn(JavaOnlyMap())
+        mockedArguments
+            .`when`<Bundle> { Arguments.toBundle(Mockito.any()) }
+            .thenAnswer { it.callRealMethod() }
+        return mockedArguments
+    }
+
+    private fun mockBundle(): MockedConstruction<Bundle> {
+        val map = HashMap<String, Any>()
+        return Mockito.mockConstruction(Bundle::class.java) { mock, _ ->
+            Mockito.doAnswer { map[it.getArgument(0)] }.`when`(mock).get(Mockito.anyString())
+
+            Mockito.doAnswer {
+                val key = it.getArgument<String>(0)
+                val value = it.getArgument<Any>(1)
+                map[key] = value
+                null
+            }.`when`(mock).putString(Mockito.anyString(), Mockito.any())
+
+            Mockito.doAnswer { map.toString() }.`when`(mock).toString()
         }
     }
 }

--- a/android/app/src/test/java/com/microsoft/reacttestapp/ManifestTest.kt
+++ b/android/app/src/test/java/com/microsoft/reacttestapp/ManifestTest.kt
@@ -55,34 +55,30 @@ class ManifestTest {
             }
         """
 
-        val mockedBundle = mockBundle()
-        val mockedArguments = mockArguments()
+        useMocks {
+            val manifest = adapter.fromJson(json)
+            assertNotNull(manifest)
 
-        val manifest = adapter.fromJson(json)
-        assertNotNull(manifest)
+            manifest?.apply {
+                assertEquals(2, components.size)
 
-        manifest?.apply {
-            assertEquals(2, components.size)
+                val componentOne = components[0]
+                assertEquals("Example", componentOne.appKey)
+                assertEquals("App", componentOne.displayName)
 
-            val componentOne = components[0]
-            assertEquals("Example", componentOne.appKey)
-            assertEquals("App", componentOne.displayName)
+                val propsOne = componentOne.initialProperties
+                assertNotNull(propsOne)
+                assertEquals("value_1", propsOne?.get("prop_1").toString())
 
-            val propsOne = componentOne.initialProperties
-            assertNotNull(propsOne)
-            assertEquals("value_1", propsOne?.get("prop_1").toString())
+                val componentTwo = components[1]
+                assertEquals("Example2", componentTwo.appKey)
+                assertEquals("App2", componentTwo.displayName)
 
-            val componentTwo = components[1]
-            assertEquals("Example2", componentTwo.appKey)
-            assertEquals("App2", componentTwo.displayName)
-
-            val propsTwo = componentTwo.initialProperties
-            assertNotNull(propsTwo)
-            assertEquals("value_2", propsTwo?.get("prop_2").toString())
+                val propsTwo = componentTwo.initialProperties
+                assertNotNull(propsTwo)
+                assertEquals("value_2", propsTwo?.get("prop_2").toString())
+            }
         }
-
-        mockedArguments.close()
-        mockedBundle.close()
     }
 
     private fun mockArguments(): MockedStatic<Arguments> {
@@ -112,6 +108,14 @@ class ManifestTest {
             }.`when`(mock).putString(Mockito.anyString(), Mockito.any())
 
             Mockito.doAnswer { map.toString() }.`when`(mock).toString()
+        }
+    }
+
+    private fun useMocks(test: () -> Unit) {
+        mockBundle().use {
+            mockArguments().use {
+                test()
+            }
         }
     }
 }

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -22,18 +22,21 @@ ext {
      * See https://github.com/dependabot/feedback/issues/345.
      */
     libraries = [
-        androidAppCompat           : "androidx.appcompat:appcompat:1.3.1",
-        androidCoreKotlinExtensions: "androidx.core:core-ktx:1.6.0",
-        androidEspressoCore        : "androidx.test.espresso:espresso-core:3.4.0",
-        androidJUnit               : "androidx.test.ext:junit:1.1.3",
-        androidRecyclerView        : "androidx.recyclerview:recyclerview:1.2.1",
-        androidSwipeRefreshLayout  : "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
-        junit                      : "junit:junit:4.13.2",
-        kotlinReflect              : "org.jetbrains.kotlin:kotlin-reflect:1.5.31",
-        kotlinStdlibJdk7           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31",
-        materialComponents         : "com.google.android.material:material:1.4.0",
-        moshiKotlin                : "com.squareup.moshi:moshi-kotlin:1.12.0",
-        moshiKotlinCodegen         : "com.squareup.moshi:moshi-kotlin-codegen:1.12.0",
+        androidAppCompat            : "androidx.appcompat:appcompat:1.3.1",
+        androidCoreKotlinExtensions : "androidx.core:core-ktx:1.6.0",
+        androidEspressoCore         : "androidx.test.espresso:espresso-core:3.4.0",
+        androidJUnit                : "androidx.test.ext:junit:1.1.3",
+        androidJUnitKotlinExtensions: "androidx.test.ext:junit-ktx:1.1.3",
+        androidRecyclerView         : "androidx.recyclerview:recyclerview:1.2.1",
+        androidSwipeRefreshLayout   : "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+        junit                       : "junit:junit:4.13.2",
+        kotlinReflect               : "org.jetbrains.kotlin:kotlin-reflect:1.5.31",
+        kotlinStdlibJdk7            : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31",
+        kotlinStdlibJdk8            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31",
+        materialComponents          : "com.google.android.material:material:1.4.0",
+        mockitoInline               : "org.mockito:mockito-inline:4.0.0",
+        moshiKotlin                 : "com.squareup.moshi:moshi-kotlin:1.12.0",
+        moshiKotlinCodegen          : "com.squareup.moshi:moshi-kotlin-codegen:1.12.0",
     ]
 
     androidPluginVersion = "4.2.2"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Failed to transform '/~/bcprov-jdk15on-1.68.jar' using Jetifier.
+# Reason: IllegalArgumentException, message: Unsupported class file major version 59.
+android.jetifier.ignorelist=bcprov-jdk15on

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "format:swift": "swiftformat --swiftversion 5.3 ios macos",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | commitlint",
     "lint:js": "eslint $(git ls-files '*.js') && tsc",
-    "lint:kt": "ktlint --relative --verbose 'android/**/*.kt'",
+    "lint:kt": "ktlint --relative --verbose 'android/app/src/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",
     "set-react-version": "node scripts/set-react-version.js",


### PR DESCRIPTION
### Description

Run unit tests locally to speed up Android CI, and switch to Ubuntu VMs since they are both faster and more reliable.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Building/testing Android should be faster.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/4123478/138575615-8658ca55-2ed1-4233-bb1e-2ab248fc409e.png) | ![image](https://user-images.githubusercontent.com/4123478/138575633-8630ea1a-b620-40ad-9f85-53fe8bdeadb1.png) |