### PR TITLE
feat(android): Add ability to configure key store

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,7 +56,31 @@ project.ext.react = [
     enableHermes : true,
 ]
 
+def signingDebug = getSigningConfigs()['debug']
+def signingRelease = getSigningConfigs()['release']
+
 android {
+    if (signingDebug || signingRelease) {
+        signingConfigs {
+            if (signingDebug) {
+                debug {
+                    keyAlias signingDebug['keyAlias']
+                    keyPassword signingDebug['keyPassword']
+                    storeFile signingDebug['storeFile']
+                    storePassword signingDebug['storePassword']
+                }
+            }
+            if (signingRelease) {
+                release {
+                    keyAlias signingRelease['keyAlias']
+                    keyPassword signingRelease['keyPassword']
+                    storeFile signingRelease['storeFile']
+                    storePassword signingRelease['storePassword']
+                }
+            }
+        }
+    }
+
     compileSdkVersion project.ext.compileSdkVersion
     buildToolsVersion project.ext.buildToolsVersion
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,26 +56,27 @@ project.ext.react = [
     enableHermes : true,
 ]
 
-def signingDebug = getSigningConfigs()['debug']
-def signingRelease = getSigningConfigs()['release']
+project.ext.signingConfigs = getSigningConfigs()
 
 android {
+    def signingDebug = project.ext.signingConfigs["debug"]
+    def signingRelease = project.ext.signingConfigs["release"]
     if (signingDebug || signingRelease) {
         signingConfigs {
             if (signingDebug) {
                 debug {
-                    keyAlias signingDebug['keyAlias']
-                    keyPassword signingDebug['keyPassword']
-                    storeFile signingDebug['storeFile']
-                    storePassword signingDebug['storePassword']
+                    keyAlias signingDebug["keyAlias"]
+                    keyPassword signingDebug["keyPassword"]
+                    storeFile signingDebug["storeFile"]
+                    storePassword signingDebug["storePassword"]
                 }
             }
             if (signingRelease) {
                 release {
-                    keyAlias signingRelease['keyAlias']
-                    keyPassword signingRelease['keyPassword']
-                    storeFile signingRelease['storeFile']
-                    storePassword signingRelease['storePassword']
+                    keyAlias signingRelease["keyAlias"]
+                    keyPassword signingRelease["keyPassword"]
+                    storeFile signingRelease["storeFile"]
+                    storePassword signingRelease["storePassword"]
                 }
             }
         }

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -145,3 +145,41 @@ ext.getReactNativeVersionNumber = { baseDir ->
     def (major, minor, patch) = manifest["version"].findAll(/\d+/)
     return (major as int) * 10000 + (minor as int) * 100 + (patch as int)
 }
+
+ext.getSigningConfigs = { baseDir ->
+    def safeSetMap = { varName, map, prop, defaultVal ->
+        map[varName] = prop.containsKey(varName) ? prop.get(varName) : defaultVal
+    }
+
+    def definedConfigs = new LinkedHashMap<String, Object>()
+    def manifestFile = findFile('app.json')
+    if (manifestFile != null) {
+        def manifest = new JsonSlurper().parseText(manifestFile.text)
+
+        if (!manifest['android']) {
+            return definedConfigs
+        }
+
+        def signingConfigs = manifest['android']['signingConfigs']
+        if (signingConfigs) {
+            signingConfigs.each { config ->
+                def configName = config.key
+                def props = config.value
+                def pathStoreFile = props.containsKey('storeFile') ?
+                    Paths.get(rootDir.toString(), props.get('storeFile')).normalize().toAbsolutePath() : null
+                if (pathStoreFile == null || !file(pathStoreFile).exists() || !file(pathStoreFile).isFile()) {
+                    throw new FileNotFoundException("Signing storeFile for flavor ${configName} is missing: " + pathStoreFile)
+                }
+
+                def signConfig = new LinkedHashMap<String, Object>()
+                safeSetMap('keyAlias', signConfig, props, 'androiddebugkey')
+                safeSetMap('keyPassword', signConfig, props, 'android')
+                safeSetMap('storePassword', signConfig, props, 'android')
+                signConfig['storeFile'] = pathStoreFile.toFile()
+                definedConfigs[configName] = signConfig
+            }
+        }
+    }
+
+    return definedConfigs
+}

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -166,7 +166,7 @@ ext.getSigningConfigs = { baseDir ->
                 def configName = config.key
                 def props = config.value
                 def pathStoreFile = props.containsKey("storeFile")
-                    ? Paths.get(rootDir.toString(), props.get("storeFile")).normalize().toAbsolutePath()
+                    ? Paths.get(manifestFile.getParent(), props.get("storeFile")).normalize().toAbsolutePath()
                     : null
                 if (pathStoreFile == null || !file(pathStoreFile).exists() || !file(pathStoreFile).isFile()) {
                     throw new FileNotFoundException("Signing storeFile for flavor ${configName} is missing: " + pathStoreFile)

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -152,30 +152,31 @@ ext.getSigningConfigs = { baseDir ->
     }
 
     def definedConfigs = new LinkedHashMap<String, Object>()
-    def manifestFile = findFile('app.json')
+    def manifestFile = findFile("app.json")
     if (manifestFile != null) {
         def manifest = new JsonSlurper().parseText(manifestFile.text)
 
-        if (!manifest['android']) {
+        if (!manifest["android"]) {
             return definedConfigs
         }
 
-        def signingConfigs = manifest['android']['signingConfigs']
+        def signingConfigs = manifest["android"]["signingConfigs"]
         if (signingConfigs) {
             signingConfigs.each { config ->
                 def configName = config.key
                 def props = config.value
-                def pathStoreFile = props.containsKey('storeFile') ?
-                    Paths.get(rootDir.toString(), props.get('storeFile')).normalize().toAbsolutePath() : null
+                def pathStoreFile = props.containsKey("storeFile")
+                    ? Paths.get(rootDir.toString(), props.get("storeFile")).normalize().toAbsolutePath()
+                    : null
                 if (pathStoreFile == null || !file(pathStoreFile).exists() || !file(pathStoreFile).isFile()) {
                     throw new FileNotFoundException("Signing storeFile for flavor ${configName} is missing: " + pathStoreFile)
                 }
 
                 def signConfig = new LinkedHashMap<String, Object>()
-                safeSetMap('keyAlias', signConfig, props, 'androiddebugkey')
-                safeSetMap('keyPassword', signConfig, props, 'android')
-                safeSetMap('storePassword', signConfig, props, 'android')
-                signConfig['storeFile'] = pathStoreFile.toFile()
+                safeSetMap("keyAlias", signConfig, props, "androiddebugkey")
+                safeSetMap("keyPassword", signConfig, props, "android")
+                safeSetMap("storePassword", signConfig, props, "android")
+                signConfig["storeFile"] = pathStoreFile.toFile()
                 definedConfigs[configName] = signConfig
             }
         }

--- a/schema.json
+++ b/schema.json
@@ -83,6 +83,38 @@
         "package": {
           "description": "Use this property to set the application ID of the APK. The value is set to `applicationId` in `build.gradle`.",
           "type": "string"
+        },
+        "signingConfigs": {
+          "description": "Use this to set the signing configurations for the app",
+          "type": "object",
+          "debug": {
+            "keyAlias": {
+              "type": "string"
+            },
+            "keyPassword": {
+              "type": "string"
+            },
+            "storeFile": {
+              "type": "string"
+            },
+            "storePassword": {
+              "type": "string"
+            }
+          },
+          "release": {
+            "keyAlias": {
+              "type": "string"
+            },
+            "keyPassword": {
+              "type": "string"
+            },
+            "storeFile": {
+              "type": "string"
+            },
+            "storePassword": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/schema.json
+++ b/schema.json
@@ -87,32 +87,52 @@
         "signingConfigs": {
           "description": "Use this to set the signing configurations for the app",
           "type": "object",
-          "debug": {
-            "keyAlias": {
-              "type": "string"
+          "properties": {
+            "debug": {
+              "description": "Use this property for the debug signing config for the app. The value `storeFile` is required. Android defaults will be provided for other properties.",
+              "type": "object",
+              "properties": {
+                "keyAlias": {
+                  "description": "Use this property to specify the alias of key to use in the store",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Use this property to specify the password of key in the store",
+                  "type": "string"
+                },
+                "storeFile": {
+                  "description": "Use this property to specify the relative file path to the key store file",
+                  "type": "string"
+                },
+                "storePassword": {
+                  "description": "Use this property to specify the password of the key store",
+                  "type": "string"
+                }
+              },
+              "required": ["storeFile"]
             },
-            "keyPassword": {
-              "type": "string"
-            },
-            "storeFile": {
-              "type": "string"
-            },
-            "storePassword": {
-              "type": "string"
-            }
-          },
-          "release": {
-            "keyAlias": {
-              "type": "string"
-            },
-            "keyPassword": {
-              "type": "string"
-            },
-            "storeFile": {
-              "type": "string"
-            },
-            "storePassword": {
-              "type": "string"
+            "release": {
+              "description": "Use this property for the release signing config for the app. The value `storeFile` is required. Android defaults will be provided for other properties.",
+              "type": "object",
+              "properties": {
+                "keyAlias": {
+                  "description": "Use this property to specify the alias of key to use in the store",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Use this property to specify the password of key in the store",
+                  "type": "string"
+                },
+                "storeFile": {
+                  "description": "Use this property to specify the relative file path to the key store file",
+                  "type": "string"
+                },
+                "storePassword": {
+                  "description": "Use this property to specify the password of the key store",
+                  "type": "string"
+                }
+              },
+              "required": ["storeFile"]
             }
           }
         }

--- a/test/android-test-app/test-app-util.test.js
+++ b/test/android-test-app/test-app-util.test.js
@@ -233,4 +233,28 @@ describe("test-app-util", () => {
     expect(status).toBe(0);
     expect(stdout).toContain(`getReactNativeVersionNumber() = 10203`);
   });
+
+  test("getSigningConfigs() returns release signing config", async () => {
+    const { status, stdout } = await runGradle({
+      "app.json": JSON.stringify({
+        name: "AppName",
+        displayName: "AppDisplayName",
+        resources: ["dist/res", "dist/main.android.jsbundle"],
+        android: {
+          signingConfigs: {
+            release: {
+              storeFile: "../README.md"
+            }
+          }
+        }
+      }),
+      "build.gradle": [
+        ...buildGradle,
+        'println("getSigningConfigs() = " + ext.getSigningConfigs())',
+      ],
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("getSigningConfigs() = [release:[keyAlias:androiddebugkey");
+  });
 });

--- a/test/android-test-app/test-app-util.test.js
+++ b/test/android-test-app/test-app-util.test.js
@@ -255,6 +255,6 @@ describe("test-app-util", () => {
     });
 
     expect(status).toBe(0);
-    expect(stdout).toContain("getSigningConfigs() = [release:[keyAlias:androiddebugkey");
+    expect(stdout).toMatch(/getSigningConfigs\(\) = \[release:\[keyAlias:androiddebugkey, keyPassword:android, storePassword:android, storeFile:.*\]\]/);
   });
 });


### PR DESCRIPTION
The ability to configure the key store is required for enabling certain features such as MSAL's auth broker.

### Description

We need to add signingConfigs property to the Android specific section in the app manifest.

I tried as much to match the DSL of the app manifest itself. 
In the code, I have 'landed' on a fixed set of flavors, debug and release.

The trouble to make this generic on the fly in the 'android' section of the gradle is that the signingConfigs are ReadOnly object when first created. If I tried to use closures inside the 'android' section with .each { flavor -> ... } then there was a mismatch with the closure and the DSL, even if I tried to use a proper Java class for the SigningConfig. Alas, two flavors for now.

Resolves #691.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Tested with overwriting the 'debug' flavor using a debug.keystore. 
Tested with a release keystore.
Tested without any signingConfig in the app.json.
Tested with signingConfig with a 
  - missing keystore
  - keystore just as '..' or any other folder
  - keystore empty

### TODO

- [x] Update the Android documentation
- [x] Update the Manifest documentation
