### PR TITLE
chore: group Android plugin updates [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,14 @@
       "allowedVersions": "~0.9.0"
     },
     {
+      "groupName": "Android",
+      "matchDatasources": ["maven"],
+      "matchPackagePrefixes": ["com.android."]
+    },
+    {
       "groupName": "Kotlin",
       "matchDatasources": ["maven"],
-      "matchPackagePrefixes": ["org.jetbrains.kotlin:"]
+      "matchPackagePrefixes": ["org.jetbrains.kotlin"]
     },
     {
       "groupName": "Metro",
@@ -23,7 +28,7 @@
     {
       "groupName": "Moshi",
       "matchDatasources": ["maven"],
-      "matchPackagePrefixes": ["com.squareup.moshi:"]
+      "matchPackagePrefixes": ["com.squareup.moshi"]
     },
     {
       "matchPackageNames": ["react"],


### PR DESCRIPTION
### Description

Group Android plugin updates.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

![image](https://user-images.githubusercontent.com/4123478/172342996-20e5226f-5923-474b-98db-5269aa291218.png)

These should become one item. But there's no way to test that until after this has merged.