### PR TITLE
ci: fix set-react-version on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,15 +398,10 @@ jobs:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}
       - name: Set up react-native@canary
-        if: ${{ github.event_name == 'schedule' }}
         run: |
           npm run set-react-version canary-windows
           yarn --no-immutable
         shell: bash
-      - name: Install
-        if: ${{ github.event_name != 'schedule' }}
-        run: |
-          yarn
       - name: Build bundle and create solution
         run: |
           yarn build:windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,10 +398,15 @@ jobs:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}
       - name: Set up react-native@canary
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           npm run set-react-version canary-windows
           yarn --no-immutable
         shell: bash
+      - name: Install
+        if: ${{ github.event_name != 'schedule' }}
+        run: |
+          yarn
       - name: Build bundle and create solution
         run: |
           yarn build:windows

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -7,6 +7,8 @@
 //
 // @ts-check
 
+const os = require("os");
+
 /**
  * @typedef {{
  *   version?: string;
@@ -50,7 +52,8 @@ function fetchPackageInfo(pkg) {
     /** @type {string[]} */
     const result = [];
 
-    const fetch = require("child_process").spawn("npm", [
+    const npm = os.platform() === "win32" ? "npm.cmd" : "npm";
+    const fetch = require("child_process").spawn(npm, [
       "view",
       "--json",
       pkg,
@@ -185,7 +188,6 @@ if (!isValidVersion(version)) {
   console.log(profile);
 
   const fs = require("fs");
-  const { EOL } = require("os");
 
   ["package.json", "example/package.json"].forEach((manifestPath) => {
     const content = fs.readFileSync(manifestPath, { encoding: "utf-8" });
@@ -197,7 +199,7 @@ if (!isValidVersion(version)) {
     const tmpFile = `${manifestPath}.tmp`;
     fs.writeFile(
       tmpFile,
-      JSON.stringify(manifest, undefined, 2) + EOL,
+      JSON.stringify(manifest, undefined, 2) + os.EOL,
       (err) => {
         if (err) {
           throw err;

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -53,11 +53,7 @@ function fetchPackageInfo(pkg) {
     const result = [];
 
     const npm = os.platform() === "win32" ? "npm.cmd" : "npm";
-    const fetch = require("child_process").spawn(npm, [
-      "view",
-      "--json",
-      pkg,
-    ]);
+    const fetch = require("child_process").spawn(npm, ["view", "--json", pkg]);
     fetch.stdout.on("data", (data) => {
       result.push(data);
     });


### PR DESCRIPTION
### Description

Nightly builds are failing on Windows machines:

```
> node scripts/set-react-version.js "canary-windows"

events.js:377
      throw er; // Unhandled 'error' event
      ^

Error: spawn npm ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:274:19)
    at onErrorNT (internal/child_process.js:469:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:280:12)
    at onErrorNT (internal/child_process.js:469:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ 'view', '--json', 'react-native-windows@canary' ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-native-test-app@0.0.1-dev set-react-version: `node scripts/set-react-version.js "canary-windows"`
npm ERR! Exit status 1
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Force building of react-native-windows@canary and make sure it succeeds.