### PR TITLE
test: fix test failing when only iOS is built

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -104,7 +104,7 @@ describe("react-native config", () => {
       project: expect.objectContaining({
         android: {
           sourceDir: expect.stringContaining(sourceDir),
-          appName: "app",
+          appName: fs.existsSync("android/app") ? "app" : "",
           packageName: "com.microsoft.reacttestapp",
         },
       }),


### PR DESCRIPTION
### Description

See https://github.com/microsoft/react-native-test-app/runs/6112386524?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a