### PR TITLE
fix(android): additional config to better support Kotlin modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,10 +14,6 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
 }
 
 repositories {
@@ -30,6 +26,7 @@ repositories {
 
     // TODO: Remove these when they've been published to Maven Central.
     // See https://github.com/microsoft/react-native-test-app/issues/305
+    // noinspection JcenterRepositoryObsolete
     jcenter() {
         content {
             includeGroup("com.facebook.fbjni")

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,5 +9,6 @@ buildscript { scriptHandler ->
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidPluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -420,6 +420,7 @@ const getConfig = (() => {
               "",
               "    dependencies {",
               `        classpath "com.android.tools.build:gradle:$androidPluginVersion"`,
+              `        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"`,
               "    }",
               "}",
               ""

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -1,7 +1,6 @@
 import groovy.json.JsonSlurper
-import org.gradle.initialization.DefaultSettings
-
 import java.nio.file.Paths
+import org.gradle.initialization.DefaultSettings
 
 private static void applySettings(Settings settings) {
     def projectDir = settings.findNodeModulesPath(settings.rootDir, "react-native-test-app")

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -77,6 +77,7 @@ Object {
 
     dependencies {
         classpath \\"com.android.tools.build:gradle:$androidPluginVersion\\"
+        classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
     }
 }
 ",
@@ -487,6 +488,7 @@ Object {
 
     dependencies {
         classpath \\"com.android.tools.build:gradle:$androidPluginVersion\\"
+        classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
     }
 }
 ",
@@ -653,6 +655,7 @@ Object {
 
     dependencies {
         classpath \\"com.android.tools.build:gradle:$androidPluginVersion\\"
+        classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
     }
 }
 ",


### PR DESCRIPTION
### Description

Declare dependency on Kotlin at the root level to avoid duplicate plugins being applied.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.