### PR TITLE
chore(windows): script for renewing the self-signed test certificate

### DIFF
--- a/.github/workflows/renew-windows-certificate.yml
+++ b/.github/workflows/renew-windows-certificate.yml
@@ -1,8 +1,8 @@
 name: Reminder to Renew Self-signed Test Certificate
 on:
   schedule:
-    # 04:05 on Monday in January and June
-    - cron: 5 4 * 1,6 1
+    # 04:05 on Monday in January and July
+    - cron: 5 4 * 1,7 1
 jobs:
   create_issue:
     name: Create reminder
@@ -14,10 +14,19 @@ jobs:
         uses: imjohnbo/issue-bot@v3.3.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Renew self-signed test certificate"
+          title: Renew self-signed test certificate
           body: |
-            The self-signed test certificate for ReactTestApp on Windows is about to expire. For more information about renewing certificates, see http://go.microsoft.com/fwlink/?LinkID=241478. For a concrete example, have a look at \#385.
+            The self-signed test certificate for ReactTestApp on Windows is about to expire.
 
-            Remember to _not_ set a password when creating the certificate.
+            1. Run `.\scripts\Renew-SelfSignedCertificate.ps1` in PowerShell
+            2. Run `yarn install-windows-test-app` inside `example`
+            3. Open the project and verify that it uses the new certificate
+            4. Verify that the test app builds and runs
+            5. Commit `ReactTestApp.vcxproj` and `ReactTestApp_TemporaryKey.pfx`
+            6. Submit a PR
+
+            For a concrete example, have a look at \#385.
+
+            For more information about renewing certificates, see http://go.microsoft.com/fwlink/?LinkID=241478.
           labels: "platform: Windows"
-          assignees: "tido64"
+          assignees: tido64

--- a/scripts/Renew-SelfSignedCertificate.ps1
+++ b/scripts/Renew-SelfSignedCertificate.ps1
@@ -1,0 +1,48 @@
+param([Switch]$Verbose=$False)
+
+$ErrorActionPreference = "Stop"
+
+$ReactTestApp_Project_Path = "windows\ReactTestApp\ReactTestApp.vcxproj"
+$ReactTestApp_Test_Cert_Path = "windows\ReactTestApp\ReactTestApp_TemporaryKey.pfx"
+
+# Set .NET current directory to PowerShell's
+[Environment]::CurrentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
+
+# Read the current certificate
+if ($Verbose) {
+    Write-Host "Reading $ReactTestApp_Test_Cert_Path..."
+}
+$Current_Cert = Get-PfxCertificate -FilePath $ReactTestApp_Test_Cert_Path
+if ($Verbose) {
+    $Current_Cert | Select-Object SerialNumber,Issuer,NotAfter,NotBefore,Subject,EnhancedKeyUsageList,Extensions,PrivateKey,PublicKey,Thumbprint
+}
+
+# Create a new certificate using properties from the current certificate
+# https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing
+# https://sitecore.stackexchange.com/questions/9419/certificate-does-not-contain-private-key-exception-while-executing-sitecore-9-in
+if ($Verbose) {
+    Write-Host "Generating new self-signed certificate..."
+    Write-Host ""
+}
+$New_Cert = New-SelfSignedCertificate `
+    -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}") `
+    -KeyUsage DigitalSignature `
+    -Provider "Microsoft Strong Cryptographic Provider" `
+    -KeySpec Signature `
+    -Type Custom `
+    -FriendlyName "ReactTestApp Development Certificate" `
+    -Subject $Current_Cert.Subject `
+    -CertStoreLocation "Cert:\CurrentUser\My"
+if ($Verbose) {
+    $New_Cert | Select-Object SerialNumber,Issuer,NotAfter,NotBefore,Subject,EnhancedKeyUsageList,Extensions,PrivateKey,PublicKey,Thumbprint
+}
+$Cert_Data = $New_Cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx)
+[System.IO.File]::WriteAllBytes($ReactTestApp_Test_Cert_Path, $Cert_Data)
+
+# Update the certificate thumbprint in the project
+if ($Verbose) {
+    Write-Host "Updating $ReactTestApp_Project_Path..."
+}
+$Project = [System.IO.File]::ReadAllText($ReactTestApp_Project_Path)
+$Updated_Project = $Project.replace($Current_Cert.Thumbprint, $New_Cert.Thumbprint)
+Set-Content -Path $ReactTestApp_Project_Path -Value $Updated_Project -NoNewline


### PR DESCRIPTION
### Description

Automate renewal of the self-signed test certificate for ReactTestApp on Windows.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

~~The renewal workflow has been configured to trigger on this PR. A new PR should be created with new and valid test certificate.~~