### PR TITLE
fix(macos): declare support for react-native-macos 0.66

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,10 +16,10 @@
     "windows": "react-native run-windows --sln windows/Example.sln"
   },
   "peerDependencies": {
-    "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1",
-    "react-native": "^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0",
-    "react-native-macos": "^0.60.0 || ^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0",
-    "react-native-windows": "^0.62.0 || ^0.63.0 || ^0.64.0"
+    "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
+    "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0",
+    "react-native-macos": "^0.0.0-0 || 0.60 - 0.66",
+    "react-native-windows": "^0.0.0-0 || 0.62 - 0.67"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mustache": "^4.0.0",
     "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
     "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0",
-    "react-native-macos": "^0.0.0-0 || 0.60 - 0.64",
+    "react-native-macos": "^0.0.0-0 || 0.60 - 0.66",
     "react-native-windows": "^0.0.0-0 || 0.62 - 0.67"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5216,10 +5216,10 @@ __metadata:
     react-native-test-app: "workspace:."
     react-native-windows: ^0.64.25
   peerDependencies:
-    react: ~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1
-    react-native: ^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0
-    react-native-macos: ^0.60.0 || ^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0
-    react-native-windows: ^0.62.0 || ^0.63.0 || ^0.64.0
+    react: ~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2
+    react-native: ^0.0.0-0 || 0.60 - 0.67 || 1000.0.0
+    react-native-macos: ^0.0.0-0 || 0.60 - 0.66
+    react-native-windows: ^0.0.0-0 || 0.62 - 0.67
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10484,7 +10484,7 @@ __metadata:
     mustache: ^4.0.0
     react: ~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2
     react-native: ^0.0.0-0 || 0.60 - 0.67 || 1000.0.0
-    react-native-macos: ^0.0.0-0 || 0.60 - 0.64
+    react-native-macos: ^0.0.0-0 || 0.60 - 0.66
     react-native-windows: ^0.0.0-0 || 0.62 - 0.67
   peerDependenciesMeta:
     "@react-native-community/cli":


### PR DESCRIPTION
### Description

Adds react-native-macos 0.66 to the support matrix.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.66
yarn
cd example
rm -rf macos/Pods macos/Podfile.lock
pod install --project-directory=macos
yarn macos
```

Screenshots: 

| With JSC | With Hermes |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/4123478/151037899-30654355-f78f-4ec6-871e-6c0de7f7149f.png) | ![image](https://user-images.githubusercontent.com/4123478/151042249-6bbf87a9-db30-46c0-8d3d-02108456eecc.png) |