### PR TITLE
[chore] Add reference to the RNEU talk in the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,10 @@ additional questions or comments.
 
 ## Commit messages
 
-This repository adheres to the [conventional commit format](https://conventionalcommits.org) via [commitlint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint). Commit messages must match the pattern:
+This repository adheres to the
+[conventional commit format](https://conventionalcommits.org) via
+[commitlint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint).
+Commit messages must match the pattern:
 
 ```sh
 type(scope?): subject  #scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,16 @@ For more information see the
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
 
+## Commit messages
+
+This repository adheres to the [conventional commit format](https://conventionalcommits.org) via [commitlint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint). Commit messages must match the pattern:
+
+```sh
+type(scope?): subject  #scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")
+```
+
+Following this is necessary to pass CI.
+
 ## Additional Dependencies
 
 - Node LTS (see [releases](https://nodejs.org/en/about/releases/) for specific

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ React Native Test App provides test apps for all platforms as a package. It
 handles the native bits for you so you can focus on what's important: your
 product.
 
-If you want to learn how RNTA is used at Microsoft, and see a demo of how to add it to an existing library - you can watch the ["Improve all the repos – exploring Microsoft’s DevExp"](https://www.youtube.com/watch?v=DAEnPV78rQc) talk by @kelset and @tido64 from React Native Europe 2021.
+If you want to learn how RNTA is used at Microsoft, and see a demo of how to add
+it to an existing library - you can watch the
+["Improve all the repos – exploring Microsoft’s DevExp"](https://youtu.be/DAEnPV78rQc?t=499)
+talk by @kelset and @tido64 from React Native Europe 2021.
 
 For more about
 [the motivation](https://github.com/microsoft/react-native-test-app/wiki#motivation)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ React Native Test App provides test apps for all platforms as a package. It
 handles the native bits for you so you can focus on what's important: your
 product.
 
-If you want to learn more about
+If you want to learn how RNTA is used at Microsoft, and see a demo of how to add it to an existing library - you can watch the ["Improve all the repos – exploring Microsoft’s DevExp"](https://www.youtube.com/watch?v=DAEnPV78rQc) talk by @kelset and @tido64 from React Native Europe 2021.
+
+For more about
 [the motivation](https://github.com/microsoft/react-native-test-app/wiki#motivation)
-or [the design](https://github.com/microsoft/react-native-test-app/wiki/Design)
+and [the design](https://github.com/microsoft/react-native-test-app/wiki/Design)
 of this tool, you can refer to the wiki.
 
 ## Quick Start


### PR DESCRIPTION
Small PR to add a direct reference to the YT video in the readme: it should help provide some context and insights in how RNTA is meant to be used.

Plus bonus tweak to Contributing, adding a direct mention of the commitlint pattern.