### PR TITLE
fix(android): fix name clash when building with Gradle 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.86.0
         with:
-          ruby-version: '3.0'
+          ruby-version: "3.0"
           bundler: Gemfile.lock
           bundler-cache: true
       - name: Install

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -3,7 +3,7 @@ import org.gradle.initialization.DefaultSettings
 
 import java.nio.file.Paths
 
-private static void apply(Settings settings) {
+private static void applySettings(Settings settings) {
     def projectDir = settings.findNodeModulesPath(settings.rootDir, "react-native-test-app")
 
     if (settings.buildReactNativeFromSource(settings.rootDir)) {
@@ -43,7 +43,7 @@ ext.applyTestAppSettings = { DefaultSettings defaultSettings ->
         apply from: "$scriptDir/android/force-resolve-trove4j.gradle", to: scriptHandler
     }
 
-    apply(defaultSettings)
+    applySettings(defaultSettings)
     applyNativeModulesSettingsGradle(defaultSettings)
 }
 


### PR DESCRIPTION
### Description

Fixes a name clash when building the test app with Gradle 7:

```
A problem occurred evaluating script.
> No signature of method: static test_app_2f7bqu5tkk9dawnfc468sfds4.apply() is applicable for argument types: (LinkedHashMap) values: [[from:/~/node_modules/react-native-test-app/android/test-app-util.gradle]]
  Possible solutions: apply(groovy.lang.Closure), apply(java.util.Map), any(), copy(groovy.lang.Closure), copy(org.gradle.api.Action), any(groovy.lang.Closure)
```

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.