### PR TITLE
ci: ensure metro-react-native-babel-preset is hoisted

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -25,6 +25,7 @@
     "@babel/core": "^7.0.0",
     "@types/jest": "^27.0.0",
     "jest": "^27.0.0",
+    "metro-react-native-babel-preset": "^0.64.0",
     "mkdirp": "^1.0.0",
     "react": "17.0.1",
     "react-native": "^0.64.3",

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -127,6 +127,7 @@ function pickCommonDependencies(dependencies, peerDependencies) {
     "@react-native-community/cli-platform-ios":
       dependencies["@react-native-community/cli-platform-ios"],
     "hermes-engine": dependencies["hermes-engine"],
+    "metro-react-native-babel-preset": dependencies["metro-react-native-babel-transformer"],
     react: peerDependencies["react"],
   };
 }

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -127,7 +127,8 @@ function pickCommonDependencies(dependencies, peerDependencies) {
     "@react-native-community/cli-platform-ios":
       dependencies["@react-native-community/cli-platform-ios"],
     "hermes-engine": dependencies["hermes-engine"],
-    "metro-react-native-babel-preset": dependencies["metro-react-native-babel-transformer"],
+    "metro-react-native-babel-preset":
+      dependencies["metro-react-native-babel-transformer"],
     react: peerDependencies["react"],
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,6 +5136,7 @@ __metadata:
     "@babel/core": ^7.0.0
     "@types/jest": ^27.0.0
     jest: ^27.0.0
+    metro-react-native-babel-preset: ^0.64.0
     mkdirp: ^1.0.0
     react: 17.0.1
     react-native: ^0.64.3
@@ -8487,7 +8488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-preset@npm:0.64.0":
+"metro-react-native-babel-preset@npm:0.64.0, metro-react-native-babel-preset@npm:^0.64.0":
   version: 0.64.0
   resolution: "metro-react-native-babel-preset@npm:0.64.0"
   dependencies:


### PR DESCRIPTION
### Description

`metro-react-native-babel-preset` is not hoisted during nightly builds. Adding it as an explicit dependency to ensure that it is.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a