### PR TITLE
fix(windows): .appxmanifest path should always be relative to project

### DIFF
--- a/test/windows-test-app/getBundleResources.test.js
+++ b/test/windows-test-app/getBundleResources.test.js
@@ -31,7 +31,7 @@ describe("getBundleResources", () => {
     } = getBundleResources("app.json", path.resolve(""));
 
     expect(appName).toBe("Example");
-    expect(appxManifest).toBe("windows/Package.appxmanifest");
+    expect(appxManifest).toBe("windows\\Package.appxmanifest");
     expect(assetItems).toMatchInlineSnapshot(`
       "<CopyFileToFolders Include=\\"$(ProjectRootDir)\\\\dist\\\\main.bundle\\">
             <DestinationFolders>$(OutDir)\\\\Bundle</DestinationFolders>
@@ -60,7 +60,7 @@ describe("getBundleResources", () => {
 
     expect(getBundleResources("app.json", path.resolve(""))).toEqual({
       appName: "ReactTestApp",
-      appxManifest: "windows/Example/Package.appxmanifest",
+      appxManifest: "windows\\Example\\Package.appxmanifest",
       assetItems: "",
       assetItemFilters: "",
       assetFilters: "",

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -164,10 +164,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" Condition="Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
+    <AppxManifest Include="$(ProjectRootDir)\$(ReactTestAppPackageManifest)" Condition="Exists('$(ProjectRootDir)\$(ReactTestAppPackageManifest)')">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" Condition="!Exists('$(SolutionDir)$(ReactTestAppPackageManifest)')">
+    <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" Condition="!Exists('$(ProjectRootDir)\$(ReactTestAppPackageManifest)')">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>

--- a/windows/ReactTestApp/ReactTestApp.vcxproj.filters
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj.filters
@@ -57,7 +57,7 @@
     <!-- ReactTestApp asset item filters -->
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="$(SolutionDir)$(ReactTestAppPackageManifest)" />
+    <AppxManifest Include="$(ProjectRootDir)\$(ReactTestAppPackageManifest)" />
     <AppxManifest Include="$(ReactTestAppDir)\Package.appxmanifest" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description

Similar to #764, the path to the `.appxmanifest` file should be relative to the project dir.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Tested in `react-native-webview`.