### PR TITLE
fix: add support for RN version string containing chars

### DIFF
--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -142,6 +142,6 @@ ext.getReactNativeVersionNumber = { baseDir ->
     def reactNativePath = findNodeModulesPath(baseDir, "react-native")
     def packageJson = file("${reactNativePath}/package.json")
     def manifest = new JsonSlurper().parseText(packageJson.text)
-    def (major, minor, patch) = manifest["version"].tokenize(".")
+    def (major, minor, patch) = manifest["version"].findAll(/\d+/)
     return (major as int) * 10000 + (minor as int) * 100 + (patch as int)
 }


### PR DESCRIPTION
### Description

The issue is that RN version strings can contain chars, i.e. non-digits.
The RNTA should tolerate this and pick out the version parts in a robust
manner.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Tested out locally with version string 0.62.34-microsoft.0

