### PR TITLE
test: skip tests rather than passing them

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -34,6 +34,18 @@
     "react-native-test-app": "workspace:.",
     "react-native-windows": "^0.66.11"
   },
+  "eslintConfig": {
+    "rules": {
+      "jest/no-standalone-expect": [
+        "error",
+        {
+          "additionalTestBlockFunctions": [
+            "testIf"
+          ]
+        }
+      ]
+    }
+  },
   "jest": {
     "roots": [
       "test"

--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -19,6 +19,15 @@ const {
 } = require("@react-native-community/cli/package.json");
 const cliMajorVersion = cliVersion.split(".")[0];
 
+/**
+ * Test only if given predicate evaluates to `true`.
+ * @param {boolean} predicate
+ * @returns {typeof test}
+ */
+function testIf(predicate) {
+  return predicate ? test : test.skip;
+}
+
 describe("react-native config", () => {
   const exampleRoot = path.sep + path.join("react-native-test-app", "example");
   const reactNativePath = path.join(
@@ -27,163 +36,159 @@ describe("react-native config", () => {
     "react-native"
   );
 
-  test("contains Android config (@react-native-community/cli@<8.0.0)", () => {
-    if (cliMajorVersion >= 8) {
-      return;
+  testIf(cliMajorVersion < 8)(
+    "contains Android config (@react-native-community/cli@<8.0.0)",
+    () => {
+      const sourceDir = path.join(exampleRoot, "android");
+
+      expect(loadConfig()).toMatchObject({
+        root: expect.stringContaining(exampleRoot),
+        reactNativePath: expect.stringContaining(reactNativePath),
+        dependencies: expect.objectContaining({
+          "react-native-test-app": expect.objectContaining({
+            name: "react-native-test-app",
+          }),
+        }),
+        commands: expect.arrayContaining([
+          expect.objectContaining({
+            name: "init-test-app",
+          }),
+        ]),
+        assets: [],
+        platforms: expect.objectContaining({
+          android: expect.anything(),
+        }),
+        project: expect.objectContaining({
+          android: expect.objectContaining({
+            sourceDir: expect.stringContaining(sourceDir),
+            folder: expect.stringContaining(exampleRoot),
+            manifestPath: expect.stringContaining(
+              path.join(
+                "react-native-test-app",
+                "android",
+                "app",
+                "src",
+                "main",
+                "AndroidManifest.xml"
+              )
+            ),
+            buildGradlePath: expect.stringContaining(
+              path.join(sourceDir, "build.gradle")
+            ),
+            settingsGradlePath: expect.stringContaining(
+              path.join(sourceDir, "settings.gradle")
+            ),
+            packageName: "com.microsoft.reacttestapp",
+            packageFolder: path.join("com", "microsoft", "reacttestapp"),
+          }),
+        }),
+      });
     }
+  );
 
-    const sourceDir = path.join(exampleRoot, "android");
+  testIf(cliMajorVersion >= 8)(
+    "contains Android config (@react-native-community/cli@>=8.0.0)",
+    () => {
+      const sourceDir = path.join(exampleRoot, "android");
 
-    expect(loadConfig()).toMatchObject({
-      root: expect.stringContaining(exampleRoot),
-      reactNativePath: expect.stringContaining(reactNativePath),
-      dependencies: expect.objectContaining({
-        "react-native-test-app": expect.objectContaining({
-          name: "react-native-test-app",
+      expect(loadConfig()).toMatchObject({
+        root: expect.stringContaining(exampleRoot),
+        reactNativePath: expect.stringContaining(reactNativePath),
+        dependencies: expect.objectContaining({
+          "react-native-test-app": expect.objectContaining({
+            name: "react-native-test-app",
+          }),
         }),
-      }),
-      commands: expect.arrayContaining([
-        expect.objectContaining({
-          name: "init-test-app",
+        commands: expect.arrayContaining([
+          expect.objectContaining({
+            name: "init-test-app",
+          }),
+        ]),
+        platforms: expect.objectContaining({
+          android: expect.anything(),
         }),
-      ]),
-      assets: [],
-      platforms: expect.objectContaining({
-        android: expect.anything(),
-      }),
-      project: expect.objectContaining({
-        android: expect.objectContaining({
-          sourceDir: expect.stringContaining(sourceDir),
-          folder: expect.stringContaining(exampleRoot),
-          manifestPath: expect.stringContaining(
-            path.join(
-              "react-native-test-app",
-              "android",
-              "app",
-              "src",
-              "main",
-              "AndroidManifest.xml"
-            )
-          ),
-          buildGradlePath: expect.stringContaining(
-            path.join(sourceDir, "build.gradle")
-          ),
-          settingsGradlePath: expect.stringContaining(
-            path.join(sourceDir, "settings.gradle")
-          ),
-          packageName: "com.microsoft.reacttestapp",
-          packageFolder: path.join("com", "microsoft", "reacttestapp"),
-        }),
-      }),
-    });
-  });
-
-  test("contains Android config (@react-native-community/cli@>=8.0.0)", () => {
-    if (cliMajorVersion < 8) {
-      return;
-    }
-
-    const sourceDir = path.join(exampleRoot, "android");
-
-    expect(loadConfig()).toMatchObject({
-      root: expect.stringContaining(exampleRoot),
-      reactNativePath: expect.stringContaining(reactNativePath),
-      dependencies: expect.objectContaining({
-        "react-native-test-app": expect.objectContaining({
-          name: "react-native-test-app",
-        }),
-      }),
-      commands: expect.arrayContaining([
-        expect.objectContaining({
-          name: "init-test-app",
-        }),
-      ]),
-      platforms: expect.objectContaining({
-        android: expect.anything(),
-      }),
-      project: expect.objectContaining({
-        android: {
-          sourceDir: expect.stringContaining(sourceDir),
-          appName: fs.existsSync("android/app") ? "app" : "",
-          packageName: "com.microsoft.reacttestapp",
-        },
-      }),
-    });
-  });
-
-  test("contains iOS config (@react-native-community/cli@<8.0.0)", () => {
-    if (os.platform() === "win32" || cliMajorVersion >= 8) {
-      return;
-    }
-
-    const sourceDir = path.join(exampleRoot, "ios");
-
-    expect(loadConfig()).toMatchObject({
-      root: expect.stringContaining(exampleRoot),
-      reactNativePath: expect.stringContaining(reactNativePath),
-      dependencies: expect.objectContaining({
-        "react-native-test-app": expect.objectContaining({
-          name: "react-native-test-app",
-        }),
-      }),
-      commands: expect.arrayContaining([
-        expect.objectContaining({
-          name: "init-test-app",
-        }),
-      ]),
-      assets: [],
-      platforms: expect.objectContaining({
-        ios: expect.anything(),
-      }),
-      project: expect.objectContaining({
-        ios: expect.objectContaining({
-          sourceDir: expect.stringContaining(sourceDir),
-          folder: expect.stringContaining(exampleRoot),
-          podfile: expect.stringContaining(path.join(sourceDir, "Podfile")),
-          podspecPath: expect.stringContaining(
-            path.join(exampleRoot, "Example-Tests.podspec")
-          ),
-        }),
-      }),
-    });
-  });
-
-  test("contains iOS config (@react-native-community/cli@>=8.0.0)", () => {
-    if (os.platform() === "win32" || cliMajorVersion < 8) {
-      return;
-    }
-
-    const sourceDir = path.join(exampleRoot, "ios");
-
-    expect(loadConfig()).toMatchObject({
-      root: expect.stringContaining(exampleRoot),
-      reactNativePath: expect.stringContaining(reactNativePath),
-      dependencies: expect.objectContaining({
-        "react-native-test-app": expect.objectContaining({
-          name: "react-native-test-app",
-        }),
-      }),
-      commands: expect.arrayContaining([
-        expect.objectContaining({
-          name: "init-test-app",
-        }),
-      ]),
-      platforms: expect.objectContaining({
-        ios: expect.anything(),
-      }),
-      project: expect.objectContaining({
-        ios: {
-          sourceDir: expect.stringContaining(sourceDir),
-          xcodeProject: {
-            name: "Example.xcworkspace",
-            isWorkspace: true,
+        project: expect.objectContaining({
+          android: {
+            sourceDir: expect.stringContaining(sourceDir),
+            appName: fs.existsSync("android/app") ? "app" : "",
+            packageName: "com.microsoft.reacttestapp",
           },
-        },
-      }),
-    });
-  });
+        }),
+      });
+    }
+  );
 
-  test("contains Windows config", () => {
+  testIf(os.platform() !== "win32" && cliMajorVersion < 8)(
+    "contains iOS config (@react-native-community/cli@<8.0.0)",
+    () => {
+      const sourceDir = path.join(exampleRoot, "ios");
+
+      expect(loadConfig()).toMatchObject({
+        root: expect.stringContaining(exampleRoot),
+        reactNativePath: expect.stringContaining(reactNativePath),
+        dependencies: expect.objectContaining({
+          "react-native-test-app": expect.objectContaining({
+            name: "react-native-test-app",
+          }),
+        }),
+        commands: expect.arrayContaining([
+          expect.objectContaining({
+            name: "init-test-app",
+          }),
+        ]),
+        assets: [],
+        platforms: expect.objectContaining({
+          ios: expect.anything(),
+        }),
+        project: expect.objectContaining({
+          ios: expect.objectContaining({
+            sourceDir: expect.stringContaining(sourceDir),
+            folder: expect.stringContaining(exampleRoot),
+            podfile: expect.stringContaining(path.join(sourceDir, "Podfile")),
+            podspecPath: expect.stringContaining(
+              path.join(exampleRoot, "Example-Tests.podspec")
+            ),
+          }),
+        }),
+      });
+    }
+  );
+
+  testIf(os.platform() !== "win32" && cliMajorVersion >= 8)(
+    "contains iOS config (@react-native-community/cli@>=8.0.0)",
+    () => {
+      const sourceDir = path.join(exampleRoot, "ios");
+
+      expect(loadConfig()).toMatchObject({
+        root: expect.stringContaining(exampleRoot),
+        reactNativePath: expect.stringContaining(reactNativePath),
+        dependencies: expect.objectContaining({
+          "react-native-test-app": expect.objectContaining({
+            name: "react-native-test-app",
+          }),
+        }),
+        commands: expect.arrayContaining([
+          expect.objectContaining({
+            name: "init-test-app",
+          }),
+        ]),
+        platforms: expect.objectContaining({
+          ios: expect.anything(),
+        }),
+        project: expect.objectContaining({
+          ios: {
+            sourceDir: expect.stringContaining(sourceDir),
+            xcodeProject: {
+              name: "Example.xcworkspace",
+              isWorkspace: true,
+            },
+          },
+        }),
+      });
+    }
+  );
+
+  testIf(os.platform() === "win32")("contains Windows config", () => {
     const projectFile = path.join(
       "node_modules",
       ".generated",


### PR DESCRIPTION
### Description

Tests that don't meet certain criteria should be skipped rather than pass.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Output without making any changes:

```
 PASS  test/config.test.js (6.369 s)
  react-native config
    ✓ contains Android config (@react-native-community/cli@<8.0.0) (3310 ms)
    ✓ contains iOS config (@react-native-community/cli@<8.0.0) (2789 ms)
    ○ skipped contains Android config (@react-native-community/cli@>=8.0.0)
    ○ skipped contains iOS config (@react-native-community/cli@>=8.0.0)
    ○ skipped contains Windows config

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 2 passed, 5 total
Snapshots:   0 total
Time:        6.411 s, estimated 7 s
Ran all test suites.
```

Output after bumping `react-native` to 0.69:

```
 PASS  test/config.test.js
  react-native config
    ✓ contains Android config (@react-native-community/cli@>=8.0.0) (632 ms)
    ✓ contains iOS config (@react-native-community/cli@>=8.0.0) (78 ms)
    ○ skipped contains Android config (@react-native-community/cli@<8.0.0)
    ○ skipped contains iOS config (@react-native-community/cli@<8.0.0)
    ○ skipped contains Windows config

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 2 passed, 5 total
Snapshots:   0 total
Time:        1.518 s, estimated 2 s
Ran all test suites.
```