### PR TITLE
fix(android): set `project.ext.minSdkVersion` for community modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,8 +59,8 @@ project.ext.react = [
 ]
 
 android {
-    compileSdkVersion sdk.version
-    buildToolsVersion sdk.buildToolsVersion
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     // We need only set `ndkVersion` when building react-native from source.
     if (hasProperty("ANDROID_NDK_VERSION")) {
@@ -81,8 +81,8 @@ android {
 
     defaultConfig {
         applicationId project.ext.react.applicationId
-        minSdkVersion sdk.minVersion
-        targetSdkVersion sdk.version
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
         versionCode reactTestApp.versionCode
         versionName reactTestApp.versionName
 

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -8,11 +8,10 @@ ext {
         versionName: "1.0"
     ]
 
-    sdk = [
-        version          : 29,
-        minVersion       : 21,
-        buildToolsVersion: "30.0.3"
-    ]
+    compileSdkVersion = 29
+    buildToolsVersion = "30.0.3"
+    minSdkVersion = 21
+    targetSdkVersion = 29
 
     /**
      * Dependabot requires a `dependencies.gradle` to evaluate Java

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -14,12 +14,12 @@ apply from: "$androidDir/force-resolve-trove4j.gradle"
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion sdk.version
-    buildToolsVersion sdk.buildToolsVersion
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion sdk.minVersion
-        targetSdkVersion sdk.version
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
         versionCode reactTestApp.versionCode
         versionName reactTestApp.versionName
     }


### PR DESCRIPTION
### Description

Test app fails to build when linked with native modules that require older SDK versions. For instance, `@react-native-community/slider`:

```
/Users/runner/work/1/s/node_modules/@react-native-community/slider/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger7906989633496071019.xml:5:5-74 Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.3] /Users/runner/.gradle/caches/transforms-3/eaa8686ae9818bf91937afd6b777f393/transformed/jetified-react-native-0.64.3/AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 21,
		or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```

Most of these modules try to read `rootProject.ext.minSdkVersion` (and others) before setting a default value. We just need to set them.

Examples:
- [`@react-native-async-storage/async-storage`](https://github.com/react-native-async-storage/async-storage/blob/0ec517c3b6e0020c4edc5a59519c4e3938707d76/android/build.gradle#L82)
- [`@react-native-community/slider`](https://github.com/callstack/react-native-slider/blob/da5d99bf1b853ee5bbf0bbf48ecf57a53fb216ef/src/android/build.gradle#L22-L30)
- [`@react-native-picker/picker`](https://github.com/react-native-picker/picker/blob/06d6b37ad1decdbb528b028fc875c7c7160eb100/android/build.gradle#L23-L32)

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Apply the changes directly to https://github.com/microsoft/fluentui-react-native/pull/1159 and verify that it builds locally.