### PR TITLE
chore: increase stability days for dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,5 +34,6 @@
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rangeStrategy": "update-lockfile",
+  "stabilityDays": 7,
   "timezone": "Europe/Oslo"
 }


### PR DESCRIPTION
### Description

Increase number of days before a dependency is updated: https://docs.renovatebot.com/configuration-options/#stabilitydays

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a