### PR TITLE
ci(nightly): update config to match latest `react-native config` output

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -210,7 +210,6 @@ describe("react-native config", () => {
           name: "init-test-app",
         }),
       ]),
-      assets: [],
       platforms: expect.objectContaining({
         windows: expect.objectContaining({
           npmPackageName: "react-native-windows",


### PR DESCRIPTION
### Description

RNW canary builds are failing due to change in config output:

```
● react-native config › contains Windows config

    expect(received).toMatchObject(expected)

    - Expected  - 1
    + Received  + 0

    @@ -1,7 +1,6 @@
      Object {
    -   "assets": Array [],
        "commands": ArrayContaining [
          ObjectContaining {
            "name": "init-test-app",
          },
        ],

      153 |       return;
      154 |     }
    > 155 |
          | ^
      156 |     const sourceDir = path.join(exampleRoot, "ios");
      157 |
      158 |     expect(loadConfig()).toMatchObject({

      at Object.<anonymous> (test/config.test.js:1[55](https://github.com/microsoft/react-native-test-app/runs/6567272589?check_suite_focus=true#step:7:56):26)
```

Full build log: https://github.com/microsoft/react-native-test-app/runs/6567272589?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app
yarn jest
```