### PR TITLE
fix(ios): use Flipper version recommended by react-native 0.66+

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -489,7 +489,10 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              semver.satisfies(targetVersion, "<0.66")
+              semver.satisfies(
+                semver.coerce(targetVersion) || "0.0.0",
+                "> 0.0.0 < 0.66"
+              )
                 ? // Use a more recent version of Flipper to avoid build
                   // break in Xcode 12.5.
                   // See https://github.com/facebook/react-native/issues/31179.

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -339,7 +339,7 @@ const getConfig = (() => {
       typeof configuration === "undefined" ||
       "JEST_WORKER_ID" in process.env // skip caching when testing
     ) {
-      const { name, testAppPath, flatten, init } = params;
+      const { name, testAppPath, targetVersion, flatten, init } = params;
       const projectPathFlag = flatten ? " --project-path ." : "";
       const testAppRelPath = projectRelativePath(params);
       const templateDir = path.relative(
@@ -489,11 +489,15 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              // Use a more recent version of Flipper to avoid build
-              // break in Xcode 12.5.
-              // See https://github.com/facebook/react-native/issues/31179.
-              "use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })",
-              "",
+              ...(semver.satisfies(targetVersion, "<0.66")
+                ? [
+                    // Use a more recent version of Flipper to avoid build
+                    // break in Xcode 12.5.
+                    // See https://github.com/facebook/react-native/issues/31179.
+                    "use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })",
+                    "",
+                  ]
+                : []),
               `workspace '${name}.xcworkspace'`,
               "",
               `use_test_app!`,

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -489,15 +489,13 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              ...(semver.satisfies(targetVersion, "<0.66")
-                ? [
-                    // Use a more recent version of Flipper to avoid build
-                    // break in Xcode 12.5.
-                    // See https://github.com/facebook/react-native/issues/31179.
-                    "use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })",
-                    "",
-                  ]
-                : []),
+              semver.satisfies(targetVersion, "<0.66")
+                ? // Use a more recent version of Flipper to avoid build
+                  // break in Xcode 12.5.
+                  // See https://github.com/facebook/react-native/issues/31179.
+                  "use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })"
+                : "use_flipper!",
+              "",
               `workspace '${name}.xcworkspace'`,
               "",
               `use_test_app!`,

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -12,7 +12,7 @@ Object {
     },
     "Podfile": "require_relative '../test_app'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!
 
 workspace 'Test.xcworkspace'
 
@@ -113,7 +113,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!
 
 workspace 'Test.xcworkspace'
 
@@ -376,7 +376,7 @@ Object {
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!
 
 workspace 'Test.xcworkspace'
 
@@ -523,7 +523,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!
 
 workspace 'Test.xcworkspace'
 
@@ -689,7 +689,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
+use_flipper!
 
 workspace 'Test.xcworkspace'
 

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -12,7 +12,7 @@ Object {
     },
     "Podfile": "require_relative '../test_app'
 
-use_flipper!
+use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
 
 workspace 'Test.xcworkspace'
 
@@ -113,7 +113,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
 
 workspace 'Test.xcworkspace'
 
@@ -376,7 +376,7 @@ Object {
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
 
 workspace 'Test.xcworkspace'
 
@@ -523,7 +523,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
 
 workspace 'Test.xcworkspace'
 
@@ -689,7 +689,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3' })
 
 workspace 'Test.xcworkspace'
 


### PR DESCRIPTION
### Description

Flipper was bumped to 0.91 in https://github.com/facebook/react-native/commit/4246c75d0d5b9dccbe0fd5ecec66b4cc0331f815. We no longer need to hard-code Flipper to 0.75 from react-native 0.66 and on. In fact, doing so will now cause `pod install` to fail:

```
Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
Fetching podspec for `boost` from `../node_modules/react-native/third-party-podspecs/boost.podspec`
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
Adding spec repo `trunk` with CDN `https://cdn.cocoapods.org/`
[!] CocoaPods could not find compatible versions for pod "Flipper-Folly":
  In Podfile:
    Flipper (= 0.75.1) was resolved to 0.75.1, which depends on
      Flipper-Folly (~> 2.5)

    Flipper (= 0.75.1) was resolved to 0.75.1, which depends on
      Flipper-RSocket (~> 1.3) was resolved to 1.4.3, which depends on
        Flipper-Folly (~> 2.6)

    Flipper-Folly (= 2.5.3)

Specs satisfying the `Flipper-Folly (= 2.5.3), Flipper-Folly (~> 2.5), Flipper-Folly (~> 2.6)` dependency were found, but they required a higher minimum deployment target.
```

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Flipper version should be set to 0.75 when below 0.66:
   ```
   yarn
   yarn react-native init-test-app --destination template-example --name TemplateExample --platform all
   cat template-example/ios/Podfile
   ```
2. Flipper version should _not_ be set when on 0.66+:
   ```
   npm run set-react-version 0.66
   yarn
   yarn react-native init-test-app --destination template-example --name TemplateExample --platform all
   cat template-example/ios/Podfile
   ```