### PR TITLE
fix(apple): `-jsBundleURLForBundleRoot:fallbackResource:` was removed

### DIFF
--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -5,10 +5,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
         NSNotification.Name("ReactInstance.scanForQRCodeNotification")
 
     static func jsBundleURL() -> URL? {
-        RCTBundleURLProvider.sharedSettings().jsBundleURL(
-            forBundleRoot: "index",
-            fallbackResource: nil
-        )
+        RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index") { nil }
     }
 
     var remoteBundleURL: URL? {
@@ -131,7 +128,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
             return remoteBundleURL
         }
 
-        let jsBundleURL = entryFiles()
+        let embeddedBundleURL = entryFiles()
             .lazy
             .map {
                 Bundle.main.url(
@@ -140,7 +137,7 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
                 )
             }
             .first(where: { $0 != nil })
-        return jsBundleURL ?? ReactInstance.jsBundleURL()
+        return embeddedBundleURL ?? ReactInstance.jsBundleURL()
     }
 
     func extraModules(for _: RCTBridge!) -> [RCTBridgeModule] {


### PR DESCRIPTION
### Description

`-jsBundleURLForBundleRoot:fallbackResource:` was removed in https://github.com/facebook/react-native/commit/0912ee179c210fb6b2ed9afbb3f2fbc5fb8a2bb3.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Apply #711, then run the following steps:

```sh
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
../scripts/xcodebuild.sh ios/Example.xcworkspace build
```