### PR TITLE
fix(windows): format `packages.config` to avoid autolink check fail

### DIFF
--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" / -->
-  <!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" / -->
-  <!-- package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" / -->
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native" / -->
-  <package id="nlohmann.json" version="3.9.1" targetFramework="native" />
+  <!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native"/ -->
+  <!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native"/ -->
+  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
+  <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->
+  <package id="nlohmann.json" version="3.9.1" targetFramework="native"/>
 </packages>

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -504,18 +504,16 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
   const projectFilesReplacements = {
     ...(hermesVersion
       ? {
-          '<!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native" / -->':
+          '<!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->':
             nuGetPackage("ReactNative.Hermes.Windows", hermesVersion),
         }
       : undefined),
     ...(useNuGet
       ? {
-          '<!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native" / -->':
+          '<!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native"/ -->':
             nuGetPackage("Microsoft.ReactNative", rnWindowsVersion),
-          '<!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native" / -->':
+          '<!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native"/ -->':
             nuGetPackage("Microsoft.ReactNative.Cxx", rnWindowsVersion),
-          '<!-- package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" / -->':
-            nuGetPackage("Microsoft.UI.Xaml", "2.6.0"),
           "<UseExperimentalNuget>false</UseExperimentalNuget>":
             "<UseExperimentalNuget>true</UseExperimentalNuget>",
           "<WinUI2xVersionDisabled />":


### PR DESCRIPTION
### Description

In react-native-windows 0.66, the second autolink run requires changes that should've been picked up during the first run. Besides cosmetic changes, it now requires `Microsoft.UI.Xaml` to always be included.

```
       AutolinkCheck:
         npx react-native autolink-windows --check --sln "TemplateExample.sln" --proj "node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj"
         - Checking auto-linked files...
         Γ£ö Checking auto-linked files...
     9>D:\a\react-native-test-app\react-native-test-app\template-example\node_modules\react-native-windows\PropertySheets\Autolink.targets(17,5): warning : Warning: Auto-linking changes were necessary but --check specified. Run 'npx react-native autolink-windows --sln "TemplateExample.sln" --proj "node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj"' to apply the changes. (2404ms) [D:\a\react-native-test-app\react-native-test-app\template-example\node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj]
         error Auto-linking changes were necessary but --check was specified. Run 'npx react-native autolink-windows --sln "TemplateExample.sln" --proj "node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj"' to apply the changes.
```

[Full build log](https://github.com/microsoft/react-native-test-app/runs/4968451809?check_suite_focus=true)

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

CI should pass.