### PR TITLE
ci: cache compiler outputs to speed up builds

### DIFF
--- a/.ccache/ccache.conf
+++ b/.ccache/ccache.conf
@@ -1,0 +1,5 @@
+depend_mode = true
+direct_mode = true
+hard_link = true
+run_second_cpp = true
+sloppiness = file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,modules,system_headers,time_macros

--- a/.github/actions/cocoapods/action.yml
+++ b/.github/actions/cocoapods/action.yml
@@ -24,7 +24,7 @@ runs:
       uses: actions/cache@v2
       with:
         path: ${{ inputs.working-directory }}/${{ inputs.project-directory }}/Pods
-        key: ${{ steps.cache-key-generator.outputs.cache-key }}
+        key: ${{ runner.os }}-pods-${{ steps.cache-key-generator.outputs.cache-key }}
     - name: Install Pods
       run: |
         pod install --project-directory=${{ inputs.project-directory }}

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -3,6 +3,8 @@ description: Sets up the toolchain for the project
 inputs:
   platform:
     description: The target platform to set up toolchain for
+  variant:
+    description: Whether we're building from example, template, etc.
 runs:
   using: composite
   steps:
@@ -19,7 +21,7 @@ runs:
       if: ${{ inputs.platform == 'windows' }}
       uses: microsoft/setup-msbuild@v1.1
     - name: Set up Ruby
-      if: ${{ inputs.platform == 'ios' || inputs.platform == 'macos' }}
+      if: ${{ inputs.platform == 'ios' || inputs.platform == 'macos' || inputs.platform == 'node' }}
       uses: ruby/setup-ruby@v1.99.0
       with:
         ruby-version: "3.0"
@@ -28,3 +30,19 @@ runs:
     - name: Set up VSTest.console.exe
       if: ${{ inputs.platform == 'windows' }}
       uses: darenm/Setup-VSTest@v1
+    - name: Generate cache key
+      id: cache-key-generator
+      run: |
+        if [[ -f example/${{ inputs.platform }}/Podfile.lock ]]; then
+          echo "::set-output name=cache-key::$(node scripts/shasum.js example/${{ inputs.platform }}/Podfile.lock)"
+        else
+          echo '::set-output name=cache-key::false'
+        fi
+      shell: bash
+    - name: Cache /.ccache
+      if: ${{ steps.cache-key-generator.outputs.cache-key != 'false' }}
+      uses: actions/cache@v2
+      with:
+        path: .ccache
+        key: ${{ runner.os }}-${{ inputs.variant }}-ccache-${{ steps.cache-key-generator.outputs.cache-key }}
+        restore-keys: ${{ runner.os }}-${{ inputs.variant }}-ccache-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain
         with:
-          platform: ${{ matrix.platform }}
+          platform: node
       - name: Deduplicate packages
         run: |
           yarn dedupe --check
@@ -122,6 +122,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain
+        with:
+          platform: ios
+          variant: example
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -171,6 +174,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain
+        with:
+          platform: ios
+          variant: template-${{ matrix.template }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -279,6 +285,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain
+        with:
+          platform: macos
+          variant: example
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -313,7 +322,7 @@ jobs:
         working-directory: example
       - name: Build ARM
         run: |
-          ../scripts/xcodebuild.sh macos/Example.xcworkspace clean
+          rm -fr macos/build
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build ARCHS=arm64
         working-directory: example
     timeout-minutes: 60
@@ -329,6 +338,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain
+        with:
+          platform: macos
+          variant: template-${{ matrix.template }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.xcworkspace/
 .DS_Store
 .android-test-*
+.ccache/*
+!.ccache/ccache.conf
 .gradle/
 .idea/
 .vs/
@@ -14,7 +16,7 @@ android/**/build/
 clang-format-diff.py
 coverage/
 dist/
-example/android/build/
+example/*/build/
 local.properties
 msbuild.binlog
 node_modules/

--- a/scripts/clang
+++ b/scripts/clang
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ccache /usr/bin/clang "$@"


### PR DESCRIPTION
### Description

iOS/macOS builds can exceed 20 minutes nowadays. Experimenting with different solutions to see if we can speed them up. Things that I've attempted but didn't work out:

- Caching DerivedData
  - Xcode rebuilds everything anyway, despite touching all files to update the file modified times and telling `xcodebuild` to ignore inode changes
  - The DerivedData folder was also very big
- [PodBuilder](https://github.com/Subito-it/PodBuilder)
  - Builds and caches Pods only
  - Requires extra build steps, and modifying `Podfile`
- [CocoaPods binary cache](https://github.com/grab/cocoapods-binary-cache)
  - Builds and caches Pods only
  - Requires extra build steps, and modifying `Podfile` and our react-native profiles
- [CocoaPods Binary](https://github.com/leavez/cocoapods-binary)
  - Builds and caches Pods only
  - Requires extra build steps, and modifying `Podfile` and our react-native profiles
  - It also seems to be abandoned (hasn't been updated since September 2020)
- [Rugby](https://swiftyfinch.medium.com/rugby-optimise-cocoapods-project-25767b23f287)
  - Builds and caches Pods only
  - Requires an extra build step and bespoke configuration
  - Deviates from how one would consume it normally (in terms of steps and configuration)
- [Module caching](https://medium.com/@SkyscannerEng/hate-to-wait-how-skyscanner-used-module-caching-to-cut-app-build-speed-in-half-e906da1c077e)
  - Cache compiled modules didn't seem to work. Tests crash on startup.
  - Requires building `Pods.xcodeproj` separately from the app

In the end, [Ccache](https://ccache.dev/) is the only one that works consistently, and with minimal effort. It wraps existing compilers (e.g. Clang, GCC), and only requires a configuration. Build steps and so on remain the same. PSPDFKit has written more about their experience here:

  - [Faster Compilation with Ccache 4.0](https://pspdfkit.com/blog/2020/faster-compilation-with-ccache/)
  - [Using Ccache for Fun and Profit](https://pspdfkit.com/blog/2015/ccache-for-fun-and-profit/)

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

CI should pass and be faster on cache hit.

| iOS cache miss (27m 54s) | iOS cache hit (8m 24s) |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/4123478/155039957-b0d306a5-00e4-4433-a65c-f81dab356968.png) | ![image](https://user-images.githubusercontent.com/4123478/155041140-d29cc23a-5f01-4b40-914d-0c2ef21769ad.png) |