### PR TITLE
fix: add support for `@react-native-community/cli` 8.x

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -7,19 +7,18 @@ const project = (() => {
       iosProjectPath,
       windowsProjectPath,
     } = require("react-native-test-app");
+    const iosProject = iosProjectPath("ios");
     return {
       android: {
         sourceDir: "android",
         manifestPath: androidManifestPath(path.join(__dirname, "android")),
-      },
-      ios: {
-        project: iosProjectPath("ios"),
       },
       windows: fs.existsSync("windows/Example.sln") && {
         sourceDir: "windows",
         solutionFile: "Example.sln",
         project: windowsProjectPath(path.join(__dirname, "windows")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -27,11 +27,14 @@ use_test_app!
     "react-native.config.js": "const project = (() => {
   try {
     const { iosProjectPath } = require(\\"react-native-test-app\\");
-    return {
-      ios: {
-        project: iosProjectPath(\\".\\"),
-      },
-    };
+    const project = iosProjectPath(\\".\\");
+    return project
+      ? {
+          ios: {
+            project,
+          },
+        }
+      : undefined;
   } catch (_) {
     return undefined;
   }
@@ -143,19 +146,18 @@ use_test_app!
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;
@@ -217,19 +219,18 @@ Object {
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;
@@ -252,19 +253,18 @@ module.exports = {
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;
@@ -316,19 +316,18 @@ use_test_app!
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;
@@ -450,19 +449,18 @@ use_test_app!
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;
@@ -591,19 +589,18 @@ use_test_app!
       iosProjectPath,
       windowsProjectPath,
     } = require(\\"react-native-test-app\\");
+    const iosProject = iosProjectPath(\\"ios\\");
     return {
       android: {
         sourceDir: \\"android\\",
         manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
-      },
-      ios: {
-        project: iosProjectPath(\\"ios\\"),
       },
       windows: fs.existsSync(\\"windows/Test.sln\\") && {
         sourceDir: \\"windows\\",
         solutionFile: \\"Test.sln\\",
         project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
       },
+      ...(iosProject ? { ios: { project: iosProject } } : undefined),
     };
   } catch (_) {
     return undefined;


### PR DESCRIPTION
### Description

A bunch of refactoring in `@react-native-community/cli` 8.x now makes the iOS config unnecessary.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan
1. Install dependencies: `yarn`
2. Build and run iOS app:
   ```sh
   cd example
   pod install --project-directory=ios
   yarn ios
   ```
3. Build and run macOS app: `yarn macos`
   ```sh
   cd example
   pod install --project-directory=macos
   yarn macos
   ```
4. Clean out everything: `yarn clean`
5. Repeat the steps 1-3 using CLI 8.0.0 alpha:
   ```diff
   diff --git a/example/package.json b/example/package.json
   index 87bdf19..3ca0f98 100644
   --- a/example/package.json
   +++ b/example/package.json
   @@ -24,6 +24,9 @@
      },
      "devDependencies": {
        "@babel/core": "^7.0.0",
   +    "@react-native-community/cli": "^8.0.0-0",
   +    "@react-native-community/cli-platform-android": "^8.0.0-0",
   +    "@react-native-community/cli-platform-ios": "^8.0.0-0",
        "@types/jest": "^27.0.0",
        "jest": "^27.0.0",
        "metro-react-native-babel-preset": "^0.66.2",
   diff --git a/package.json b/package.json
   index 80920db..c24d151 100644
   --- a/package.json
   +++ b/package.json
   @@ -109,9 +109,9 @@
        "@commitlint/cli": "^16.0.0",
        "@commitlint/config-conventional": "^16.0.0",
        "@microsoft/eslint-plugin-sdl": "^0.2.0",
   -    "@react-native-community/cli": "^6.0.0",
   -    "@react-native-community/cli-platform-android": "^6.0.0",
   -    "@react-native-community/cli-platform-ios": "^6.0.0",
   +    "@react-native-community/cli": "^8.0.0-0",
   +    "@react-native-community/cli-platform-android": "^8.0.0-0",
   +    "@react-native-community/cli-platform-ios": "^8.0.0-0",
        "@rnx-kit/eslint-plugin": "^0.2.0",
        "@types/jest": "^27.0.0",
        "@types/mustache": "^4.0.0",
   @@ -137,6 +137,9 @@
      },
      "packageManager": "yarn@3.1.1",
      "resolutions": {
   +    "@react-native-community/cli": "^8.0.0-0",
   +    "@react-native-community/cli-platform-android": "^8.0.0-0",
   +    "@react-native-community/cli-platform-ios": "^8.0.0-0",
        "eslint-plugin-react": "^7.26.0",
        "npm/chalk": "^4.1.0"
      },
   ```