### PR TITLE
fix(windows): template `NuGet.Config` was renamed to `NuGet_Config`

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -748,6 +748,17 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
     if (useNuGet) {
       const nugetConfigPath =
         findNearest(
+          // In 0.70, the template was renamed from `NuGet.Config` to `NuGet_Config`
+          path.join(
+            nodeModulesDir,
+            "react-native-windows",
+            "template",
+            "shared-app",
+            "proj",
+            "NuGet_Config"
+          )
+        ) ||
+        findNearest(
           // In 0.64, the template was moved into `react-native-windows`
           path.join(
             nodeModulesDir,


### PR DESCRIPTION
### Description

The template for `NuGet.Config` was recently renamed to `NuGet_Config`. Also look for this new file when generating the Windows test app project.

See https://github.com/microsoft/react-native-windows/commit/3bc05e058d255120f60ed265db856654d9c164f4

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-nuget
```

Validate that `example/windows/NuGet.config` gets generated.