### PR TITLE
ci(windows): fix nightlies not being restored correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,6 +403,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           nuget sources Add -Name react-native-windows -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
+          cp NuGet.Config ../node_modules/.generated/windows/ReactTestApp
         working-directory: example/windows
       - name: Build
         run: |


### PR DESCRIPTION
### Description

Nightly Windows builds are failing to restore NuGet packages: https://github.com/microsoft/react-native-test-app/runs/6112387718?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
yarn set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-nuget
yarn ci:windows --arch x64
```