### PR TITLE
ci: disable macOS tests when building nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,7 @@ jobs:
         with:
           project-directory: macos
           working-directory: example
-      - name: Build
+      - name: Build x86
         run: |
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build-for-testing
         working-directory: example
@@ -294,6 +294,7 @@ jobs:
           yarn jest
         working-directory: example
       - name: Test
+        if: ${{ github.event_name != 'schedule' }}
         run: |
           ../scripts/xcodebuild.sh macos/Example.xcworkspace test-without-building
         working-directory: example


### PR DESCRIPTION
### Description

macOS tests are rather flaky when built against react-native@main. Disabling them on nightly builds for now.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a