### PR TITLE
fix: declare support for react-native 0.69

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,6 +16,7 @@ plugins {
 buildDir = "${rootDir}/${name}/build"
 
 def reactNativeDir = findNodeModulesPath(rootDir, "react-native")
+def reactNativeVersion = getReactNativeVersionNumber(rootDir)
 
 repositories {
     maven {
@@ -26,7 +27,7 @@ repositories {
     google()
 
     // TODO: Remove this block when we drop support for 0.64.
-    if (getReactNativeVersionNumber(rootDir) < 6500) {
+    if (reactNativeVersion < 6500) {
         // Artifacts for 0.65+ are published to Maven Central. If we're on an
         // older version, we still need to use JCenter.
         // noinspection JcenterRepositoryObsolete
@@ -69,14 +70,20 @@ android {
 
     // TODO: Remove this block when minSdkVersion >= 24. See
     // https://stackoverflow.com/q/53402639 for details.
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    if (reactNativeVersion < 6900) {
+        compileOptions {
+            sourceCompatibility(JavaVersion.VERSION_1_8)
+            targetCompatibility(JavaVersion.VERSION_1_8)
+        }
     }
 
     kotlinOptions {
         allWarningsAsErrors = true
-        jvmTarget = JavaVersion.VERSION_1_8
+        if (reactNativeVersion < 6900) {
+            jvmTarget = JavaVersion.VERSION_1_8
+        } else {
+            jvmTarget = JavaVersion.VERSION_11
+        }
     }
 
     defaultConfig {
@@ -149,7 +156,7 @@ android {
 
         // TODO: Remove this block when we drop support for 0.67.
         // https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4
-        if (getReactNativeVersionNumber(rootDir) < 6800) {
+        if (reactNativeVersion < 6800) {
             main.java.srcDirs += "src/reactinstanceeventlistener-pre-0.68/java"
         } else {
             main.java.srcDirs += "src/reactinstanceeventlistener-0.68/java"
@@ -161,16 +168,23 @@ dependencies {
     implementation project(":support")
 
     if (project.ext.react.enableHermes) {
-        def hermesEngineDir =
-            findNodeModulesPath(file(reactNativeDir), "hermes-engine")
-                ?: findNodeModulesPath(file(reactNativeDir), "hermesvm")
-        if (hermesEngineDir == null) {
-            throw new GradleException("Could not find 'hermes-engine'. Please make sure you've added it to 'package.json'.")
-        }
+        // TODO: Remove this block when we drop support for 0.68.
+        if (reactNativeVersion < 6900) {
+            def hermesEngineDir =
+                findNodeModulesPath(file(reactNativeDir), "hermes-engine")
+                    ?: findNodeModulesPath(file(reactNativeDir), "hermesvm")
+            if (hermesEngineDir == null) {
+                throw new GradleException("Could not find 'hermes-engine'. Please make sure you've added it to 'package.json'.")
+            }
 
-        def hermesAndroidDir = "${hermesEngineDir}/android"
-        releaseImplementation files("${hermesAndroidDir}/hermes-release.aar")
-        debugImplementation files("${hermesAndroidDir}/hermes-debug.aar")
+            def hermesAndroidDir = "${hermesEngineDir}/android"
+            releaseImplementation files("${hermesAndroidDir}/hermes-release.aar")
+            debugImplementation files("${hermesAndroidDir}/hermes-debug.aar")
+        } else {
+            implementation("com.facebook.react:hermes-engine:+") {
+                exclude(group: "com.facebook.fbjni")
+            }
+        }
     }
 
     if (buildReactNativeFromSource(rootDir)) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,0 @@
-plugins {
-    apply(from: "${buildscript.sourceFile.getParent()}/dependencies.gradle")
-
-    id("com.android.application") version "${androidPluginVersion}" apply false
-    id("com.android.library") version "${androidPluginVersion}" apply false
-    id("kotlin-android") version "${kotlinVersion}" apply false
-    id("kotlin-kapt") version "${kotlinVersion}" apply false
-}

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        mavenLocal()
+        mavenCentral()
         google()
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -17,10 +17,10 @@
     "windows": "react-native run-windows --no-packager"
   },
   "peerDependencies": {
-    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
-    "react-native": "^0.0.0-0 || 0.62 - 0.68 || 1000.0.0",
+    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0",
+    "react-native": "^0.0.0-0 || 0.62 - 0.69 || 1000.0.0",
     "react-native-macos": "^0.0.0-0 || 0.62 - 0.66",
-    "react-native-windows": "^0.0.0-0 || 0.62 - 0.68"
+    "react-native-windows": "^0.0.0-0 || 0.62 - 0.69"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
     "@react-native-community/cli-platform-android": ">=4.10.0",
     "@react-native-community/cli-platform-ios": ">=4.10.0",
     "mustache": "^4.0.0",
-    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2",
-    "react-native": "^0.0.0-0 || 0.62 - 0.68 || 1000.0.0",
+    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0",
+    "react-native": "^0.0.0-0 || 0.62 - 0.69 || 1000.0.0",
     "react-native-macos": "^0.0.0-0 || 0.62 - 0.66",
-    "react-native-windows": "^0.0.0-0 || 0.62 - 0.68"
+    "react-native-windows": "^0.0.0-0 || 0.62 - 0.69"
   },
   "peerDependenciesMeta": {
     "@react-native-community/cli": {

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -544,7 +544,7 @@ const getConfig = (() => {
               "pluginManagement {",
               "    repositories {",
               "        gradlePluginPortal()",
-              "        mavenLocal()",
+              "        mavenCentral()",
               "        google()",
               "    }",
               "}",

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -113,7 +113,7 @@ allprojects {
     "android/settings.gradle": "pluginManagement {
     repositories {
         gradlePluginPortal()
-        mavenLocal()
+        mavenCentral()
         google()
     }
 }
@@ -410,7 +410,7 @@ allprojects {
     "android/settings.gradle": "pluginManagement {
     repositories {
         gradlePluginPortal()
-        mavenLocal()
+        mavenCentral()
         google()
     }
 }
@@ -556,7 +556,7 @@ allprojects {
     "android/settings.gradle": "pluginManagement {
     repositories {
         gradlePluginPortal()
-        mavenLocal()
+        mavenCentral()
         google()
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5364,10 +5364,10 @@ __metadata:
     react-native-test-app: "workspace:."
     react-native-windows: ^0.66.11
   peerDependencies:
-    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2
-    react-native: ^0.0.0-0 || 0.62 - 0.68 || 1000.0.0
+    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0
+    react-native: ^0.0.0-0 || 0.62 - 0.69 || 1000.0.0
     react-native-macos: ^0.0.0-0 || 0.62 - 0.66
-    react-native-windows: ^0.0.0-0 || 0.62 - 0.68
+    react-native-windows: ^0.0.0-0 || 0.62 - 0.69
   languageName: unknown
   linkType: soft
 
@@ -10579,10 +10579,10 @@ __metadata:
     "@react-native-community/cli-platform-android": ">=4.10.0"
     "@react-native-community/cli-platform-ios": ">=4.10.0"
     mustache: ^4.0.0
-    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2
-    react-native: ^0.0.0-0 || 0.62 - 0.68 || 1000.0.0
+    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0
+    react-native: ^0.0.0-0 || 0.62 - 0.69 || 1000.0.0
     react-native-macos: ^0.0.0-0 || 0.62 - 0.66
-    react-native-windows: ^0.0.0-0 || 0.62 - 0.68
+    react-native-windows: ^0.0.0-0 || 0.62 - 0.69
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true


### PR DESCRIPTION
### Description

Declare support for `react-native` 0.69.

Discussion: https://github.com/reactwg/react-native-releases/discussions/21

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [x] Windows

### Test plan

- [x] Android
  - [x] Fabric off
  - [x] Fabric **ON**
- [ ] iOS
  - [x] Fabric off / Hermes off
  - [x] Fabric off / Hermes **ON**
  - [x] Fabric **ON** / Hermes off
  - [ ] Fabric **ON** / Hermes **ON**
- [x] Windows
  - [x] NuGet off
  - [x] NuGet **ON**
