### PR TITLE
chore(apple): remove unused compat layer for reloading

### DIFF
--- a/ios/ReactTestApp/React+Compatibility.h
+++ b/ios/ReactTestApp/React+Compatibility.h
@@ -1,7 +1,3 @@
 #import <Foundation/Foundation.h>
 
-@class RCTBridge;
-
 IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector);
-
-void RTATriggerReloadCommand(RCTBridge *, NSString *reason);

--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -27,23 +27,6 @@ IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
     return originalImpl;
 }
 
-// MARK: - [0.62] RCTTriggerReloadCommandListeners replaces -[RCTBridge reload]
-
-// `RCTReloadCommand.h` is excluded from `react-native-macos`
-// See https://github.com/microsoft/react-native-macos/blob/v0.61.39/React-Core.podspec#L66
-#if REACT_NATIVE_VERSION == 0 || REACT_NATIVE_VERSION >= 6200
-#import <React/RCTReloadCommand.h>
-#endif
-
-void RTATriggerReloadCommand(RCTBridge *bridge, NSString *reason)
-{
-#if REACT_NATIVE_VERSION > 0 && REACT_NATIVE_VERSION < 6200
-    [bridge reload];
-#else
-    RCTTriggerReloadCommandListeners(reason);
-#endif
-}
-
 // MARK: - [0.63.2] Images do not render on iOS 14
 // See https://github.com/facebook/react-native/pull/29420
 

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -88,14 +88,14 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
     }
 
     func initReact(bundleRoot: String?, onDidInitialize: @escaping () -> Void) {
-        if let bridge = bridge {
+        if bridge != nil {
             if remoteBundleURL == nil {
                 // When loading the embedded bundle, we must disable remote
                 // debugging to prevent the bridge from getting stuck in
                 // -[RCTWebSocketExecutor executeApplicationScript:sourceURL:onComplete:]
                 RCTDevSettings().isDebuggingRemotely = false
             }
-            RTATriggerReloadCommand(bridge, "ReactTestApp")
+            RCTTriggerReloadCommandListeners("ReactTestApp")
             return
         }
 

--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -7,6 +7,7 @@
 #import <React/RCTDevSettings.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTLog.h>
+#import <React/RCTReloadCommand.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
 #import <React/RCTVersion.h>


### PR DESCRIPTION
### Description

When we dropped support for 0.61, we also forgot to remove the compatibility layer for `RCTTriggerReloadCommandListeners`.

Sidenote: A full list of patches can now be found in [the wiki](https://github.com/microsoft/react-native-test-app/wiki/Patches).

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
yarn set-react-version 0.62
cd example
pod install --project-directory=macos
yarn macos
```