### PR TITLE
fix(windows): disable appx package signing

### DIFF
--- a/scripts/MSBuild.ps1
+++ b/scripts/MSBuild.ps1
@@ -17,7 +17,6 @@ MSBuild `
     -maxCpuCount `
     -property:Configuration=$Configuration `
     -property:Platform=$Platform `
-    -property:AppxPackageSigningEnabled=false `
     -property:UseBundle=false `
     -target:$Target `
     $ProjectFile

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -64,7 +64,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
### Description

Should address the build issue seen in https://github.com/microsoft/fluentui-react-native/pull/1241.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Windows build should pass.