### PR TITLE
fix(windows): find `app.json` starting from the solution dir

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -493,7 +493,7 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
   fs.mkdirSync(projectFilesDestPath, { recursive: true });
   fs.mkdirSync(destPath, { recursive: true });
 
-  const manifestFilePath = findNearest("app.json");
+  const manifestFilePath = findNearest("app.json", destPath);
   const { appName, appxManifest, assetItems, assetItemFilters, assetFilters } =
     getBundleResources(manifestFilePath, projectFilesDestPath);
 


### PR DESCRIPTION
### Description

In some projects, the example app is just another directory in the repository (e.g. https://github.com/react-native-webview/react-native-webview/pull/2148). The Windows test app script fails to find `app.json` because it assumes that the file lives next to the nearest `node_modules` folder.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Tested in `react-native-webview`.