### PR TITLE
fix(windows): crash on startup with cannot find resource

### DIFF
--- a/windows/ReactTestApp/App.xaml
+++ b/windows/ReactTestApp/App.xaml
@@ -3,4 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:ReactTestApp">
+
+    <Application.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"/>
+    </Application.Resources>
+
 </Application>

--- a/windows/ReactTestApp/MainPage.xaml
+++ b/windows/ReactTestApp/MainPage.xaml
@@ -9,7 +9,7 @@
 
     <Grid Background="{StaticResource SystemControlAcrylicWindowBrush}">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="32"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 


### PR DESCRIPTION
### Description

Windows test app crashes on startup with react-native 0.66:

```
Cannot find a Resource with the Name/Key TabViewScrollButtonBackground
Cannot find a Resource with the Name/Key TabViewScrollButtonBackground [Line: 2854 Position: 35]
Cannot find a Resource with the Name/Key TabViewButtonBackground
Cannot find a Resource with the Name/Key TabViewScrollButtonBackground [Line: 2570 Position: 35]
```

I also had to hard-code the title bar height, otherwise layout would be messed up like this:

![Screenshot 2022-02-06 002311](https://user-images.githubusercontent.com/4123478/152662632-ef1eb255-3632-4c1a-9d3d-e14cc36384b4.png)

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
npm run set-react-version 0.66
yarn
cd example
yarn install-windows-test-app --use-nuget
yarn windows
```

Repeat the steps above for 0.64.