### PR TITLE
ci: fix conditional expressions in composite actions

### DIFF
--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -11,12 +11,12 @@ runs:
       uses: actions/cache@v2
       with:
         path: .yarn/cache
-        key: ${{ hashFiles('yarn.lock') }}
+        key: yarn-${{ inputs.immutable }}-${{ hashFiles('yarn.lock') }}
     - name: Install npm dependencies
-      if: ${{ inputs.immutable }}
+      if: ${{ inputs.immutable == 'true' }}
       run: yarn
       shell: bash
     - name: Install npm dependencies (ignore lockfile changes)
-      if: ${{ !inputs.immutable }}
+      if: ${{ inputs.immutable != 'true' }}
       run: yarn --no-immutable
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
-          immutable: ${{ github.event_name != 'schedule' }}
+          immutable: ${{ github.event_name == 'schedule' }}
       - name: Bundle JavaScript
         run: |
           set -eo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
-          immutable: ${{ github.event_name == 'schedule' }}
+          immutable: ${{ github.event_name != 'schedule' }}
       - name: Bundle JavaScript
         run: |
           set -eo pipefail


### PR DESCRIPTION
### Description

It doesn't look like booleans are being passed to composite actions as is, but are serialized or something.

Nightly builds are failing because yarn action passes `immutable` as a string instead of a boolean: https://github.com/microsoft/react-native-test-app/runs/4415712667?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.