### PR TITLE
docs: remove copyright header from all files

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 package com.microsoft.reacttestapp
 
 import android.app.Activity

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 package com.microsoft.reacttestapp.component
 
 import android.app.Activity

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 package com.microsoft.reacttestapp.component
 
 import android.os.Bundle

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentViewModel.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentViewModel.kt
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 package com.microsoft.reacttestapp.component
 
 import android.os.Bundle

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/ReadableMapExt.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/ReadableMapExt.kt
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 package com.microsoft.reacttestapp.react
 
 import com.facebook.react.bridge.Arguments

--- a/common/AppRegistry.cpp
+++ b/common/AppRegistry.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "AppRegistry.h"
 
 #if __has_include(<jsi/jsi.h>)

--- a/common/AppRegistry.h
+++ b/common/AppRegistry.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #ifndef COMMON_APPREGISTRY_
 #define COMMON_APPREGISTRY_
 

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <XCTest/XCTest.h>
 
 #import <ReactTestApp-DevSupport/ReactTestApp-DevSupport.h>

--- a/example/ios/ExampleTests/ManifestTests.swift
+++ b/example/ios/ExampleTests/ManifestTests.swift
@@ -1,9 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // swiftlint:disable force_cast
 
 import XCTest

--- a/example/ios/ExampleTests/ReactNativePerformanceTests.m
+++ b/example/ios/ExampleTests/ReactNativePerformanceTests.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <XCTest/XCTest.h>
 
 #import <React/RCTBridge.h>

--- a/example/windows/ReactTestAppTests/ManifestTests.cpp
+++ b/example/windows/ReactTestAppTests/ManifestTests.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include <CppUnitTest.h>

--- a/ios/ReactTestApp/AppDelegate.swift
+++ b/ios/ReactTestApp/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import UIKit
 
 @UIApplicationMain

--- a/ios/ReactTestApp/AppRegistryModule.h
+++ b/ios/ReactTestApp/AppRegistryModule.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>

--- a/ios/ReactTestApp/AppRegistryModule.mm
+++ b/ios/ReactTestApp/AppRegistryModule.mm
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import "AppRegistryModule.h"
 
 #import <jsi/jsi.h>

--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import AVFoundation
 import UIKit
 

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/ReactTestApp/RCTDevSupport+UIScene.m
+++ b/ios/ReactTestApp/RCTDevSupport+UIScene.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>

--- a/ios/ReactTestApp/React+Compatibility.h
+++ b/ios/ReactTestApp/React+Compatibility.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <Foundation/Foundation.h>
 
 @class RCTBridge;

--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import "React+Compatibility.h"
 
 #include <TargetConditionals.h>

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import Foundation
 
 final class ReactInstance: NSObject, RCTBridgeDelegate {

--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 #import <React/RCTAssert.h>

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import <Foundation/Foundation.h>
 
 NSNotificationName const ReactTestAppDidInitializeNotification =

--- a/ios/ReactTestApp/SceneDelegate.swift
+++ b/ios/ReactTestApp/SceneDelegate.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import Foundation
 import UIKit
 

--- a/ios/ReactTestApp/Session.swift
+++ b/ios/ReactTestApp/Session.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import Foundation
 
 struct Session {

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.h
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 #import <UIKit/UIViewController.h>

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.m
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.m
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #import "UIViewController+ReactTestApp.h"
 
 @protocol RTAViewController <NSObject>

--- a/ios/ReactTestAppTests/ReactTestAppTests.swift
+++ b/ios/ReactTestAppTests/ReactTestAppTests.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import XCTest
 
 class ReactTestAppTests: XCTestCase {

--- a/ios/ReactTestAppUITests/ReactTestAppUITests.swift
+++ b/ios/ReactTestAppUITests/ReactTestAppUITests.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import XCTest
 
 class ReactTestAppUITests: XCTestCase {

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 def find_file(file_name, current_dir)
   return if current_dir.expand_path.to_s == '/'
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 require('json')
 require('pathname')
 require('rubygems/version')

--- a/ios/use_react_native-0.60.rb
+++ b/ios/use_react_native-0.60.rb
@@ -1,9 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
 # rubocop:disable Layout/LineLength
 
 require_relative('pod_helpers')

--- a/ios/use_react_native-0.61.rb
+++ b/ios/use_react_native-0.61.rb
@@ -1,9 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
 # rubocop:disable Layout/LineLength
 
 def include_react_native!(options)

--- a/ios/use_react_native-0.62.rb
+++ b/ios/use_react_native-0.62.rb
@@ -1,9 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
 # rubocop:disable Layout/LineLength
 
 require_relative('pod_helpers')

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 def include_react_native!(options)
   react_native, flipper_versions, project_root, target_platform = options.values_at(
     :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import Cocoa
 
 @NSApplicationMain

--- a/macos/ReactTestApp/ViewController.swift
+++ b/macos/ReactTestApp/ViewController.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation. All rights reserved.
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import Cocoa
 
 final class ViewController: NSViewController {

--- a/macos/ReactTestAppTests/ReactTestAppTests.swift
+++ b/macos/ReactTestAppTests/ReactTestAppTests.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import XCTest
 
 class ReactTestAppTests: XCTestCase {

--- a/macos/ReactTestAppUITests/ReactTestAppUITests.swift
+++ b/macos/ReactTestAppUITests/ReactTestAppUITests.swift
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 import XCTest
 
 class ReactTestAppUITests: XCTestCase {

--- a/macos/test_app.rb
+++ b/macos/test_app.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 require_relative('../ios/test_app')
 
 def use_test_app!(options = {}, &block)

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 /**
  * @template Args

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 require("./link")(module);
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 (async () => {
   const { version: targetVersion } = require("react-native/package.json");

--- a/scripts/prettier-diff.js
+++ b/scripts/prettier-diff.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 const { spawnSync } = require("child_process");
 const fs = require("fs");

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 const { spawn } = require("child_process");
 const os = require("os");

--- a/test/__mocks__/fs.js
+++ b/test/__mocks__/fs.js
@@ -1,9 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 "use strict";
 
 const fs = jest.createMockFromModule("fs");

--- a/test/configure/console.test.js
+++ b/test/configure/console.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("console", () => {
   const { error, warn } = require("../../scripts/configure");

--- a/test/configure/gatherConfig.test.js
+++ b/test/configure/gatherConfig.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("gatherConfig()", () => {
   const { mockParams } = require("./mockParams");

--- a/test/configure/getAppName.test.js
+++ b/test/configure/getAppName.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/configure/getConfig.test.js
+++ b/test/configure/getConfig.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("getConfig()", () => {
   const { mockParams } = require("./mockParams");

--- a/test/configure/getPlatformPackage.test.js
+++ b/test/configure/getPlatformPackage.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("getPlatformPackage()", () => {
   const { getPlatformPackage } = require("../../scripts/configure");

--- a/test/configure/isDestructive.test.js
+++ b/test/configure/isDestructive.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/configure/isInstalled.test.js
+++ b/test/configure/isInstalled.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("isInstalled()", () => {
   const { isInstalled } = require("../../scripts/configure");

--- a/test/configure/join.test.js
+++ b/test/configure/join.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("join()", () => {
   const { join } = require("../../scripts/configure");

--- a/test/configure/mergeConfig.test.js
+++ b/test/configure/mergeConfig.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("mergeConfig()", () => {
   const { mergeConfig } = require("../../scripts/configure");

--- a/test/configure/mockParams.js
+++ b/test/configure/mockParams.js
@@ -1,11 +1,6 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
 // istanbul ignore file
+"use strict";
 
 /**
  * Returns mock parameters.

--- a/test/configure/packageSatisfiesVersionRange.test.js
+++ b/test/configure/packageSatisfiesVersionRange.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("packageSatisfiesVersionRange()", () => {
   const { packageSatisfiesVersionRange } = require("../../scripts/configure");

--- a/test/configure/projectRelativePath.test.js
+++ b/test/configure/projectRelativePath.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("projectRelativePath()", () => {
   const { mockParams } = require("./mockParams");

--- a/test/configure/reactNativeConfig.test.js
+++ b/test/configure/reactNativeConfig.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("reactNativeConfig()", () => {
   const { mockParams } = require("./mockParams");

--- a/test/configure/removeAllFiles.test.js
+++ b/test/configure/removeAllFiles.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/configure/updatePackageManifest.test.js
+++ b/test/configure/updatePackageManifest.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/configure/writeAllFiles.test.js
+++ b/test/configure/writeAllFiles.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/mockFiles.js
+++ b/test/mockFiles.js
@@ -1,11 +1,6 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
 // istanbul ignore file
+"use strict";
 
 jest.mock("fs");
 

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 require('minitest/autorun')
 
 require_relative('../ios/test_app')

--- a/test/validate-manifest.test.js
+++ b/test/validate-manifest.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/copyAndReplace.test.js
+++ b/test/windows-test-app/copyAndReplace.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/findNearest.test.js
+++ b/test/windows-test-app/findNearest.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("findNearest", () => {
   const path = require("path");

--- a/test/windows-test-app/findUserProjects.test.js
+++ b/test/windows-test-app/findUserProjects.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("findUserProjects", () => {
   const path = require("path");

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/getBundleResources.test.js
+++ b/test/windows-test-app/getBundleResources.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/getHermesVersion.test.js
+++ b/test/windows-test-app/getHermesVersion.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/getPackageVersion.test.js
+++ b/test/windows-test-app/getPackageVersion.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("getPackageVersion", () => {
   const path = require("path");

--- a/test/windows-test-app/getVersionNumber.test.js
+++ b/test/windows-test-app/getVersionNumber.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("getVersionNumber", () => {
   const { getVersionNumber } = require("../../windows/test-app");

--- a/test/windows-test-app/parseResources.test.js
+++ b/test/windows-test-app/parseResources.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 jest.mock("fs");
 

--- a/test/windows-test-app/replaceContent.test.js
+++ b/test/windows-test-app/replaceContent.test.js
@@ -1,10 +1,5 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 describe("replaceContent", () => {
   const { replaceContent } = require("../../windows/test-app");

--- a/test_app.rb
+++ b/test_app.rb
@@ -1,10 +1,3 @@
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 require_relative('ios/test_app')
 
 def use_test_app!(options = {}, &block)

--- a/windows/ReactTestApp/App.cpp
+++ b/windows/ReactTestApp/App.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include "App.h"

--- a/windows/ReactTestApp/App.h
+++ b/windows/ReactTestApp/App.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include "App.xaml.g.h"

--- a/windows/ReactTestApp/AutolinkedNativeModules.g.h
+++ b/windows/ReactTestApp/AutolinkedNativeModules.g.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include <winrt/Microsoft.ReactNative.h>

--- a/windows/ReactTestApp/MainPage.cpp
+++ b/windows/ReactTestApp/MainPage.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include "MainPage.h"

--- a/windows/ReactTestApp/MainPage.h
+++ b/windows/ReactTestApp/MainPage.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include <any>

--- a/windows/ReactTestApp/Manifest.cpp
+++ b/windows/ReactTestApp/Manifest.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include "Manifest.h"

--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include "ReactInstance.h"

--- a/windows/ReactTestApp/ReactInstance.h
+++ b/windows/ReactTestApp/ReactInstance.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include <functional>

--- a/windows/ReactTestApp/ReactPackageProvider.cpp
+++ b/windows/ReactTestApp/ReactPackageProvider.cpp
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"
 
 #include "ReactPackageProvider.h"

--- a/windows/ReactTestApp/ReactPackageProvider.h
+++ b/windows/ReactTestApp/ReactPackageProvider.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include <winrt/Microsoft.ReactNative.h>

--- a/windows/ReactTestApp/Session.h
+++ b/windows/ReactTestApp/Session.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #include <winrt/Windows.Foundation.h>

--- a/windows/ReactTestApp/pch.cpp
+++ b/windows/ReactTestApp/pch.cpp
@@ -1,8 +1,1 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #include "pch.h"

--- a/windows/ReactTestApp/pch.h
+++ b/windows/ReactTestApp/pch.h
@@ -1,10 +1,3 @@
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
-
 #pragma once
 
 #define NOMINMAX

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-//
-// Copyright (c) Microsoft Corporation
-//
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree.
-//
 // @ts-check
+"use strict";
 
 const fs = require("fs");
 const os = require("os");


### PR DESCRIPTION
### Description

Removes copyright header from all files. We're applying them inconsistently and it's strictly not necessary to have them.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a