### PR TITLE
ci: hash `yarn.lock` ourselves for better consistency

### DIFF
--- a/.github/actions/init-test-app/action.yml
+++ b/.github/actions/init-test-app/action.yml
@@ -7,11 +7,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Generate cache key
+      id: cache-key-generator
+      run: echo "::set-output name=cache-key::$(node scripts/shasum.js yarn.lock)"
+      shell: bash
     - name: Cache /.yarn/cache
       uses: actions/cache@v2
       with:
         path: .yarn/cache
-        key: ${{ hashFiles('yarn.lock') }}
+        key: yarn-true-${{ steps.cache-key-generator.outputs.cache-key }}
     - name: Install
       run: |
         scripts/install-test-template.sh ${{ inputs.platform }}

--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -7,11 +7,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Generate cache key
+      id: cache-key-generator
+      run: echo "::set-output name=cache-key::$(node scripts/shasum.js yarn.lock)"
+      shell: bash
     - name: Cache /.yarn/cache
       uses: actions/cache@v2
       with:
         path: .yarn/cache
-        key: yarn-${{ inputs.immutable }}-${{ hashFiles('yarn.lock') }}
+        key: yarn-${{ inputs.immutable }}-${{ steps.cache-key-generator.outputs.cache-key }}
     - name: Install npm dependencies
       if: ${{ inputs.immutable == 'true' }}
       run: yarn

--- a/scripts/shasum.js
+++ b/scripts/shasum.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * @param {string} filename
+ * @param {string=} algorithm
+ * @returns {string}
+ */
+function hashFile(filename, algorithm = "sha256") {
+  const data = require("fs")
+    .readFileSync(filename, { encoding: "utf-8" })
+    .replace(/\r/g, "");
+  return require("crypto").createHash(algorithm).update(data).digest("hex");
+}
+
+const { [2]: filename } = process.argv;
+console.log(hashFile(filename));


### PR DESCRIPTION
### Description

GitHub's `hashFiles()` function creates platform unique keys. Yarn's cache only contains tarballs and should be shareable across all platforms.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.