### PR TITLE
chore: address CVE-2021-43138

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,11 +3346,11 @@ __metadata:
   linkType: hard
 
 "async@npm:^2.4.0":
-  version: 2.6.3
-  resolution: "async@npm:2.6.3"
+  version: 2.6.4
+  resolution: "async@npm:2.6.4"
   dependencies:
     lodash: ^4.17.14
-  checksum: 5e5561ff8fca807e88738533d620488ac03a5c43fce6c937451f7e35f943d33ad06c24af3f681a48cca3d2b0002b3118faff0a128dc89438a9bf0226f712c499
+  checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

For more details, see https://github.com/advisories/GHSA-fwr7-v2mv-hh25

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a