### PR TITLE
ci: disable semantic-release success comment to reduce spam

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,17 @@
     "branches": [
       "trunk"
     ],
-    "tagFormat": "${version}"
+    "tagFormat": "${version}",
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      [
+        "@semantic-release/github",
+        {
+          "successComment": false
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
### Description

semantic-release currently does not allow configuring when to post a success comment (see https://github.com/semantic-release/github/issues/361). This results in a lot of spam when it posts comments on unrelated issues and PRs.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a