### PR TITLE
chore: also update `Podfile.lock` when upgrading react-native

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": ["config:base", "schedule:earlyMondays"],
   "labels": ["dependencies"],
+  "allowPostUpgradeCommandTemplating": true,
+  "allowedPostUpgradeCommands": ["^yarn", "^cd example$", "^pod install"],
   "packageRules": [
     {
       "matchPackagePrefixes": ["@react-native-community/cli"],
@@ -35,6 +37,28 @@
         "react-native-windows"
       ],
       "allowedVersions": "^0.64.0"
+    },
+    {
+      "matchPackageNames": ["react-native"],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn --no-immutable",
+          "cd example",
+          "pod install --project-directory=ios"
+        ],
+        "fileFilters": ["example/ios/Podfile.lock"]
+      }
+    },
+    {
+      "matchPackageNames": ["react-native-macos"],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn --no-immutable",
+          "cd example",
+          "pod install --project-directory=macos"
+        ],
+        "fileFilters": ["example/macos/Podfile.lock"]
+      }
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
### Description

Also update `Podfile.lock` when upgrading react-native and react-native-macos.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

No way to test this. Here's the doc: https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating