### PR TITLE
fix(android): set `allprojects.repositories` in project template

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -12,3 +12,14 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
+
+allprojects {
+    repositories {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("${rootDir}/../node_modules/react-native/android")
+        }
+        mavenCentral()
+        google()
+    }
+}

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -423,7 +423,10 @@ const getConfig = (() => {
               "    repositories {",
               "        maven {",
               "            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm",
-              `            url("\${rootDir}/${path.join(path.dirname(testAppRelPath), "react-native")}/android")`,
+              `            url("\${rootDir}/${path.posix.join(
+                path.dirname(testAppRelPath),
+                "react-native"
+              )}/android")`,
               "        }",
               "        mavenCentral()",
               "        google()",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -418,6 +418,17 @@ const getConfig = (() => {
               `        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"`,
               "    }",
               "}",
+              "",
+              "allprojects {",
+              "    repositories {",
+              "        maven {",
+              "            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm",
+              `            url("\${rootDir}/${path.join(path.dirname(testAppRelPath), "react-native")}/android")`,
+              "        }",
+              "        mavenCentral()",
+              "        google()",
+              "    }",
+              "}",
               ""
             ),
             "gradle/wrapper/gradle-wrapper.jar": {

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -79,6 +79,17 @@ Object {
         classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
     }
 }
+
+allprojects {
+    repositories {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url(\\"\${rootDir}/../react-native/android\\")
+        }
+        mavenCentral()
+        google()
+    }
+}
 ",
     "android/gradle.properties": Object {
       "source": "example/android/gradle.properties",
@@ -489,6 +500,17 @@ Object {
         classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
     }
 }
+
+allprojects {
+    repositories {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url(\\"\${rootDir}/../react-native/android\\")
+        }
+        mavenCentral()
+        google()
+    }
+}
 ",
     "android/gradle.properties": Object {
       "source": "example/android/gradle.properties",
@@ -653,6 +675,17 @@ Object {
     dependencies {
         classpath \\"com.android.tools.build:gradle:$androidPluginVersion\\"
         classpath \\"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\\"
+    }
+}
+
+allprojects {
+    repositories {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url(\\"\${rootDir}/../react-native/android\\")
+        }
+        mavenCentral()
+        google()
     }
 }
 ",


### PR DESCRIPTION
### Description

Some community modules require `allprojects.repositories` to be set to build correctly.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Add `@react-native-community/slider` to example app
   ```diff
   diff --git a/example/package.json b/example/package.json
   index 3097cd5..8e50072 100644
   --- a/example/package.json
   +++ b/example/package.json
   @@ -15,6 +15,9 @@
        "start": "react-native start",
        "windows": "react-native run-windows --sln windows/Example.sln"
      },
   +  "dependencies": {
   +    "@react-native-community/slider": "^4.2.0"
   +  },
      "peerDependencies": {
        "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
        "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0",
   ```
2. Run `yarn`
3. Build the Android test app
   ```sh
   cd example/android
   ./gradlew clean build
   ```