### PR TITLE
fix(apple): apply `Time.h` patch with correct path

### DIFF
--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -19,6 +19,16 @@ def include_react_native!(options)
     react_native_post_install(installer)
     if defined?(__apply_Xcode_12_5_M1_post_install_workaround)
       __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+      # The path to `Time.h` is hard-coded in 0.66.0 - 0.67.1, and does not take
+      # `--project-directory` into consideration. Re-applying the "patch" here
+      # in case we missed it the first time.
+      time_header = "#{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h"
+      if File.exist?(time_header)
+        # rubocop:disable Layout/LineLength
+        `sed -i -e  $'s/__IPHONE_OS_VERSION_MIN_REQUIRED </__IPHONE_OS_VERSION_MIN_REQUIRED >=/' #{time_header}`
+        # rubocop:enable Layout/LineLength
+      end
     end
   }
 end

--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -25,9 +25,7 @@ def include_react_native!(options)
       # in case we missed it the first time.
       time_header = "#{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h"
       if File.exist?(time_header)
-        # rubocop:disable Layout/LineLength
-        `sed -i -e  $'s/__IPHONE_OS_VERSION_MIN_REQUIRED </__IPHONE_OS_VERSION_MIN_REQUIRED >=/' #{time_header}`
-        # rubocop:enable Layout/LineLength
+        `sed -i -e $'s/VERSION_MIN_REQUIRED </VERSION_MIN_REQUIRED >=/' #{time_header}`
       end
     end
   }


### PR DESCRIPTION
### Description

The path to `Time.h` is hard-coded in 0.66.0 - 0.67.1 and does not take `--project-directory` into consideration. Re-apply the "patch" in case we missed it the first time.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.66
yarn
cd example
rm -rf ios/Podfile.lock ios/Pods
pod install --project-directory=ios
yarn ios
```