### PR TITLE
ci: address Gradle download flakiness on Windows

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -1,6 +1,9 @@
 name: Gradle Build
 description: Executes a Gradle build
 inputs:
+  arguments:
+    description: Gradle will execute a build with the provided arguments
+    default: --no-daemon clean build check test
   project-root:
     description: The path to the root of the project
     required: true
@@ -27,5 +30,5 @@ runs:
       uses: gradle/gradle-build-action@v2.1.0
       with:
         gradle-version: wrapper
-        arguments: --no-daemon clean build check test
+        arguments: ${{ inputs.arguments }}
         build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,13 @@ jobs:
           echo "::add-matcher::.github/minitest.json"
           bundle exec ruby -Ilib:test test/test_test_app.rb
           echo "::remove-matcher owner=minitest::"
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Populate Gradle cache
+        uses: ./.github/actions/gradle
+        with:
+          arguments: clean
+          project-root: example
       - name: JavaScript
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -203,8 +210,6 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: android
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |


### PR DESCRIPTION
### Description

Gradle tests often fail while downloading Gradle on Windows CI:

```
Exception in thread "main" java.net.SocketException: Software caused connection abort: socket write error
	at java.base/java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.base/java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:110)
	at java.base/java.net.SocketOutputStream.write(SocketOutputStream.java:150)
	...
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a