### PR TITLE
fix(windows): fix wrong preprocessor check

### DIFF
--- a/windows/ReactTestApp/ReactInstance.cpp
+++ b/windows/ReactTestApp/ReactInstance.cpp
@@ -141,10 +141,10 @@ void ReactInstance::Reload()
     instanceSettings.UseDeveloperSupport(false);
 #endif
 
-#ifdef REACT_NATIVE_VERSION >= 6300
+#if REACT_NATIVE_VERSION >= 6300
     auto [host, port] = BundlerAddress();
     instanceSettings.SourceBundleHost(host);
-    instanceSettings.SourceBundlePort(port);
+    instanceSettings.SourceBundlePort(static_cast<uint16_t>(port));
 #endif  // REACT_NATIVE_VERSION >= 6300
 
     reactNativeHost_.ReloadInstance();


### PR DESCRIPTION
### Description

We should be checking whether the value of `REACT_NATIVE_VERSION` is greater than 0.63, not whether it is defined.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

CI should pass.