### PR TITLE
fix(macos): prepare support for react-native-macos 0.66

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,10 +21,10 @@ Metrics/MethodLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
-  IgnoredMethods: [make_project!, use_test_app_internal!]
+  IgnoredMethods: [make_project!, react_native_pods, use_test_app_internal!]
 
 Metrics/PerceivedComplexity:
-  IgnoredMethods: [make_project!, use_test_app_internal!]
+  IgnoredMethods: [make_project!, react_native_pods, use_test_app_internal!]
 
 Naming/FileName:
   Exclude:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,9 +33,9 @@ repositories {
         jcenter() {
             content {
                 includeGroup("com.facebook.fbjni")
-                    includeGroup("com.facebook.flipper")
-                    includeGroup("com.facebook.fresco")
-                    includeGroup("com.facebook.yoga")
+                includeGroup("com.facebook.flipper")
+                includeGroup("com.facebook.fresco")
+                includeGroup("com.facebook.yoga")
             }
         }
     }

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -96,7 +96,9 @@ end
 
 def react_native_pods(version)
   v = version.release
-  if v == Gem::Version.new('0.0.0') || v >= Gem::Version.new('0.63')
+  if v == Gem::Version.new('0.0.0') || v >= Gem::Version.new('0.64')
+    'use_react_native-0.64'
+  elsif v >= Gem::Version.new('0.63')
     'use_react_native-0.63'
   elsif v >= Gem::Version.new('0.62')
     'use_react_native-0.62'

--- a/ios/use_react_native-0.63.rb
+++ b/ios/use_react_native-0.63.rb
@@ -8,11 +8,6 @@ def include_react_native!(options)
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
   use_react_native!(options)
 
-  # In 0.64, `react_native_post_install` should be called instead
-  if defined?(react_native_post_install)
-    return ->(installer) { react_native_post_install(installer) }
-  end
-
   if target_platform == :macos
     return lambda { |installer|
       begin

--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -1,0 +1,17 @@
+def include_react_native!(options)
+  react_native, flipper_versions, project_root, target_platform = options.values_at(
+    :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform
+  )
+
+  require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
+
+  use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
+  use_react_native!(options)
+
+  lambda { |installer|
+    react_native_post_install(installer)
+    if defined?(__apply_Xcode_12_5_M1_post_install_workaround)
+      __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    end
+  }
+end

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -15,7 +15,7 @@ const os = require("os");
 
 const VALID_TAGS = ["canary-macos", "canary-windows", "main", "nightly"];
 const REACT_NATIVE_VERSIONS = {
-  "canary-macos": "^0.64",
+  "canary-macos": "^0.66",
   "canary-windows": "^0.67.0-0",
 };
 

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -93,10 +93,13 @@ class TestTestApp < Minitest::Test
   end
 
   def test_react_native_pods
-    assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('1000.0.0')))
+    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('1000.0.0')))
 
+    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.64.0')))
+    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.64.0-rc.1')))
+
+    assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('0.63.4')))
     assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('0.63.0')))
-    assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('0.63.0-rc.1')))
 
     assert_equal('use_react_native-0.62', react_native_pods(Gem::Version.new('0.62.2')))
     assert_equal('use_react_native-0.62', react_native_pods(Gem::Version.new('0.62.0')))


### PR DESCRIPTION
### Description

Make sure to call `__apply_Xcode_12_5_M1_post_install_workaround` if it is defined.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version canary-macos
yarn
cd example
pod install --project-directory=macos
../scripts/xcodebuild.sh macos/Example.xcworkspace build

# Also make sure iOS builds
pod install --project-directory=ios
../scripts/xcodebuild.sh ios/Example.xcworkspace build
```