### PR TITLE
fix(android): workaround for `Java heap space` when patching CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "files": [
     "/*.{gradle,js,md,podspec,rb}",
     "/android/**/*.gradle",
+    "/android/app/lint.xml",
     "/android/app/src/{flipper,main}",
     "/android/support/src",
     "/common",

--- a/scripts/patch-cli-platform-android.js
+++ b/scripts/patch-cli-platform-android.js
@@ -16,6 +16,8 @@ try {
   );
 
   const script = fs.readFileSync(nativeModulesScript, { encoding: "utf-8" });
+  // TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
+  // https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
   const patched = script.replace(
     "ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules",
     "ArrayList<HashMap<String, String>> packages = this.reactNativeModules"

--- a/scripts/patch-cli-platform-android.js
+++ b/scripts/patch-cli-platform-android.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// @ts-check
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+try {
+  const nativeModulesScript = path.join(
+    path.dirname(
+      require.resolve(
+        "@react-native-community/cli-platform-android/package.json"
+      )
+    ),
+    "native_modules.gradle"
+  );
+
+  const script = fs.readFileSync(nativeModulesScript, { encoding: "utf-8" });
+  const patched = script.replace(
+    "ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules",
+    "ArrayList<HashMap<String, String>> packages = this.reactNativeModules"
+  );
+  if (patched !== script) {
+    fs.writeFileSync(nativeModulesScript, patched);
+  }
+} catch (_) {
+  // Ignore if we cannot patch
+}

--- a/scripts/patch-cli-platform-android.js
+++ b/scripts/patch-cli-platform-android.js
@@ -5,6 +5,8 @@
 const fs = require("fs");
 const path = require("path");
 
+// TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
+// https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
 try {
   const nativeModulesScript = path.join(
     path.dirname(
@@ -16,8 +18,6 @@ try {
   );
 
   const script = fs.readFileSync(nativeModulesScript, { encoding: "utf-8" });
-  // TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
-  // https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
   const patched = script.replace(
     "ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules",
     "ArrayList<HashMap<String, String>> packages = this.reactNativeModules"

--- a/scripts/patch-cli-platform-android.js
+++ b/scripts/patch-cli-platform-android.js
@@ -5,8 +5,6 @@
 const fs = require("fs");
 const path = require("path");
 
-// TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
-// https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
 try {
   const nativeModulesScript = path.join(
     path.dirname(
@@ -18,6 +16,8 @@ try {
   );
 
   const script = fs.readFileSync(nativeModulesScript, { encoding: "utf-8" });
+  // TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
+  // https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
   const patched = script.replace(
     "ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules",
     "ArrayList<HashMap<String, String>> packages = this.reactNativeModules"

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -35,23 +35,19 @@ private static void applySettings(Settings settings) {
 
 // TODO: Remove when `@react-native-community/cli` 6.0+ is required. See also
 // https://github.com/react-native-community/cli/commit/fa0d09b2c9be144bbdff526bb14f171d7ddca88e
-private static void patchArgumentTypeMismatchError(String cliAndroidDir) {
-    def script = new File("${cliAndroidDir}/native_modules.gradle")
-    if (script.exists()) {
-        def content = script.text
-        def patched = content.replace(
-            "ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules",
-            "ArrayList<HashMap<String, String>> packages = this.reactNativeModules",
-        )
-        script.write(patched)
-    }
+private static void patchArgumentTypeMismatchError(String testAppDir, File rootDir) {
+    // We need to delegate this to a separate script to avoid running out of
+    // Java heap space.
+    String[] patch = ["node", "${testAppDir}/scripts/patch-cli-platform-android.js"]
+    Runtime.getRuntime().exec(patch, null, rootDir).waitFor()
 }
 
-def scriptDir = buildscript.sourceFile.getParent()
-apply(from: "${scriptDir}/android/test-app-util.gradle")
+def testAppDir = buildscript.sourceFile.getParent()
+apply(from: "${testAppDir}/android/test-app-util.gradle")
+
+patchArgumentTypeMismatchError(testAppDir, rootDir)
 
 def cliAndroidDir = findNodeModulesPath(rootDir, "@react-native-community/cli-platform-android")
-patchArgumentTypeMismatchError(cliAndroidDir)
 apply(from: "${cliAndroidDir}/native_modules.gradle")
 
 ext.applyTestAppSettings = { DefaultSettings defaultSettings ->

--- a/test/android-test-app/test-app-util.test.js
+++ b/test/android-test-app/test-app-util.test.js
@@ -47,11 +47,6 @@ describe("test-app-util", () => {
     removeProject(defaultTestProject);
   });
 
-  // TODO: Figure out why Windows CI keeps running out of Java heap space.
-  // https://github.com/microsoft/react-native-test-app/issues/738
-  const test =
-    process.env["CI"] && require("os").platform() === "win32" ? it.skip : it;
-
   test("getAppName() returns `name` if `displayName` is omitted", async () => {
     const { status, stdout } = await runGradle({
       "app.json": JSON.stringify({


### PR DESCRIPTION
### Description

Patching `@react-native-community/cli-platform-android` inline causes Gradle to run out of heap space.

Resolves #738

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

I have a consistent repro in an internal repo, running:

```
rm -rf ~/.gradle
git clean -dfqx
./gradlew clean build
```