### PR TITLE
fix(windows): support Visual Studio 2022

### DIFF
--- a/example/windows/ReactTestAppTests/ReactTestAppTests.vcxproj
+++ b/example/windows/ReactTestAppTests/ReactTestAppTests.vcxproj
@@ -39,15 +39,13 @@
     <ProjectGuid>{D2B221C0-0781-4D20-8BF1-D88684662A5D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ReactTestAppTests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <UseOfMfc>false</UseOfMfc>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -62,7 +62,6 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>


### PR DESCRIPTION
### Description

Use default value for PlatformToolset to not be bound to a specific version of Visual Studio.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Build test app using [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) (Community edition is sufficient). Visual Studio should not ask you to retarget to v143.
