### PR TITLE
fix(macos): tests fail to build with latest Xcode

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -379,8 +379,10 @@ def use_test_app_internal!(target_platform, options)
         # Ensure `ENABLE_TESTING_SEARCH_PATHS` is always set otherwise Xcode may
         # fail to properly import XCTest
         unless test_dependencies.assoc(target.name).nil?
+          key = 'ENABLE_TESTING_SEARCH_PATHS'
           target.build_configurations.each do |config|
-            config.build_settings['ENABLE_TESTING_SEARCH_PATHS'] = 'YES'
+            setting = config.resolve_build_setting(key)
+            config.build_settings[key] = 'YES' if setting.nil?
           end
         end
       end

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -346,6 +346,16 @@ def use_test_app_internal!(target_platform, options)
   post_install do |installer|
     react_native_post_install&.call(installer)
 
+    test_dependencies = {}
+    %w[ReactTestAppTests ReactTestAppUITests].each do |target|
+      definition = target_definitions[target]
+      next if definition.nil?
+
+      definition.non_inherited_dependencies.each do |dependency|
+        test_dependencies[dependency.name] = dependency
+      end
+    end
+
     installer.pods_project.targets.each do |target|
       case target.name
       when 'SwiftLint'
@@ -364,6 +374,14 @@ def use_test_app_internal!(target_platform, options)
           # Xcode 10.2 requires suppression of nullability for React
           # https://stackoverflow.com/questions/37691049/xcode-compile-flag-to-suppress-nullability-warnings-not-working
           config.build_settings['WARNING_CFLAGS'] ||= ['"-Wno-nullability-completeness"']
+        end
+      else
+        # Ensure `ENABLE_TESTING_SEARCH_PATHS` is always set otherwise Xcode may
+        # fail to properly import XCTest
+        unless test_dependencies.assoc(target.name).nil?
+          target.build_configurations.each do |config|
+            config.build_settings['ENABLE_TESTING_SEARCH_PATHS'] = 'YES'
+          end
         end
       end
     end


### PR DESCRIPTION
### Description

macOS tests fail to build with latest Xcode:

```
/~/ios/ExampleTests/ManifestTests.swift:15:13: error: cannot find 'XCTFail' in scope
            XCTFail("Failed to read 'app.json'")
            ^~~~~~~
/~/ios/ExampleTests/ManifestTests.swift:19:9: error: cannot find 'XCTAssertEqual' in scope
        XCTAssertEqual(checksum.count, 64)
        ^~~~~~~~~~~~~~
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Should build successfully with latest Xcode: 
    ```
    cd example
    pod install --project-directory=macos
    ../scripts/xcodebuild.sh macos/Example.xcworkspace build-for-testing
    ```
2. We should not overwrite existing setting. The following should fail the build:
    ```diff
    diff --git a/example/Example-Tests.podspec b/example/Example-Tests.podspec
    index f504e44..6b65a70 100644
    --- a/example/Example-Tests.podspec
    +++ b/example/Example-Tests.podspec
    @@ -18,6 +18,7 @@ Pod::Spec.new do |s|
       s.dependency 'ReactTestApp-DevSupport'

       s.framework             = 'XCTest'
    +  s.pod_target_xcconfig   = { 'ENABLE_TESTING_SEARCH_PATHS' => 'NO' }
       s.user_target_xcconfig  = { 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => '$(inherited)' }

       s.source_files = 'ios/ExampleTests/**/*.{m,swift}'
    ```