### PR TITLE
fix(macos): set up `RCTLinkingManager` on startup

### DIFF
--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -67,6 +67,13 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
                 name: .didReceiveRemoteBundleURL,
                 object: nil
             )
+        #else
+            NSAppleEventManager.shared().setEventHandler(
+                RCTLinkingManager.self,
+                andSelector: #selector(RCTLinkingManager.getUrlEventHandler(_:withReplyEvent:)),
+                forEventClass: AEEventClass(kInternetEventClass),
+                andEventID: AEEventID(kAEGetURL)
+            )
         #endif
 
         #if USE_FLIPPER

--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -6,6 +6,7 @@
 #import <React/RCTDevMenu.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTEventEmitter.h>
+#import <React/RCTLinkingManager.h>
 #import <React/RCTLog.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTRootView.h>

--- a/ios/ReactTestApp/SceneDelegate.swift
+++ b/ios/ReactTestApp/SceneDelegate.swift
@@ -61,6 +61,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            RCTLinkingManager.application(
+                UIApplication.shared,
+                open: context.url,
+                options: context.options.dictionary()
+            )
+        }
+
         NotificationCenter.default.post(
             name: .ReactTestAppSceneDidOpenURL,
             object: [
@@ -68,5 +76,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 "URLContexts": URLContexts,
             ]
         )
+    }
+}
+
+extension UIScene.OpenURLOptions {
+    func dictionary() -> [UIApplication.OpenURLOptionsKey: Any] {
+        var options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+
+        if let sourceApplication = sourceApplication {
+            options[.sourceApplication] = sourceApplication
+        }
+
+        if let annotation = annotation {
+            options[.annotation] = annotation
+        }
+
+        options[.openInPlace] = openInPlace
+
+        if #available(iOS 14.5, *) {
+            if let eventAttribution = eventAttribution {
+                options[.eventAttribution] = eventAttribution
+            }
+        }
+
+        return options
     }
 }


### PR DESCRIPTION
### Description

`RCTLinkingManager` needs to be set up on startup.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

CI should pass.