### PR TITLE
chore(deps): group Moshi updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,11 @@
       "matchPackagePrefixes": ["org.jetbrains.kotlin:"]
     },
     {
+      "groupName": "Moshi",
+      "matchDatasources": ["maven"],
+      "matchPackagePrefixes": ["com.squareup.moshi:"]
+    },
+    {
       "matchPackageNames": ["org.jetbrains.intellij.deps:trove4j"],
       "enabled": false
     },


### PR DESCRIPTION
### Description

Group Moshi updates together to prevent them from going out of sync:

![image](https://user-images.githubusercontent.com/4123478/145454575-736ad437-0ea5-40d9-b24d-f548d8049168.png)

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a