### PR TITLE
fix(android): add config to support MSAL

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,6 +35,11 @@ repositories {
             includeGroup("com.facebook.yoga")
         }
     }
+
+    // https://github.com/AzureAD/microsoft-authentication-library-for-android#step-1-declare-dependency-on-msal
+    maven {
+        url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
+    }
 }
 
 apply from: "$projectDir/../force-resolve-trove4j.gradle"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.microsoft.reacttestapp">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application


### PR DESCRIPTION
### Description

Adds an extra Maven feed and an Android permission to support MSAL integration.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

There's nothing to test.