### PR TITLE
fix(apple): prepare `react-native-codegen` when using main

### DIFF
--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 def include_react_native!(options)
   react_native, flipper_versions, project_root, target_platform = options.values_at(
     :path, :rta_flipper_versions, :rta_project_root, :rta_target_platform
@@ -7,6 +9,11 @@ def include_react_native!(options)
 
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
   use_react_native!(options)
+
+  # If we're using react-native@main, we'll also need to prepare
+  # `react-native-codegen`.
+  codegen = File.join(project_root, react_native, 'packages', 'react-native-codegen')
+  Open3.popen3('yarn', :chdir => codegen) if File.directory?(codegen)
 
   lambda { |installer|
     react_native_post_install(installer)


### PR DESCRIPTION
### Description

When using `react-native`@main, we also need to build `react-native-codegen`.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
../scripts/xcodebuild.sh ios/Example.xcworkspace build
```