### PR TITLE
fix(android): add compat layer for `ReactInstanceEventListener`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     def androidDir = "${buildscript.sourceFile.getParent()}/../"
-    apply(from: "$androidDir/test-app-util.gradle")
-    apply(from: "$androidDir/dependencies.gradle")
+    apply(from: "${androidDir}/test-app-util.gradle")
+    apply(from: "${androidDir}/dependencies.gradle")
 }
 
 plugins {
@@ -13,7 +13,7 @@ plugins {
 // `react-native run-android` is hard-coded to look for the output APK at a very
 // specific location. See
 // https://github.com/react-native-community/cli/blob/6cf12b00c02aca6d4bc843446394331d71a9749e/packages/platform-android/src/commands/runAndroid/index.ts#L180
-buildDir = "$rootDir/$name/build"
+buildDir = "${rootDir}/${name}/build"
 
 def reactNativeDir = findNodeModulesPath(rootDir, "react-native")
 
@@ -46,7 +46,7 @@ repositories {
     }
 }
 
-apply(from: "$projectDir/../../test-app.gradle")
+apply(from: "${projectDir}/../../test-app.gradle")
 applyTestAppModule(project)
 
 project.ext.react = [
@@ -59,29 +59,6 @@ project.ext.react = [
 project.ext.signingConfigs = getSigningConfigs()
 
 android {
-    def signingDebug = project.ext.signingConfigs["debug"]
-    def signingRelease = project.ext.signingConfigs["release"]
-    if (signingDebug || signingRelease) {
-        signingConfigs {
-            if (signingDebug) {
-                debug {
-                    keyAlias signingDebug["keyAlias"]
-                    keyPassword signingDebug["keyPassword"]
-                    storeFile signingDebug["storeFile"]
-                    storePassword signingDebug["storePassword"]
-                }
-            }
-            if (signingRelease) {
-                release {
-                    keyAlias signingRelease["keyAlias"]
-                    keyPassword signingRelease["keyPassword"]
-                    storeFile signingRelease["storeFile"]
-                    storePassword signingRelease["storePassword"]
-                }
-            }
-        }
-    }
-
     compileSdkVersion project.ext.compileSdkVersion
 
     // We need only set `ndkVersion` when building react-native from source.
@@ -129,9 +106,40 @@ android {
         pickFirst "lib/x86/libc++_shared.so"
     }
 
+    def signingDebug = project.ext.signingConfigs["debug"]
+    def signingRelease = project.ext.signingConfigs["release"]
+    if (signingDebug || signingRelease) {
+        signingConfigs {
+            if (signingDebug) {
+                debug {
+                    keyAlias signingDebug["keyAlias"]
+                    keyPassword signingDebug["keyPassword"]
+                    storeFile signingDebug["storeFile"]
+                    storePassword signingDebug["storePassword"]
+                }
+            }
+            if (signingRelease) {
+                release {
+                    keyAlias signingRelease["keyAlias"]
+                    keyPassword signingRelease["keyPassword"]
+                    storeFile signingRelease["storeFile"]
+                    storePassword signingRelease["storePassword"]
+                }
+            }
+        }
+    }
+
     sourceSets {
         if (project.ext.react.enableFlipper) {
             debug.java.srcDirs += "src/flipper/java"
+        }
+
+        // TODO: Remove this block when we drop support for 0.67.
+        // https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4
+        if (getReactNativeVersionNumber(rootDir) < 6800) {
+            main.java.srcDirs += "src/reactinstanceeventlistener-pre-0.68/java"
+        } else {
+            main.java.srcDirs += "src/reactinstanceeventlistener-0.68/java"
         }
     }
 }
@@ -147,9 +155,9 @@ dependencies {
             throw new GradleException("Could not find 'hermes-engine'. Please make sure you've added it to 'package.json'.")
         }
 
-        def hermesAndroidDir = "$hermesEngineDir/android"
-        releaseImplementation files("$hermesAndroidDir/hermes-release.aar")
-        debugImplementation files("$hermesAndroidDir/hermes-debug.aar")
+        def hermesAndroidDir = "${hermesEngineDir}/android"
+        releaseImplementation files("${hermesAndroidDir}/hermes-release.aar")
+        debugImplementation files("${hermesAndroidDir}/hermes-debug.aar")
     }
 
     if (buildReactNativeFromSource(rootDir)) {

--- a/android/app/src/flipper/java/com/microsoft/reacttestapp/ReactNativeFlipper.kt
+++ b/android/app/src/flipper/java/com/microsoft/reacttestapp/ReactNativeFlipper.kt
@@ -13,9 +13,9 @@ import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.react.ReactInstanceManager
-import com.facebook.react.ReactInstanceManager.ReactInstanceEventListener
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.network.NetworkingModule
+import com.microsoft.reacttestapp.compat.ReactInstanceEventListener
 
 @Suppress("unused")
 object ReactNativeFlipper {

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -20,6 +20,7 @@ import com.facebook.react.modules.systeminfo.ReactNativeVersion
 import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.BuildConfig
 import com.microsoft.reacttestapp.R
+import com.microsoft.reacttestapp.compat.ReactInstanceEventListener
 import java.util.concurrent.CountDownLatch
 
 sealed class BundleSource {
@@ -61,7 +62,7 @@ class TestAppReactNativeHost(
             error("init() can only be called once on startup")
         }
 
-        val reactInstanceListener = object : ReactInstanceManager.ReactInstanceEventListener {
+        val reactInstanceListener = object : ReactInstanceEventListener {
             override fun onReactContextInitialized(context: ReactContext?) {
                 afterReactNativeInit()
 

--- a/android/app/src/reactinstanceeventlistener-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt
+++ b/android/app/src/reactinstanceeventlistener-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt
@@ -1,0 +1,3 @@
+package com.microsoft.reacttestapp.compat
+
+typealias ReactInstanceEventListener = com.facebook.react.ReactInstanceEventListener

--- a/android/app/src/reactinstanceeventlistener-pre-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt
+++ b/android/app/src/reactinstanceeventlistener-pre-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt
@@ -1,0 +1,5 @@
+package com.microsoft.reacttestapp.compat
+
+import com.facebook.react.ReactInstanceManager
+
+typealias ReactInstanceEventListener = ReactInstanceManager.ReactInstanceEventListener

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "/*.{gradle,js,md,podspec,rb}",
     "/android/**/*.gradle",
     "/android/app/lint.xml",
+    "/android/app/src/**/compat",
     "/android/app/src/{flipper,main}",
     "/android/support/src",
     "/common",


### PR DESCRIPTION
### Description

`ReactInstanceEventListener` was moved in 0.68: https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
yarn
cd example
yarn android
```

Repeat the steps above for 0.68: `npm run set-react-version 0.68`
