### PR TITLE
fix: `validate-manifest` breaks on Node 12

### DIFF
--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -47,12 +47,15 @@ function validateManifest(manifestPath = findAppManifest()) {
     console.error(
       `${manifestPath}: error: ${APP_JSON} is not a valid app manifest`
     );
-    validate.errors?.map(({ instancePath, message }) =>
-      console.error(
-        `${manifestPath}: error: ${instancePath || "<root>"} ${message}`
-      )
-    );
-    process.exit(1);
+    const errors = validate.errors;
+    if (errors) {
+      errors.map(({ instancePath, message }) =>
+        console.error(
+          `${manifestPath}: error: ${instancePath || "<root>"} ${message}`
+        )
+      );
+      process.exit(1);
+    }
   }
 }
 

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -54,8 +54,8 @@ function validateManifest(manifestPath = findAppManifest()) {
           `${manifestPath}: error: ${instancePath || "<root>"} ${message}`
         )
       );
-      process.exit(1);
     }
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
### Description

`validate-manifest` breaks on Node 12 due to use of optional chaining.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.