### PR TITLE
fix(windows): use latest installed Windows SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,7 +356,7 @@ jobs:
     timeout-minutes: 60
   windows:
     name: "Windows"
-    runs-on: windows-2022
+    runs-on: windows-latest
     strategy:
       matrix:
         platform: [ARM64, x64]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,7 +356,7 @@ jobs:
     timeout-minutes: 60
   windows:
     name: "Windows"
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         platform: [ARM64, x64]

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -15,7 +15,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Label="NuGet">


### PR DESCRIPTION
### Description

`react-native-test-app` fails to build on [`windows-2022`](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md) VMs due to missing Windows SDK version:

`C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 10.0.18362.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [D:\a\async-storage\async-storage\node_modules\react-native-windows\Common\Common.vcxproj]`

First discovered in AsyncStorage: https://github.com/react-native-async-storage/async-storage/runs/5217160888?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Building on `windows-2022` does not fail.

Successful build: https://github.com/microsoft/react-native-test-app/runs/5244688451?check_suite_focus=true

![image](https://user-images.githubusercontent.com/4123478/154648434-3f242e91-43de-4fd5-9e9b-6f05da0fe5b5.png)
