### PR TITLE
chore: address CVE-2022-22912

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10273,12 +10273,12 @@ __metadata:
   linkType: hard
 
 "plist@npm:^3.0.1, plist@npm:^3.0.2":
-  version: 3.0.4
-  resolution: "plist@npm:3.0.4"
+  version: 3.0.5
+  resolution: "plist@npm:3.0.5"
   dependencies:
     base64-js: ^1.5.1
     xmlbuilder: ^9.0.7
-  checksum: cb5883ed1b1aa227ddc5f99003750d312a8ac5cfd6f58d3ce0b24939255b175b54f25ebc6adcbd4266105ffd54f6831acb6cb06f529652bb3344215c10f5601b
+  checksum: f8b82816f66559965a4dabf139bd8dd95cdec7e51f32742bb353af276ea8228b9807113743b860eda3e867f6ed70d2bcbc1e135b3204d92b5c37ac765f68444e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

For details, see https://github.com/advisories/GHSA-4cpg-3vgw-4877.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.