### PR TITLE
chore: fix `set-react-version` not running on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,9 @@ jobs:
           echo "::add-matcher::.github/swiftlint.json"
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
+      - name: Smoke test `set-react-version`
+        run: |
+          npm run set-react-version 0.66
     timeout-minutes: 60
   ios:
     name: "iOS"


### PR DESCRIPTION
### Description

`set-react-version` fails to run on Windows:

```
Error: spawn npm ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:478:[16](https://github.com/microsoft/react-native-test-app/runs/6534858478?check_suite_focus=true#step:4:17))
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:[21](https://github.com/microsoft/react-native-test-app/runs/6534858478?check_suite_focus=true#step:4:22)) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ 'view', '--json', 'react-native-windows@0.0.0-canary.501' ]
}
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Smoke test added.