### PR TITLE
docs: prefer `npx` over `yarn` to be more package manager agnostic

### DIFF
--- a/.github/actions/init-test-app/action.yml
+++ b/.github/actions/init-test-app/action.yml
@@ -22,6 +22,6 @@ runs:
       shell: bash
     - name: react-native init-test-app
       run: |
-        yarn react-native init-test-app --destination test-app --name TestApp --platform ${{ inputs.platform }}
+        npx react-native init-test-app --destination test-app --name TestApp --platform ${{ inputs.platform }}
       shell: bash
       working-directory: template-example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           npm run lint:js
           echo "::remove-matcher owner=eslint-stylish::"
           npx tsc
-          npm run test:js --ci
+          npm run test:js -- --ci
       - name: ktlint
         if: ${{ matrix.platform == 'macos' }}
         run: |
@@ -105,7 +105,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && matrix.platform == 'macos' }}
         run: |
           echo "::add-matcher::.github/swiftformat.json"
-          npm run format:swift --lint
+          npm run format:swift -- --lint
           echo "::remove-matcher owner=swiftformat::"
       - name: SwiftLint
         if: ${{ matrix.platform == 'macos' }}
@@ -134,7 +134,7 @@ jobs:
           # https://github.com/microsoft/react-native-macos/issues/620 for more
           # details.
           yarn
-          npm run set-react-version main
+          npm run set-react-version -- main
           rm example/ios/Podfile.lock
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
@@ -224,7 +224,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           yarn
-          npm run set-react-version nightly
+          npm run set-react-version -- nightly
         shell: bash
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
@@ -236,7 +236,9 @@ jobs:
         working-directory: example
       - name: Bundle JavaScript
         run: |
-          npm run build:android || npm run build:android
+          # `npm run` fails with "Workspaces not supported for global packages"
+          # on Windows if we don't use `yarn` here. ¯\_(ツ)_/¯
+          yarn build:android || yarn build:android
         shell: bash
         working-directory: example
       - name: Build
@@ -265,7 +267,7 @@ jobs:
           platform: ${{ matrix.template }}
       - name: Bundle JavaScript
         run: |
-          npm run build:android || npm run build:android
+          yarn build:android || yarn build:android
         shell: bash
         working-directory: template-example
       - name: Build
@@ -292,7 +294,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           yarn
-          npm run set-react-version canary-macos
+          npm run set-react-version -- canary-macos
           rm example/macos/Podfile.lock
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
@@ -384,7 +386,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: |
           yarn
-          npm run set-react-version canary-windows
+          npm run set-react-version -- canary-windows
         shell: bash
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
@@ -408,9 +410,9 @@ jobs:
       - name: Build
         run: |
           if ("${{ matrix.configuration }}" -eq "Release") {
-            npm run ci:windows --release --arch ${{ matrix.platform }}
+            npm run ci:windows -- --release --arch ${{ matrix.platform }}
           } else {
-            npm run ci:windows --arch ${{ matrix.platform }}
+            npm run ci:windows -- --arch ${{ matrix.platform }}
           }
         working-directory: example/windows
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/yarn
       - name: Lint commit message
         run: |
-          yarn lint:commit
+          npm run lint:commit
   lint-test:
     name: "lint + test"
     strategy:
@@ -50,9 +50,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yarn codegen
+          npm run codegen
           if [[ -n "$GITHUB_TOKEN" ]]; then
-            git diff | yarn suggestion-bot
+            git diff | npx suggestion-bot
           fi
           git diff --exit-code
         shell: bash
@@ -90,22 +90,22 @@ jobs:
           #       account.
           scripts/prettier-diff.js $(git ls-files '*.js' '*.yml' 'test/**/*.json') || true
           echo "::add-matcher::.github/eslint-stylish.json"
-          yarn lint:js
+          npm run lint:js
           echo "::remove-matcher owner=eslint-stylish::"
-          yarn tsc
-          yarn test:js --ci
+          npx tsc
+          npm run test:js --ci
       - name: ktlint
         if: ${{ matrix.platform == 'macos' }}
         run: |
           brew install ktlint
           echo "::add-matcher::.github/ktlint.json"
-          yarn lint:kt
+          npm run lint:kt
           echo "::remove-matcher owner=ktlint::"
       - name: SwiftFormat
         if: ${{ github.event_name == 'pull_request' && matrix.platform == 'macos' }}
         run: |
           echo "::add-matcher::.github/swiftformat.json"
-          yarn format:swift --lint
+          npm run format:swift --lint
           echo "::remove-matcher owner=swiftformat::"
       - name: SwiftLint
         if: ${{ matrix.platform == 'macos' }}
@@ -142,7 +142,7 @@ jobs:
           immutable: ${{ github.event_name != 'schedule' }}
       - name: Bundle JavaScript
         run: |
-          yarn build:ios || yarn build:ios
+          npm run build:ios || npm run build:ios
         working-directory: example
       - name: Install Pods
         uses: ./.github/actions/cocoapods
@@ -155,7 +155,7 @@ jobs:
         working-directory: example
       - name: Test `react-native config`
         run: |
-          yarn jest
+          npx jest
         working-directory: example
       - name: Test
         run: |
@@ -183,7 +183,7 @@ jobs:
           platform: ${{ matrix.template }}
       - name: Bundle JavaScript
         run: |
-          yarn build:ios || yarn build:ios
+          npm run build:ios || npm run build:ios
         working-directory: template-example
       - name: Determine project directory
         id: configure
@@ -232,11 +232,11 @@ jobs:
           immutable: ${{ github.event_name != 'schedule' }}
       - name: Test `react-native config`
         run: |
-          yarn jest
+          npx jest
         working-directory: example
       - name: Bundle JavaScript
         run: |
-          yarn build:android || yarn build:android
+          npm run build:android || npm run build:android
         shell: bash
         working-directory: example
       - name: Build
@@ -265,7 +265,7 @@ jobs:
           platform: ${{ matrix.template }}
       - name: Bundle JavaScript
         run: |
-          yarn build:android || yarn build:android
+          npm run build:android || npm run build:android
         shell: bash
         working-directory: template-example
       - name: Build
@@ -300,7 +300,7 @@ jobs:
           immutable: ${{ github.event_name != 'schedule' }}
       - name: Bundle JavaScript
         run: |
-          yarn build:macos || yarn build:macos
+          npm run build:macos || npm run build:macos
         working-directory: example
       - name: Install Pods
         uses: ./.github/actions/cocoapods
@@ -313,7 +313,7 @@ jobs:
         working-directory: example
       - name: Test `react-native config`
         run: |
-          yarn jest
+          npx jest
         working-directory: example
       - name: Test
         if: ${{ github.event_name != 'schedule' }}
@@ -347,7 +347,7 @@ jobs:
           platform: ${{ matrix.template }}
       - name: Bundle JavaScript
         run: |
-          yarn build:macos || yarn build:macos
+          npm run build:macos || npm run build:macos
         working-directory: template-example
       - name: Determine project directory
         id: configure
@@ -392,12 +392,12 @@ jobs:
           immutable: ${{ github.event_name != 'schedule' }}
       - name: Build bundle and create solution
         run: |
-          yarn build:windows
-          yarn install-windows-test-app --use-nuget
+          npm run build:windows
+          npx install-windows-test-app --use-nuget
         working-directory: example
       - name: Test `react-native config`
         run: |
-          yarn jest
+          npx jest
         working-directory: example
       - name: Set up NuGet sources
         if: ${{ github.event_name == 'schedule' }}
@@ -408,9 +408,9 @@ jobs:
       - name: Build
         run: |
           if ("${{ matrix.configuration }}" -eq "Release") {
-            yarn ci:windows --release --arch ${{ matrix.platform }}
+            npm run ci:windows --release --arch ${{ matrix.platform }}
           } else {
-            yarn ci:windows --arch ${{ matrix.platform }}
+            npm run ci:windows --arch ${{ matrix.platform }}
           }
         working-directory: example/windows
       - name: Test
@@ -440,16 +440,16 @@ jobs:
           platform: ${{ matrix.template }}
       - name: Build bundle and create solution
         run: |
-          yarn build:windows
-          if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app }
-          else { yarn install-windows-test-app --project-directory=. }
+          npm run build:windows
+          if ("${{ matrix.template }}" -eq "all") { npx install-windows-test-app }
+          else { npx install-windows-test-app --project-directory=. }
         working-directory: template-example
       - name: Build
         run: |
           if ("${{ matrix.template }}" -eq "all") {
-            yarn react-native run-windows --logging --no-packager --no-launch --no-deploy
+            npx react-native run-windows --logging --no-packager --no-launch --no-deploy
           } else {
-            yarn react-native run-windows --logging --no-packager --no-launch --no-deploy --sln TemplateExample.sln
+            npx react-native run-windows --logging --no-packager --no-launch --no-deploy --sln TemplateExample.sln
           }
         working-directory: template-example
     timeout-minutes: 60

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel=warn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ open macos/Example.xcworkspace
 Before you can run the Windows app, you must first generate it:
 
 ```sh
-yarn install-windows-test-app --use-nuget
+npx install-windows-test-app --use-nuget
 ```
 
 To start the Windows app, run:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ yarn build:ios
 Before you can run the Windows app, you must first generate it:
 
 ```sh
-yarn install-windows-test-app --use-nuget
+npx install-windows-test-app --use-nuget
 ```
 
 To start the Windows app, run:

--- a/schema.json
+++ b/schema.json
@@ -197,19 +197,19 @@
       "type": "object",
       "properties": {
         "appxManifest": {
-          "description": "Sets the path to your <a href='https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest'>app package manifest</a>. If none is set, a default manifest will be provided. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/0.5.5'>0.5.5</a>.",
+          "description": "Sets the path to your <a href='https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest'>app package manifest</a>. If none is set, a default manifest will be provided. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/0.5.5'>0.5.5</a>.",
           "type": "string"
         },
         "certificateKeyFile": {
-          "description": "The path to the certificate to use. If specified, it will also enable package signing. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
+          "description": "The path to the certificate to use. If specified, it will also enable package signing. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
           "type": "string"
         },
         "certificatePassword": {
-          "description": "The password for the private key in the certificate. Leave unset if no password. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
+          "description": "The password for the private key in the certificate. Leave unset if no password. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
           "type": "string"
         },
         "certificateThumbprint": {
-          "description": "This value must match the thumbprint in the signing certificate, or be unset. Changes to this property will not be automatically be picked up; you need to re-run `yarn install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
+          "description": "This value must match the thumbprint in the signing certificate, or be unset. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in <a href='//github.com/microsoft/react-native-test-app/releases/tag/1.1.0'>1.1.0</a>.",
           "type": "string"
         }
       }

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -7,4 +7,4 @@ if [[ -z $DEBUG ]]; then
 fi
 git diff --unified=0 --no-color @^ \
   | python clang-format-diff.py -p1 -regex '.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hh|hpp|m|mm|inc)' -sort-includes \
-  | yarn suggestion-bot
+  | npx suggestion-bot

--- a/scripts/install-test-template.sh
+++ b/scripts/install-test-template.sh
@@ -35,7 +35,7 @@ done
 npm pack
 
 yarn
-yarn react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
+npx react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
 
 pushd template-example 1> /dev/null
 


### PR DESCRIPTION
### Description

Prefer `npx` over `yarn` where the latter is strictly not required.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a