### PR TITLE
ci(nightlies): fetch latest react-native-windows canary from NuGet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,13 +400,13 @@ jobs:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}
       - name: Set up react-native@canary
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           npm run set-react-version canary-windows
           yarn --no-immutable
         shell: bash
       - name: Install
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name != 'schedule' }}
         run: |
           yarn
       - name: Build bundle and create solution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,13 +400,13 @@ jobs:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}
       - name: Set up react-native@canary
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name != 'schedule' }}
         run: |
           npm run set-react-version canary-windows
           yarn --no-immutable
         shell: bash
       - name: Install
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           yarn
       - name: Build bundle and create solution

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -7,6 +7,7 @@
 //
 // @ts-check
 
+const { spawn } = require("child_process");
 const os = require("os");
 
 /**
@@ -53,7 +54,7 @@ function fetchPackageInfo(pkg) {
     const result = [];
 
     const npm = os.platform() === "win32" ? "npm.cmd" : "npm";
-    const fetch = require("child_process").spawn(npm, ["view", "--json", pkg]);
+    const fetch = spawn(npm, ["view", "--json", pkg]);
     fetch.stdout.on("data", (data) => {
       result.push(data);
     });
@@ -75,6 +76,38 @@ function fetchPackageInfo(pkg) {
       }
     });
   });
+}
+
+/**
+ * Fetches the latest react-native-windows@canary information via NuGet.
+ * @return {Promise<Manifest>}
+ */
+function fetchReactNativeWindowsCanaryInfoViaNuGet() {
+  return new Promise((resolve) => {
+    const pattern = /Microsoft\.ReactNative\.Cxx ([-.\d]*canary[-.\d]*)/;
+
+    let isResolved = false;
+    const list = spawn("nuget.exe", [
+      "list",
+      "Microsoft.ReactNative.Cxx",
+      "-Source",
+      "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json",
+      "-AllVersions",
+      "-Prerelease",
+    ]);
+    list.stdout.on("data", (data) => {
+      if (isResolved) {
+        return;
+      }
+
+      const m = data.toString().match(pattern);
+      if (m) {
+        isResolved = true;
+        resolve(`react-native-windows@${m[1]}`);
+        list.kill();
+      }
+    });
+  }).then(fetchPackageInfo);
 }
 
 /**
@@ -115,14 +148,14 @@ async function getProfile(v) {
     }
 
     case "canary-windows": {
-      const { dependencies, peerDependencies } = await fetchPackageInfo(
-        "react-native-windows@canary"
-      );
+      const { version, dependencies, peerDependencies } = process.env["CI"]
+        ? await fetchReactNativeWindowsCanaryInfoViaNuGet()
+        : await fetchPackageInfo("react-native-windows@canary");
       return {
         ...pickCommonDependencies(dependencies, peerDependencies),
         "react-native": REACT_NATIVE_VERSIONS[v],
         "react-native-macos": undefined,
-        "react-native-windows": "canary",
+        "react-native-windows": version,
       };
     }
 

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -101,11 +101,14 @@ function fetchReactNativeWindowsCanaryInfoViaNuGet() {
       }
 
       const m = data.toString().match(pattern);
-      if (m) {
-        isResolved = true;
-        resolve(`react-native-windows@${m[1]}`);
-        list.kill();
+      if (!m) {
+        return;
       }
+
+      isResolved = true;
+      resolve(`react-native-windows@${m[1]}`);
+
+      list.kill();
     });
   }).then(fetchPackageInfo);
 }


### PR DESCRIPTION
### Description

Nightly builds with react-native-windows@canary often fail due to the NuGet feed being out of sync with npm.

- When the latest nightly was built, .422 was the latest canary and could not be found on the NuGet feed: https://github.com/microsoft/react-native-test-app/runs/4330499508?check_suite_focus=true
- When I reran the job, the latest became .423: https://github.com/microsoft/react-native-test-app/runs/4334664457?check_suite_focus=true
- With the fix, we are building .422 instead: https://github.com/microsoft/react-native-test-app/runs/4335061574?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

This "nightly" build should be green: https://github.com/microsoft/react-native-test-app/runs/4335061574?check_suite_focus=true