### PR TITLE
fix(android): app crashes when trying to render `TextInput`

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -21,7 +21,11 @@ ext {
      * See https://github.com/dependabot/feedback/issues/345.
      */
     libraries = [
-        androidAppCompat            : "androidx.appcompat:appcompat:1.4.0",
+        // androidx.appcompat:appcompat:1.4.0 breaks TextInput. For now, we
+        // need to lock it to 1.3.1 until the fix is released with the next
+        // version of react-native. For more details, see
+        // https://github.com/facebook/react-native/issues/31572.
+        androidAppCompat            : "androidx.appcompat:appcompat:1.3.1",
         androidCoreKotlinExtensions : "androidx.core:core-ktx:1.7.0",
         androidEspressoCore         : "androidx.test.espresso:espresso-core:3.4.0",
         androidJUnit                : "androidx.test.ext:junit:1.1.3",


### PR DESCRIPTION
### Description

The app crashes when trying to render `TextInput` with AppCompat Library at v1.4.0. For more details, see the GitHub issue:
https://github.com/facebook/react-native/issues/31572

This reverts commit 4c34c8c737d2c352fdf1ed8a268ceaefeb44fb3a.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a