### PR TITLE
ci: extract Gradle build action

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -1,0 +1,31 @@
+name: Gradle Build
+description: Executes a Gradle build
+inputs:
+  project-root:
+    description: The path to the root of the project
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Determine build root directory
+      id: build-root-directory-finder
+      run: |
+        if [[ -f android/build.gradle ]]; then
+          echo "::set-output name=build-root-directory::${{ inputs.project-root }}/android"
+        else
+          echo "::set-output name=build-root-directory::${{ inputs.project-root }}"
+        fi
+      shell: bash
+      working-directory: ${{ inputs.project-root }}
+    - name: Configure JVM memory
+      env:
+        JVM_ARGS: org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+      run: |
+        echo $JVM_ARGS >> ${{ steps.build-root-directory-finder.outputs.build-root-directory }}/gradle.properties
+      shell: bash
+    - name: Build
+      uses: gradle/gradle-build-action@v2.1.0
+      with:
+        gradle-version: wrapper
+        arguments: --no-daemon clean build check test
+        build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,10 +213,9 @@ jobs:
         shell: bash
         working-directory: example
       - name: Build
-        run: |
-          ./gradlew clean build check test
-        shell: bash
-        working-directory: example/android
+        uses: ./.github/actions/gradle
+        with:
+          project-root: example
   android-template:
     name: "Android [template]"
     strategy:
@@ -242,11 +241,9 @@ jobs:
         shell: bash
         working-directory: template-example
       - name: Build
-        run: |
-          [[ -d android ]] && pushd android 1> /dev/null
-          ./gradlew clean build check test
-        shell: bash
-        working-directory: template-example
+        uses: ./.github/actions/gradle
+        with:
+          project-root: template-example
       - name: react-native run-android
         run: |
           ../test/react-native.js run-android


### PR DESCRIPTION
### Description

Extract Gradle build action and bump the heap size to avoid out-of-memory exceptions.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.