### PR TITLE
ci: fix `npx install-windows-test-app` failing on nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,7 +395,7 @@ jobs:
       - name: Build bundle and create solution
         run: |
           npm run build:windows
-          npx install-windows-test-app --use-nuget
+          npx --package react-native-test-app -- install-windows-test-app --use-nuget
         working-directory: example
       - name: Test `react-native config`
         run: |


### PR DESCRIPTION
### Description

Not exactly sure why this only happens on nightlies. Both PR and nightly builds use the same workflow definition.

```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/install-windows-test-app - Not found
npm ERR! 404 
npm ERR! 404  'install-windows-test-app@latest' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\npm\cache\_logs\[20](https://github.com/microsoft/react-native-test-app/runs/6519292039?check_suite_focus=true#step:6:21)[22](https://github.com/microsoft/react-native-test-app/runs/6519292039?check_suite_focus=true#step:6:23)-05-20T05_07_12_302Z-debug-0.log
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

n/a