### PR TITLE
docs: add Windows certificate properties to JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -204,6 +204,18 @@
         "appxManifest": {
           "description": "Sets the path to your app package manifest. If none is set, a default manifest will be provided. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.",
           "type": "string"
+        },
+        "certificateKeyFile": {
+          "description": "The path to the certificate to use. If specified, it will also enable package signing. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.",
+          "type": "string"
+        },
+        "certificatePassword": {
+          "description": "The password for the private key in the certificate. Leave unset if no password. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.",
+          "type": "string"
+        },
+        "certificateThumbprint": {
+          "description": "This value must match the thumbprint in the signing certificate, or be unset. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.",
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
### Description

Windows signing capabilities were added in https://github.com/microsoft/react-native-test-app/pull/762. Updated the schema and [the wiki](https://github.com/microsoft/react-native-test-app/wiki/Manifest-(app.json)#windows) to reflect the changes.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

![image](https://user-images.githubusercontent.com/4123478/155167159-1542b5b2-8793-435b-95c0-c6b284953db2.png)