### PR TITLE
fix(ios): fix `pod install` causing duplicates

### DIFF
--- a/ios/use_react_native-0.68.rb
+++ b/ios/use_react_native-0.68.rb
@@ -26,7 +26,7 @@ def include_react_native!(options)
   # If we're using react-native@main, we'll also need to prepare
   # `react-native-codegen`.
   codegen = File.join(project_root, react_native, 'packages', 'react-native-codegen')
-  Open3.popen3('yarn', :chdir => codegen) if File.directory?(codegen)
+  Open3.popen3('yarn build', :chdir => codegen) if File.directory?(codegen)
 
   lambda { |installer|
     react_native_post_install(installer)


### PR DESCRIPTION
### Description

When building `react-native` from `main`, we invoke `yarn` under `react-native/packages/react-native-codegen` to prepare it. This also installs dependencies, causing duplicates to appear and fails our tests.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
yarn jest
```