### PR TITLE
docs: fix Visual Studio Code badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native Test App
 
-[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/microsoft/react-native-test-app)
+[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&color=007acc&labelColor=444444&logoColor=007acc)](https://vscode.dev/github/microsoft/react-native-test-app)
 [![build](https://github.com/microsoft/react-native-test-app/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/react-native-test-app/actions/workflows/build.yml)
 [![npm version](https://img.shields.io/npm/v/react-native-test-app)](https://www.npmjs.com/package/react-native-test-app)
 


### PR DESCRIPTION
### Description

The badge was removed at some point. Made a custom one at [Shields.io](https://shields.io/) using the [official colour palette](https://code.visualstudio.com/brand#brand-colors).

Resolves #825.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a