### PR TITLE
fix(android): recommend appropriate Flipper version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,6 +86,11 @@ android {
         versionCode reactTestApp.versionCode
         versionName reactTestApp.versionName
 
+        def recommendedFlipperVersion = getFlipperRecommendedVersion(rootDir)
+        buildConfigField "String",
+                         "ReactTestApp_recommendedFlipperVersion",
+                         recommendedFlipperVersion ? "\"${recommendedFlipperVersion}\"" : '"0"'
+
         resValue "string", "app_name", project.ext.react.appName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -16,6 +16,7 @@ import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import com.facebook.react.modules.systeminfo.ReactNativeVersion
 import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.BuildConfig
 import com.microsoft.reacttestapp.R
@@ -82,12 +83,17 @@ class TestAppReactNativeHost(
                     .getMethod("initialize", Context::class.java, ReactInstanceManager::class.java)
                     .invoke(null, application, reactInstanceManager)
             } catch (e: ClassNotFoundException) {
-                Log.i(
-                    "ReactTestApp",
-                    "To use Flipper, define `FLIPPER_VERSION` in your `gradle.properties`. " +
-                        "If you're using React Native 0.63, you should use " +
-                        "`FLIPPER_VERSION=0.54.0`."
-                )
+                val flipperVersion = BuildConfig.ReactTestApp_recommendedFlipperVersion
+                if (flipperVersion != "0") {
+                    val major = ReactNativeVersion.VERSION["major"] as Int
+                    val minor = ReactNativeVersion.VERSION["minor"] as Int
+                    Log.i(
+                        "ReactTestApp",
+                        "To use Flipper, define `FLIPPER_VERSION` in your `gradle.properties`. " +
+                            "Since you're using React Native ${major}.${minor}, we recommend " +
+                            "setting `FLIPPER_VERSION=${flipperVersion}`."
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -90,8 +90,8 @@ class TestAppReactNativeHost(
                     Log.i(
                         "ReactTestApp",
                         "To use Flipper, define `FLIPPER_VERSION` in your `gradle.properties`. " +
-                            "Since you're using React Native ${major}.${minor}, we recommend " +
-                            "setting `FLIPPER_VERSION=${flipperVersion}`."
+                            "Since you're using React Native $major.$minor, we recommend setting " +
+                            "`FLIPPER_VERSION=$flipperVersion`."
                     )
                 }
             }

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -111,14 +111,18 @@ ext.getApplicationId = { baseDir ->
     return 'com.microsoft.reacttestapp'
 }
 
-ext.getFlipperVersion = { baseDir ->
+ext.getFlipperRecommendedVersion = { baseDir ->
     def reactNativePath = findNodeModulesPath(baseDir, 'react-native')
     def props = new Properties()
     file("${reactNativePath}/template/android/gradle.properties").withInputStream {
         props.load(it)
     }
 
-    def recommendedFlipperVersion = props.getProperty('FLIPPER_VERSION')
+    return props.getProperty('FLIPPER_VERSION')
+}
+
+ext.getFlipperVersion = { baseDir ->
+    def recommendedFlipperVersion = getFlipperRecommendedVersion(baseDir)
     if (recommendedFlipperVersion == null) {
         // Current React Native version doesn't support Flipper
         return null


### PR DESCRIPTION
### Description

Recommend the appropriate Flipper version for currently running React Native version.

Resolves #526.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

- By default, Flipper is enabled and we should get the output below.
- If `FLIPPER_VERSION=false`, or current React Native version does not support Flipper, we should not get any output. 

Example output:
```
2021-10-26 14:58:28.010 8125-8125/com.microsoft.reacttestapp I/ReactTestApp: To use Flipper, define `FLIPPER_VERSION` in your `gradle.properties`. Since you're using React Native 0.63, we recommend setting `FLIPPER_VERSION=0.54.0`.
```