### PR TITLE
ci(nightly): ensure react-native-windows canaries can be installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,7 @@ jobs:
         working-directory: example
       - name: Install NuGet packages
         run: |
-          nuget restore
+          nuget restore -FallbackSource "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json"
         working-directory: example/windows
       - name: Build
         run: |


### PR DESCRIPTION
### Description

Nightly builds of react-native-windows have been failing consistently:

```
Errors in packages.config projects
    Unable to find version '0.0.0-canary.442' of package 'Microsoft.ReactNative'.
      https://api.nuget.org/v3/index.json: Package 'Microsoft.ReactNative.0.0.0-canary.442' is not found on source 'https://api.nuget.org/v3/index.json'.
    Unable to find version '0.0.0-canary.442' of package 'Microsoft.ReactNative.Cxx'.
      https://api.nuget.org/v3/index.json: Package 'Microsoft.ReactNative.Cxx.0.0.0-canary.442' is not found on source 'https://api.nuget.org/v3/index.json'.
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
# Run `set-react-version` with CI=1 to fetch latest version from NuGet
CI=1 npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-nuget
cd windows

# this will fail
nuget restore

# this will succeed
nuget restore -FallbackSource "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json"
```