### PR TITLE
fix(windows): don't overwrite existing `NuGet.Config`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,8 @@ jobs:
         working-directory: example
       - name: Install NuGet packages
         run: |
-          nuget restore -Source "https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json;https://api.nuget.org/v3/index.json"
+          nuget sources Add -Name react-native -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
+          nuget restore
         working-directory: example/windows
       - name: Build
         run: |

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -765,9 +765,10 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
             "NuGet.Config"
           )
         );
-      if (nugetConfigPath) {
+      const nugetConfigDestPath = path.join(destPath, "NuGet.Config");
+      if (nugetConfigPath && !fs.existsSync(nugetConfigDestPath)) {
         fs.writeFile(
-          path.join(destPath, "NuGet.Config"),
+          nugetConfigDestPath,
           mustache.render(
             fs.readFileSync(nugetConfigPath, textFileReadOptions),
             {}


### PR DESCRIPTION
### Description

Don't overwrite `NuGet.Config` if it exists.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

n/a