### PR TITLE
chore: set-react-version should fetch versions from npm

### DIFF
--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -79,6 +79,24 @@ function fetchPackageInfo(pkg) {
 }
 
 /**
+ * Returns an object with common dependencies.
+ * @param {Manifest["dependencies"]} dependencies
+ * @param {Manifest["peerDependencies"]} peerDependencies
+ * @return {Record<string, string | undefined>}
+ */
+function pickCommonDependencies(dependencies, peerDependencies) {
+  return {
+    "@react-native-community/cli": dependencies["@react-native-community/cli"],
+    "@react-native-community/cli-platform-android":
+      dependencies["@react-native-community/cli-platform-android"],
+    "@react-native-community/cli-platform-ios":
+      dependencies["@react-native-community/cli-platform-ios"],
+    "hermes-engine": dependencies["hermes-engine"],
+    react: peerDependencies["react"],
+  };
+}
+
+/**
  * Returns a profile for specified version.
  * @param {string} v
  * @return {Promise<Record<string, string | undefined>>}
@@ -90,14 +108,7 @@ async function getProfile(v) {
         "react-native-macos@canary"
       );
       return {
-        "@react-native-community/cli":
-          dependencies["@react-native-community/cli"],
-        "@react-native-community/cli-platform-android":
-          dependencies["@react-native-community/cli-platform-android"],
-        "@react-native-community/cli-platform-ios":
-          dependencies["@react-native-community/cli-platform-ios"],
-        "hermes-engine": dependencies["hermes-engine"],
-        react: peerDependencies["react"],
+        ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": REACT_NATIVE_VERSIONS[v],
         "react-native-macos": "canary",
         "react-native-windows": undefined,
@@ -109,14 +120,7 @@ async function getProfile(v) {
         "react-native-windows@canary"
       );
       return {
-        "@react-native-community/cli":
-          dependencies["@react-native-community/cli"],
-        "@react-native-community/cli-platform-android":
-          dependencies["@react-native-community/cli-platform-android"],
-        "@react-native-community/cli-platform-ios":
-          dependencies["@react-native-community/cli-platform-ios"],
-        "hermes-engine": dependencies["hermes-engine"],
-        react: peerDependencies["react"],
+        ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": REACT_NATIVE_VERSIONS[v],
         "react-native-macos": undefined,
         "react-native-windows": "canary",
@@ -128,14 +132,7 @@ async function getProfile(v) {
         "react-native@nightly"
       );
       return {
-        "@react-native-community/cli":
-          dependencies["@react-native-community/cli"],
-        "@react-native-community/cli-platform-android":
-          dependencies["@react-native-community/cli-platform-android"],
-        "@react-native-community/cli-platform-ios":
-          dependencies["@react-native-community/cli-platform-ios"],
-        "hermes-engine": dependencies["hermes-engine"],
-        react: peerDependencies["react"],
+        ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": "facebook/react-native",
         "react-native-macos": undefined,
         "react-native-windows": undefined,
@@ -147,14 +144,7 @@ async function getProfile(v) {
         "react-native@nightly"
       );
       return {
-        "@react-native-community/cli":
-          dependencies["@react-native-community/cli"],
-        "@react-native-community/cli-platform-android":
-          dependencies["@react-native-community/cli-platform-android"],
-        "@react-native-community/cli-platform-ios":
-          dependencies["@react-native-community/cli-platform-ios"],
-        "hermes-engine": dependencies["hermes-engine"],
-        react: peerDependencies["react"],
+        ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": "nightly",
         "react-native-macos": undefined,
         "react-native-windows": undefined,
@@ -172,14 +162,7 @@ async function getProfile(v) {
         fetchPackageInfo(`react-native-windows@^${v}.0-0`),
       ]);
       return {
-        "@react-native-community/cli":
-          dependencies["@react-native-community/cli"],
-        "@react-native-community/cli-platform-android":
-          dependencies["@react-native-community/cli-platform-android"],
-        "@react-native-community/cli-platform-ios":
-          dependencies["@react-native-community/cli-platform-ios"],
-        "hermes-engine": dependencies["hermes-engine"],
-        react: peerDependencies["react"],
+        ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": rnVersion,
         "react-native-macos": rnmVersion,
         "react-native-windows": rnwVersion,

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -191,7 +191,9 @@ async function getProfile(v) {
 const { [2]: version } = process.argv;
 if (!isValidVersion(version)) {
   const script = require("path").basename(__filename);
-  console.log(`Usage: ${script} [<version number> | ${VALID_TAGS.join(" | ")}]`);
+  console.log(
+    `Usage: ${script} [<version number> | ${VALID_TAGS.join(" | ")}]`
+  );
   process.exit(1);
 }
 

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -22,7 +22,7 @@ const REACT_NATIVE_VERSIONS = {
 };
 
 /**
- * Returns specified string is a valid version.
+ * Returns whether specified string is a valid version number.
  * @param {string} v
  * @return {boolean}
  */


### PR DESCRIPTION
### Description

`set-react-version` should fetch latest information from npm so we don't have to maintain this list manually.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
% npm run set-react-version 0.60
{
  '@react-native-community/cli': '^2.6.0',
  '@react-native-community/cli-platform-android': '^2.6.0',
  '@react-native-community/cli-platform-ios': '^2.4.1',
  'hermes-engine': undefined,
  react: '16.8.6',
  'react-native': '0.60.6',
  'react-native-macos': '0.60.0-microsoft.79',
  'react-native-windows': '0.60.0-vnext.172'
}
```

```
% npm run set-react-version 0.66
{
  '@react-native-community/cli': '^6.0.0',
  '@react-native-community/cli-platform-android': '^6.0.0',
  '@react-native-community/cli-platform-ios': '^6.0.0',
  'hermes-engine': '~0.9.0',
  react: '17.0.2',
  'react-native': '0.66.3',
  'react-native-macos': undefined,
  'react-native-windows': '0.66.3'
}
```

```
% npm run set-react-version main
{
  '@react-native-community/cli': '^6.0.0',
  '@react-native-community/cli-platform-android': '^6.0.0',
  '@react-native-community/cli-platform-ios': '^6.0.0',
  'hermes-engine': '~0.9.0',
  react: '17.0.2',
  'react-native': 'facebook/react-native',
  'react-native-macos': undefined,
  'react-native-windows': undefined
}
```

```
% npm run set-react-version nightly
{
  '@react-native-community/cli': '^6.0.0',
  '@react-native-community/cli-platform-android': '^6.0.0',
  '@react-native-community/cli-platform-ios': '^6.0.0',
  'hermes-engine': '~0.9.0',
  react: '17.0.2',
  'react-native': 'nightly',
  'react-native-macos': undefined,
  'react-native-windows': undefined
}
```

```
% npm run set-react-version canary-macos
{
  '@react-native-community/cli': '^4.13.0',
  '@react-native-community/cli-platform-android': '^4.13.0',
  '@react-native-community/cli-platform-ios': '^4.13.0',
  'hermes-engine': '~0.7.0',
  react: '17.0.1',
  'react-native': '^0.64',
  'react-native-macos': 'canary',
  'react-native-windows': undefined
}
```

```
% npm run set-react-version canary-windows
{
  '@react-native-community/cli': '^6.0.0',
  '@react-native-community/cli-platform-android': '^6.0.0',
  '@react-native-community/cli-platform-ios': '^6.0.0',
  'hermes-engine': '~0.9.0',
  react: '17.0.2',
  'react-native': '^0.67.0-0',
  'react-native-macos': undefined,
  'react-native-windows': 'canary'
}
```