### PR TITLE
ci: remove Podfile.lock when building nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
           # details.
           npm run set-react-version main
           yarn --no-immutable
+          rm example/ios/Podfile.lock
       - name: Install
         if: ${{ github.event_name != 'schedule' }}
         run: |
@@ -307,6 +308,7 @@ jobs:
         run: |
           npm run set-react-version canary-macos
           yarn --no-immutable
+          rm example/macos/Podfile.lock
         shell: bash
       - name: Install
         if: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
### Description

This prevents errors of type 'CocoaPods could not find compatible
versions for pod X', requiring manual intervention.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

This only affects nightly builds.