### PR TITLE
fix(windows): fix duplicate NuGet packages when on 0.68+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,14 +399,18 @@ jobs:
         run: |
           yarn jest
         working-directory: example
-      - name: Install NuGet packages
+      - name: Set up NuGet sources
+        if: ${{ github.event_name == 'schedule' }}
         run: |
-          nuget sources Add -Name react-native -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
-          nuget restore
+          nuget sources Add -Name react-native-windows -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
         working-directory: example/windows
       - name: Build
         run: |
-          ../../scripts/MSBuild.ps1 -Configuration ${{ matrix.configuration }} -Platform ${{ matrix.platform }} Example.sln
+          if ("${{ matrix.configuration }}" -eq "Release") {
+            yarn ci:windows --release --arch ${{ matrix.platform }}
+          } else {
+            yarn ci:windows --arch ${{ matrix.platform }}
+          }
         working-directory: example/windows
       - name: Test
         if: ${{ matrix.platform == 'x64' }}
@@ -439,15 +443,13 @@ jobs:
           if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app }
           else { yarn install-windows-test-app --project-directory=. }
         working-directory: template-example
-      - name: Install NuGet packages
-        run: |
-          if ("${{ matrix.template }}" -eq "all") { cd windows }
-          nuget restore
-        working-directory: template-example
       - name: Build
         run: |
-          if ("${{ matrix.template }}" -eq "all") { ../scripts/MSBuild.ps1 windows/TemplateExample.sln }
-          else { ../scripts/MSBuild.ps1 TemplateExample.sln }
+          if ("${{ matrix.template }}" -eq "all") {
+            yarn react-native run-windows --logging --no-packager --no-launch --no-deploy
+          } else {
+            yarn react-native run-windows --logging --no-packager --no-launch --no-deploy --sln TemplateExample.sln
+          }
         working-directory: template-example
     timeout-minutes: 60
   release:

--- a/example/package.json
+++ b/example/package.json
@@ -8,12 +8,13 @@
     "build:ios": "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
     "build:macos": "mkdirp dist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
     "build:windows": "mkdirp dist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
+    "ci:windows": "react-native run-windows --logging --no-packager --no-launch --no-deploy",
     "clean": "yarn workspace react-native-test-app clean",
     "ios": "react-native run-ios",
     "macos": "react-native run-macos --scheme Example",
     "set-react-version": "yarn workspace react-native-test-app set-react-version",
     "start": "react-native start",
-    "windows": "react-native run-windows --sln windows/Example.sln"
+    "windows": "react-native run-windows --no-packager"
   },
   "peerDependencies": {
     "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",

--- a/scripts/set-react-version.js
+++ b/scripts/set-react-version.js
@@ -15,7 +15,6 @@ const pacote = require("pacote");
 const VALID_TAGS = ["canary-macos", "canary-windows", "main", "nightly"];
 const REACT_NATIVE_VERSIONS = {
   "canary-macos": "^0.66",
-  "canary-windows": "^0.67.0-0",
 };
 
 /**
@@ -61,7 +60,7 @@ function fetchReactNativeWindowsCanaryInfoViaNuGet() {
     const { spawn } = require("child_process");
 
     let isResolved = false;
-    const list = spawn("nuget.exe", [
+    const list = spawn(process.env["NUGET_EXE"] || "nuget.exe", [
       "list",
       "Microsoft.ReactNative.Cxx",
       "-Source",
@@ -128,12 +127,13 @@ async function getProfile(v) {
     }
 
     case "canary-windows": {
-      const { version, dependencies, peerDependencies } = process.env["CI"]
-        ? await fetchReactNativeWindowsCanaryInfoViaNuGet()
-        : await fetchPackageInfo("react-native-windows@canary");
+      const { version, dependencies, peerDependencies } =
+        process.env["CI"] || process.env["NUGET_EXE"]
+          ? await fetchReactNativeWindowsCanaryInfoViaNuGet()
+          : await fetchPackageInfo("react-native-windows@canary");
       return {
         ...pickCommonDependencies(dependencies, peerDependencies),
-        "react-native": REACT_NATIVE_VERSIONS[v],
+        "react-native": peerDependencies?.["react-native"] || "^0.0.0-0",
         "react-native-macos": undefined,
         "react-native-windows": version,
       };

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -555,7 +555,12 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
   const rnWindowsVersion = getPackageVersion(rnWindowsPath);
   const rnWindowsVersionNumber = getVersionNumber(rnWindowsVersion);
   const hermesVersion = useHermes && getHermesVersion(rnWindowsPath);
-  const xamlVersion = rnWindowsVersionNumber < 6700 ? "2.6.0" : "2.7.0";
+  const usePackageReferences =
+    rnWindowsVersionNumber === 0 || rnWindowsVersionNumber >= 6800;
+  const xamlVersion =
+    rnWindowsVersionNumber > 0 && rnWindowsVersionNumber < 6700
+      ? "2.6.0"
+      : "2.7.0";
 
   /** @type {[string, Record<string, string>?][]} */
   const projectFiles = [
@@ -603,7 +608,7 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
       {
         '<package id="Microsoft.UI.Xaml" version="0.0.0" targetFramework="native"/>':
           nuGetPackage("Microsoft.UI.Xaml", xamlVersion),
-        ...(useNuGet
+        ...(useNuGet && !usePackageReferences
           ? {
               '<!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native"/ -->':
                 nuGetPackage("Microsoft.ReactNative", rnWindowsVersion),
@@ -611,7 +616,7 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
                 nuGetPackage("Microsoft.ReactNative.Cxx", rnWindowsVersion),
             }
           : undefined),
-        ...(hermesVersion
+        ...(hermesVersion && !usePackageReferences
           ? {
               '<!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->':
                 nuGetPackage("ReactNative.Hermes.Windows", hermesVersion),


### PR DESCRIPTION
### Description

Windows nightlies are failing due errors like below:

```
2>D:\react-native-test-app\example\windows\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.474\tools\Microsoft.ReactNative.Cxx\ModuleRegistration.cpp : fatal error C1083: Cannot open compiler generated file: 'D:\react-native-test-app\example\node_modules\.generated\windows\ReactTestApp\x64\Debug\ModuleRegistration.obj': Permission denied [D:\react-native-test-app\example\node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj]
2>C:\~\.nuget\packages\microsoft.reactnative.cxx\0.0.0-canary.474\tools\Microsoft.ReactNative.Cxx\JSValueTreeReader.cpp : fatal error C1083: Cannot open compiler generated file: 'D:\react-native-test-app\example\node_modules\.generated\windows\ReactTestApp\x64\Debug\JSValueTreeReader.obj': Permission denied [D:\react-native-test-app\example\node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj]
2>D:\react-native-test-app\example\windows\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.474\tools\Microsoft.ReactNative.Cxx\jsi\jsi.h(34,25): error C2011: 'facebook::jsi::Buffer': 'class' type redefinition (compiling source file C:\~\.nuget\packages\microsoft.reactnative.cxx\0.0.0-canary.474\tools\Microsoft.ReactNative.Cxx\TurboModuleProvider.cpp) [D:\react-native-test-app\example\node_modules\.generated\windows\ReactTestApp\ReactTestApp.vcxproj]
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Repeat the steps below for `0.66`, `0.68`, `canary-windows`:

```sh
NUGET_EXE=/path/to/nuget.exe yarn set-react-version [version]
yarn clean
yarn

cd example

yarn install-windows-test-app --use-nuget
yarn ci:windows

git clean -dfqx node_modules/.generated windows

yarn install-windows-test-app
yarn ci:windows
```