### PR TITLE
fix: helper functions to help declutter `react-native.config.js`

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -3,6 +3,7 @@
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*
 # any settings specified in this file.
+
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 

--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -1,61 +1,24 @@
 const fs = require("fs");
 const path = require("path");
-
-const windowsProjectFile = path.join(
-  "node_modules",
-  ".generated",
-  "windows",
-  "ReactTestApp",
-  "ReactTestApp.vcxproj"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require("react-native-test-app");
 
 module.exports = {
   project: {
     android: {
       sourceDir: "android",
-      manifestPath: path.relative(
-        path.join(__dirname, "android"),
-        path.join(
-          path.dirname(require.resolve("react-native-test-app/package.json")),
-          "android",
-          "app",
-          "src",
-          "main",
-          "AndroidManifest.xml"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, "android")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require("react-native-test-app/scripts/configure");
-        if (
-          packageSatisfiesVersionRange(
-            "@react-native-community/cli-platform-ios",
-            "<5.0.2"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // `project` was only used to infer `sourceDir` and `podfile`.
-          return "ios/ReactTestApp-Dummy.xcodeproj";
-        }
-
-        // `sourceDir` and `podfile` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return "node_modules/.generated/ios/ReactTestApp.xcodeproj";
-      })(),
+      project: iosProjectPath("ios"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync("windows/Example.sln") && {
       sourceDir: "windows",
       solutionFile: "Example.sln",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, "windows"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, "windows")),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "/windows/*.{js,props,sln}",
     "/windows/ReactTestApp"
   ],
+  "main": "scripts/configure.js",
   "bin": {
     "configure-test-app": "scripts/configure.js",
     "init-test-app": "scripts/init.js",

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -24,18 +24,11 @@ use_test_app!
     "metro.config.js": Object {
       "source": "example/metro.config.js",
     },
-    "react-native.config.js": "const {
-  packageSatisfiesVersionRange,
-} = require(\\"react-native-test-app/scripts/configure\\");
+    "react-native.config.js": "const { iosProjectPath } = require(\\"react-native-test-app\\");
 module.exports = {
   project: {
     ios: {
-      project: packageSatisfiesVersionRange(
-        \\"@react-native-community/cli-platform-ios\\",
-        \\"<5.0.2\\"
-      )
-        ? \\"ReactTestApp-Dummy.xcodeproj\\"
-        : \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\",
+      project: iosProjectPath(\\".\\"),
     }
   }
 };
@@ -135,62 +128,25 @@ use_test_app!
     },
     "react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };
@@ -239,62 +195,25 @@ Object {
     },
     "common/react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };
@@ -304,62 +223,25 @@ module.exports = {
     },
     "react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };
@@ -398,62 +280,25 @@ use_test_app!
     },
     "react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };
@@ -562,62 +407,25 @@ use_test_app!
     },
     "react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };
@@ -733,62 +541,25 @@ use_test_app!
     },
     "react-native.config.js": "const fs = require(\\"fs\\");
 const path = require(\\"path\\");
-
-const windowsProjectFile = path.join(
-  \\"node_modules\\",
-  \\".generated\\",
-  \\"windows\\",
-  \\"ReactTestApp\\",
-  \\"ReactTestApp.vcxproj\\"
-);
+const {
+  androidManifestPath,
+  iosProjectPath,
+  windowsProjectPath,
+} = require(\\"react-native-test-app\\");
 
 module.exports = {
   project: {
     android: {
       sourceDir: \\"android\\",
-      manifestPath: path.relative(
-        path.join(__dirname, \\"android\\"),
-        path.join(
-          path.dirname(require.resolve(\\"react-native-test-app/package.json\\")),
-          \\"android\\",
-          \\"app\\",
-          \\"src\\",
-          \\"main\\",
-          \\"AndroidManifest.xml\\"
-        )
-      ),
+      manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
     },
     ios: {
-      project: (() => {
-        const {
-          packageSatisfiesVersionRange,
-        } = require(\\"react-native-test-app/scripts/configure\\");
-        if (
-          packageSatisfiesVersionRange(
-            \\"@react-native-community/cli-platform-ios\\",
-            \\"<5.0.2\\"
-          )
-        ) {
-          // Prior to @react-native-community/cli-platform-ios v5.0.0,
-          // \`project\` was only used to infer \`sourceDir\` and \`podfile\`.
-          return \\"ios/ReactTestApp-Dummy.xcodeproj\\";
-        }
-
-        // \`sourceDir\` and \`podfile\` detection was fixed in
-        // @react-native-community/cli-platform-ios v5.0.2 (see
-        // https://github.com/react-native-community/cli/pull/1444).
-        return \\"node_modules/.generated/ios/ReactTestApp.xcodeproj\\";
-      })(),
+      project: iosProjectPath(\\"ios\\"),
     },
-    windows: fs.existsSync(windowsProjectFile) && {
+    windows: fs.existsSync(\\"windows/Test.sln\\") && {
       sourceDir: \\"windows\\",
       solutionFile: \\"Test.sln\\",
-      project: {
-        projectFile: path.relative(
-          path.join(__dirname, \\"windows\\"),
-          windowsProjectFile
-        ),
-      },
+      project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
     },
   },
 };

--- a/test/configure/reactNativeConfig.test.js
+++ b/test/configure/reactNativeConfig.test.js
@@ -23,34 +23,30 @@ describe("reactNativeConfig()", () => {
 
   test("returns Android specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["android"], flatten: true });
-    expect(reactNativeConfig(params)).toContain("AndroidManifest.xml");
-    expect(reactNativeConfig(params)).not.toContain(
-      "ReactTestApp-Dummy.xcodeproj"
-    );
-    expect(reactNativeConfig(params)).not.toContain("ReactTestApp.vcxproj");
+    expect(reactNativeConfig(params)).toContain("androidManifestPath");
+    expect(reactNativeConfig(params)).not.toContain("iosProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
   });
 
   test("returns iOS specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["ios"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("AndroidManifest.xml");
-    expect(reactNativeConfig(params)).toContain("ReactTestApp-Dummy.xcodeproj");
-    expect(reactNativeConfig(params)).not.toContain("ReactTestApp.vcxproj");
+    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
+    expect(reactNativeConfig(params)).toContain("iosProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
   });
 
   test("returns macOS specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["macos"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("AndroidManifest.xml");
-    expect(reactNativeConfig(params)).toContain("ReactTestApp-Dummy.xcodeproj");
-    expect(reactNativeConfig(params)).not.toContain("ReactTestApp.vcxproj");
+    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
+    expect(reactNativeConfig(params)).toContain("iosProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
   });
 
   test("returns Windows specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["windows"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("AndroidManifest.xml");
-    expect(reactNativeConfig(params)).not.toContain(
-      "ReactTestApp-Dummy.xcodeproj"
-    );
-    expect(reactNativeConfig(params)).toContain("ReactTestApp.vcxproj");
+    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
+    expect(reactNativeConfig(params)).not.toContain("iosProjectPath");
+    expect(reactNativeConfig(params)).toContain("windowsProjectPath");
   });
 
   test("throws when an unknown platform is specified", () => {


### PR DESCRIPTION
### Description

Introduce helper functions to help declutter `react-native.config.js`

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

CI should pass.