### PR TITLE
fix(android): contain use of JCenter to 0.64 and older

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,15 +24,18 @@ repositories {
     google()
     mavenCentral()
 
-    // TODO: Remove these when they've been published to Maven Central.
-    // See https://github.com/microsoft/react-native-test-app/issues/305
-    // noinspection JcenterRepositoryObsolete
-    jcenter() {
-        content {
-            includeGroup("com.facebook.fbjni")
-            includeGroup("com.facebook.flipper")
-            includeGroup("com.facebook.fresco")
-            includeGroup("com.facebook.yoga")
+    // TODO: Remove this block when we drop support for 0.64.
+    if (getReactNativeVersionNumber(rootDir) < 6500) {
+        // Artifacts for 0.65+ are published to Maven Central. If we're on an
+        // older version, we still need to use JCenter.
+        // noinspection JcenterRepositoryObsolete
+        jcenter() {
+            content {
+                includeGroup("com.facebook.fbjni")
+                    includeGroup("com.facebook.flipper")
+                    includeGroup("com.facebook.fresco")
+                    includeGroup("com.facebook.yoga")
+            }
         }
     }
 

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -137,3 +137,11 @@ ext.getFlipperVersion = { baseDir ->
     // Use the recommended Flipper version
     return recommendedFlipperVersion
 }
+
+ext.getReactNativeVersionNumber = { baseDir ->
+    def reactNativePath = findNodeModulesPath(baseDir, "react-native")
+    def packageJson = file("${reactNativePath}/package.json")
+    def manifest = new JsonSlurper().parseText(packageJson.text)
+    def (major, minor, patch) = manifest["version"].tokenize(".")
+    return (major as int) * 10000 + (minor as int) * 100 + (patch as int)
+}


### PR DESCRIPTION
### Description

Only react-native artifacts for 0.65+ are uploaded to Maven Central. We are stuck with JCenter for 0.64 and below.

Resolves #305.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Test app should build for both 0.64 and 0.65.