### PR TITLE
test(android): add more tests for parsing signing configs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,13 @@
 "platform: Android":
   - android/**/*
   - example/android/**/*
+  - test/android-test-app/**/*
   - test-app.gradle
 "platform: iOS":
   - ReactTestApp-DevSupport.podspec
   - example/ios/**/*
   - ios/**/*
+  - test/*.rb
   - test_app.rb
 "platform: macOS":
   - ReactTestApp-DevSupport.podspec
@@ -18,6 +20,8 @@
   - ios/ReactTestApp/Session.swift
   - ios/ReactTestApp/UIViewController+ReactTestApp.{h,m}
   - macos/**/*
+  - test/*.rb
 "platform: Windows":
   - example/windows/**/*
+  - test/windows-test-app/**/*
   - windows/**/*

--- a/test/android-test-app/gradle.js
+++ b/test/android-test-app/gradle.js
@@ -103,11 +103,12 @@ async function runGradleWithProject(name, platforms, setupFiles = {}) {
   const projectPath = await makeProject(name, platforms, setupFiles);
   const result = runGradle(projectPath);
   const stdout = joinStrings(result.stdout);
+  const stderr = joinStrings(result.stderr);
   if (result.stderr) {
     console.log(stdout);
-    console.error(joinStrings(result.stderr));
+    console.error(stderr);
   }
-  return { ...result, stdout };
+  return { ...result, stdout, stderr };
 }
 
 exports.removeProject = removeProject;


### PR DESCRIPTION
### Description

Adds more tests for parsing signing configs.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Tests should pass.