### PR TITLE
fix(android): stop using workaround for trove4j

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    def androidDir = "${buildscript.sourceFile.getParent()}/../"
+    apply(from: "$androidDir/test-app-util.gradle")
+    apply(from: "$androidDir/dependencies.gradle")
+}
+
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("kotlin-kapt")
+}
+
 // `react-native run-android` is hard-coded to look for the output APK at a very
 // specific location. See
 // https://github.com/react-native-community/cli/blob/6cf12b00c02aca6d4bc843446394331d71a9749e/packages/platform-android/src/commands/runAndroid/index.ts#L180
@@ -5,24 +17,13 @@ buildDir = "$rootDir/$name/build"
 
 def reactNativeDir = findNodeModulesPath(rootDir, "react-native")
 
-buildscript {
-    def androidDir = "${buildscript.sourceFile.getParent()}/../"
-    apply from: "$androidDir/test-app-util.gradle"
-    apply from: "$androidDir/dependencies.gradle"
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 repositories {
     maven {
-        url("${reactNativeDir}/android")
+        url = uri("${reactNativeDir}/android")
     }
 
-    google()
     mavenCentral()
+    google()
 
     // TODO: Remove these when they've been published to Maven Central.
     // See https://github.com/microsoft/react-native-test-app/issues/305
@@ -38,19 +39,11 @@ repositories {
 
     // https://github.com/AzureAD/microsoft-authentication-library-for-android#step-1-declare-dependency-on-msal
     maven {
-        url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
+        url = uri("https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1")
     }
 }
 
-apply from: "$projectDir/../force-resolve-trove4j.gradle"
-
-apply plugin: "com.android.application"
-apply plugin: "kotlin-android"
-apply plugin: "kotlin-kapt"
-
-def testAppDir = file("$projectDir/../../")
-
-apply from: file("${testAppDir}/test-app.gradle")
+apply(from: "$projectDir/../../test-app.gradle")
 applyTestAppModule(project)
 
 project.ext.react = [
@@ -91,7 +84,7 @@ android {
         def recommendedFlipperVersion = getFlipperRecommendedVersion(rootDir)
         buildConfigField "String",
                          "ReactTestApp_recommendedFlipperVersion",
-                         recommendedFlipperVersion ? "\"${recommendedFlipperVersion}\"" : '"0"'
+                         recommendedFlipperVersion ? "\"${recommendedFlipperVersion}\"" : "\"0\""
 
         resValue "string", "app_name", project.ext.react.appName
 
@@ -107,7 +100,7 @@ android {
 
     sourceSets {
         if (project.ext.react.enableFlipper) {
-            debug.java.srcDirs += 'src/flipper/java'
+            debug.java.srcDirs += "src/flipper/java"
         }
     }
 }
@@ -129,7 +122,7 @@ dependencies {
     }
 
     if (buildReactNativeFromSource(rootDir)) {
-        implementation project(':ReactAndroid')
+        implementation project(":ReactAndroid")
     } else {
         implementation "com.facebook.react:react-native:+"
     }
@@ -137,6 +130,7 @@ dependencies {
     implementation libraries.kotlinStdlibJdk7
     implementation libraries.kotlinStdlibJdk8
     implementation libraries.kotlinReflect
+
     implementation libraries.androidAppCompat
     implementation libraries.androidCoreKotlinExtensions
     implementation libraries.androidRecyclerView
@@ -155,13 +149,13 @@ dependencies {
     if (project.ext.react.enableFlipper) {
         def flipperVersion = project.ext.react.enableFlipper
         debugImplementation("com.facebook.flipper:flipper:${flipperVersion}") {
-            exclude group: 'com.facebook.fbjni'
+            exclude(group: "com.facebook.fbjni")
         }
         debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${flipperVersion}") {
-            exclude group: 'com.facebook.flipper'
+            exclude(group: "com.facebook.flipper")
         }
         debugImplementation("com.facebook.flipper:flipper-network-plugin:${flipperVersion}") {
-            exclude group: 'com.facebook.flipper'
+            exclude(group: "com.facebook.flipper")
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,8 @@
-buildscript { scriptHandler ->
-    def buildscriptDir = buildscript.sourceFile.getParent()
-    apply from: "$buildscriptDir/dependencies.gradle"
-    apply from: "$buildscriptDir/force-resolve-trove4j.gradle", to: scriptHandler
+plugins {
+    apply(from: "${buildscript.sourceFile.getParent()}/dependencies.gradle")
 
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "com.android.tools.build:gradle:$androidPluginVersion"
-    }
+    id("com.android.application") version "${androidPluginVersion}" apply false
+    id("com.android.library") version "${androidPluginVersion}" apply false
+    id("kotlin-android") version "${kotlinVersion}" apply false
+    id("kotlin-kapt") version "${kotlinVersion}" apply false
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,10 @@
-rootProject.name='react-test-app'
-include ':app', ':support'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
+rootProject.name = "react-test-app"
+include ":app", ":support"

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -1,19 +1,16 @@
-buildscript {
-    def androidDir = "${buildscript.sourceFile.getParent()}/../"
-    apply from: "$androidDir/dependencies.gradle"
+plugins {
+    id("com.android.library")
 }
 
 repositories {
-    google()
     mavenCentral()
+    google()
 }
 
-def androidDir = "${buildscript.sourceFile.getParent()}/../"
-apply from: "$androidDir/force-resolve-trove4j.gradle"
-
-apply plugin: "com.android.library"
-
 android {
+    def androidDir = "${buildscript.sourceFile.getParent()}/../"
+    apply(from: "$androidDir/dependencies.gradle")
+
     compileSdkVersion project.ext.compileSdkVersion
     buildToolsVersion project.ext.buildToolsVersion
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,10 +1,10 @@
-buildscript { scriptHandler ->
+buildscript {
     def androidTestAppDir = "../node_modules/react-native-test-app/android"
-    apply from: "$androidTestAppDir/dependencies.gradle"
+    apply(from: "${androidTestAppDir}/dependencies.gradle")
 
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 
     dependencies {

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 
-rootProject.name='example'
+rootProject.name = "example"
 
-apply from: file("../node_modules/react-native-test-app/test-app.gradle")
+apply(from: "../node_modules/react-native-test-app/test-app.gradle")
 applyTestAppSettings(settings)

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -408,14 +408,13 @@ const getConfig = (() => {
         android: {
           files: {
             "build.gradle": join(
-              "buildscript { scriptHandler ->",
+              "buildscript {",
               `    def androidTestAppDir = "${testAppRelPath}/android"`,
-              '    apply from: "$androidTestAppDir/dependencies.gradle"',
-              '    apply from: "$androidTestAppDir/force-resolve-trove4j.gradle", to: scriptHandler',
+              '    apply(from: "${androidTestAppDir}/dependencies.gradle")',
               "",
               "    repositories {",
-              "        google()",
               "        mavenCentral()",
+              "        google()",
               "    }",
               "",
               "    dependencies {",
@@ -473,9 +472,9 @@ const getConfig = (() => {
               "    }",
               "}",
               "",
-              `rootProject.name='${name}'`,
+              `rootProject.name = "${name}"`,
               "",
-              `apply from: file("${testAppRelPath}/test-app.gradle")`,
+              `apply(from: "${testAppRelPath}/test-app.gradle")`,
               "applyTestAppSettings(settings)",
               ""
             ),

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -38,10 +38,6 @@ def cliAndroidDir = findNodeModulesPath(rootDir, "@react-native-community/cli-pl
 apply from: "$cliAndroidDir/native_modules.gradle"
 
 ext.applyTestAppSettings = { DefaultSettings defaultSettings ->
-    buildscript { scriptHandler ->
-        apply from: "$scriptDir/android/force-resolve-trove4j.gradle", to: scriptHandler
-    }
-
     applySettings(defaultSettings)
     applyNativeModulesSettingsGradle(defaultSettings)
 }

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -65,14 +65,13 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript { scriptHandler ->
+    "android/build.gradle": "buildscript {
     def androidTestAppDir = \\"../../android\\"
-    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
-    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
+    apply(from: \\"\${androidTestAppDir}/dependencies.gradle\\")
 
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 
     dependencies {
@@ -104,9 +103,9 @@ Object {
     }
 }
 
-rootProject.name='Test'
+rootProject.name = \\"Test\\"
 
-apply from: file(\\"../../test-app.gradle\\")
+apply(from: \\"../../test-app.gradle\\")
 applyTestAppSettings(settings)
 ",
     "babel.config.js": Object {
@@ -476,14 +475,13 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript { scriptHandler ->
+    "android/build.gradle": "buildscript {
     def androidTestAppDir = \\"../../android\\"
-    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
-    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
+    apply(from: \\"\${androidTestAppDir}/dependencies.gradle\\")
 
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 
     dependencies {
@@ -515,9 +513,9 @@ Object {
     }
 }
 
-rootProject.name='Test'
+rootProject.name = \\"Test\\"
 
-apply from: file(\\"../../test-app.gradle\\")
+apply(from: \\"../../test-app.gradle\\")
 applyTestAppSettings(settings)
 ",
     "babel.config.js": Object {
@@ -643,14 +641,13 @@ Object {
     ".watchmanconfig": Object {
       "source": "node_modules/react-native/template/_watchmanconfig",
     },
-    "android/build.gradle": "buildscript { scriptHandler ->
+    "android/build.gradle": "buildscript {
     def androidTestAppDir = \\"../../android\\"
-    apply from: \\"$androidTestAppDir/dependencies.gradle\\"
-    apply from: \\"$androidTestAppDir/force-resolve-trove4j.gradle\\", to: scriptHandler
+    apply(from: \\"\${androidTestAppDir}/dependencies.gradle\\")
 
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 
     dependencies {
@@ -682,9 +679,9 @@ Object {
     }
 }
 
-rootProject.name='Test'
+rootProject.name = \\"Test\\"
 
-apply from: file(\\"../../test-app.gradle\\")
+apply(from: \\"../../test-app.gradle\\")
 applyTestAppSettings(settings)
 ",
     "babel.config.js": Object {


### PR DESCRIPTION
### Description

`org.jetbrains.trove4j:trove4j` has been uploaded to Maven Central: https://search.maven.org/artifact/org.jetbrains.trove4j/trove4j/20160824/jar

`force-resolve-trove4j.gradle` is now deprecated and will be removed in the next major release.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.