### PR TITLE
ci: fix Windows nightlies failing to restore NuGet pkgs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
         working-directory: example
       - name: Install NuGet packages
         run: |
-          nuget restore -FallbackSource "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json"
+          nuget restore -Source "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json;https://api.nuget.org/v3/index.json"
         working-directory: example/windows
       - name: Build
         run: |


### PR DESCRIPTION
### Description

Windows nightlies are failing to restore NuGet packages: https://github.com/microsoft/react-native-test-app/runs/5655243721?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
yarn set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-nuget
cd windows
nuget restore -Source "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json;https://api.nuget.org/v3/index.json"
```