### PR TITLE
test: fix config test failing on nightlies

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -2,11 +2,11 @@
 
 const loadConfig = (() => {
   try {
+    return require("@react-native-community/cli/build/tools/config").default;
+  } catch (_) {
     // `loadConfig` was made public in 7.0:
     // https://github.com/react-native-community/cli/pull/1464
     return require("@react-native-community/cli").loadConfig;
-  } catch (_) {
-    return require("@react-native-community/cli/build/tools/config").default;
   }
 })();
 

--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -1,7 +1,15 @@
 // @ts-check
 
-const loadConfig =
-  require("@react-native-community/cli/build/tools/config").default;
+const loadConfig = (() => {
+  try {
+    // `loadConfig` was made public in 7.0:
+    // https://github.com/react-native-community/cli/pull/1464
+    return require("@react-native-community/cli").loadConfig;
+  } catch (_) {
+    return require("@react-native-community/cli/build/tools/config").default;
+  }
+})();
+
 const fs = require("fs");
 const os = require("os");
 const path = require("path");


### PR DESCRIPTION
### Description

iOS nightly started to fail:

```
FAIL test/config.test.js
  ● Test suite failed to run

    Cannot find module '@react-native-community/cli/build/tools/config' from 'test/config.test.js'

      1 | // @ts-check
      2 |
    > 3 | const loadConfig =
        | ^
      4 |   require("@react-native-community/cli/build/tools/config").default;
      5 | const fs = require("fs");
      6 | const os = require("os");

      at Resolver.resolveModule (node_modules/jest-resolve/build/resolver.js:324:[11](https://github.com/microsoft/react-native-test-app/runs/5047146453?check_suite_focus=true#step:9:11))
      at Object.<anonymous> (test/config.test.js:3:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.[14](https://github.com/microsoft/react-native-test-app/runs/5047146453?check_suite_focus=true#step:9:14)1 s
Ran all test suites.
Error: Process completed with exit code 1.
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.