### PR TITLE
fix: declare support for react-native 0.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@
 - [Migrate an Existing Test App](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App)
 - [Known Issues](#known-issues)
 
-React Native Test App (RNTA) provides test apps for all platforms as a package. It
-handles the native bits for you so you can focus on what's important: your
+React Native Test App (RNTA) provides test apps for all platforms as a package.
+It handles the native bits for you so you can focus on what's important: your
 product.
 
 If you want to learn how RNTA is used at Microsoft, and see a demo of how to add
 it to an existing library - you can watch the
 ["Improve all the repos – exploring Microsoft’s DevExp"](https://youtu.be/DAEnPV78rQc?t=499)
-talk by [@kelset](https://github.com/kelset) and [@tido64](https://github.com/tido64) from React Native Europe 2021.
+talk by [@kelset](https://github.com/kelset) and
+[@tido64](https://github.com/tido64) from React Native Europe 2021.
 
 In the wiki, you can read more about
 [the motivation](https://github.com/microsoft/react-native-test-app/wiki#motivation)
@@ -25,7 +26,8 @@ of this tool.
 
 ## Quick Start
 
-*If you want to migrate an existing test app for a library, follow the [dedicated guide in the wiki](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App).*
+_If you want to migrate an existing test app for a library, follow the
+[dedicated guide in the wiki](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App)._
 
 Install `react-native-test-app` as a dev dependency. We will use the wizard to
 generate your test app:
@@ -60,7 +62,9 @@ cd sample
 yarn
 ```
 
-Once the dependencies are installed, follow the [platform specific instructions](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start#platform-specific-instructions) in the wiki.
+Once the dependencies are installed, follow the
+[platform specific instructions](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start#platform-specific-instructions)
+in the wiki.
 
 ## Configuring the Test App
 
@@ -81,7 +85,8 @@ For a list of known issues and workarounds, please refer to the
 
 ## Contributing
 
-Thank you for your interest in this project! We welcome all contributions and suggestions!
+Thank you for your interest in this project! We welcome all contributions and
+suggestions!
 
 Take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 

--- a/example/package.json
+++ b/example/package.json
@@ -17,8 +17,8 @@
     "windows": "react-native run-windows --no-packager"
   },
   "peerDependencies": {
-    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0",
-    "react-native": "^0.0.0-0 || 0.62 - 0.69 || 1000.0.0",
+    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~18.0.0 || ~18.1.0",
+    "react-native": "^0.0.0-0 || 0.62 - 0.70 || 1000.0.0",
     "react-native-macos": "^0.0.0-0 || 0.62 - 0.64 || ^0.66 || ^0.68",
     "react-native-windows": "^0.0.0-0 || 0.62 - 0.69"
   },

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "@react-native-community/cli-platform-android": ">=4.10.0",
     "@react-native-community/cli-platform-ios": ">=4.10.0",
     "mustache": "^4.0.0",
-    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0",
-    "react-native": "^0.0.0-0 || 0.62 - 0.69 || 1000.0.0",
+    "react": "~16.11.0 || ~16.13.1 || ~17.0.1 || ~18.0.0 || ~18.1.0",
+    "react-native": "^0.0.0-0 || 0.62 - 0.70 || 1000.0.0",
     "react-native-macos": "^0.0.0-0 || 0.62 - 0.64 || ^0.66 || ^0.68",
     "react-native-windows": "^0.0.0-0 || 0.62 - 0.69"
   },
@@ -137,9 +137,7 @@
   "resolutions": {
     "@commitlint/is-ignored/semver": "^7.3.5",
     "@microsoft/eslint-plugin-sdl/eslint-plugin-react": "^7.26.0",
-    "@react-native-community/cli-tools/shell-quote": "^1.7.3",
-    "core-js-compat/semver": "^7.3.5",
-    "npm/chalk": "^4.1.0"
+    "core-js-compat/semver": "^7.3.5"
   },
   "workspaces": [
     "example"

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -eo pipefail
+
+PACKAGE_MANAGER=yarn
+VERSION=${1}
+
+function pod_install {
+  rm -fr $1/Podfile.lock $1/Pods
+  pod install --project-directory=$1
+}
+
+function prepare {
+  [[ -z "$(jobs -p)" ]] || kill $(jobs -p)
+  git checkout .
+  npm run set-react-version ${VERSION}
+  npm run clean
+  ${PACKAGE_MANAGER} install
+  pushd example 1> /dev/null
+  start_dev_server
+}
+
+function start_dev_server {
+  echo "*** Starting Metro dev server in the background (logs go to '$(pwd)/metro.server.log')"
+  yarn start &> metro.server.log &
+}
+
+function wait_for_user {
+  echo
+  if [[ -n "$1" ]]; then
+    echo "*** $1 ***"
+    echo
+  fi
+  read -n 1 -r -s -p "Press any key to continue..."
+  echo
+}
+
+if command -v ccache 1> /dev/null; then
+  export USE_CCACHE=1
+  export ANDROID_CCACHE=$(which ccache)
+  export CCACHE_DIR=$HOME/.cache/ccache
+  export PATH=$(dirname $(dirname $ANDROID_CCACHE))/opt/ccache/libexec:$PATH
+fi
+
+pushd $(git rev-parse --show-toplevel) 1> /dev/null
+prepare
+
+echo
+echo "┌─────────────────┐"
+echo "│  Build Android  │"
+echo "└─────────────────┘"
+echo
+
+npm run android --no-packager
+wait_for_user "Android app is ready for testing"
+
+echo
+echo "┌─────────────┐"
+echo "│  Build iOS  │"
+echo "└─────────────┘"
+echo
+
+pod_install ios
+npm run ios --no-packager
+wait_for_user "iOS app is ready for testing"
+
+echo
+echo "┌─────────────────────────┐"
+echo "│  Build iOS with Hermes  │"
+echo "└─────────────────────────┘"
+echo
+
+sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
+pod_install ios
+npm run ios --no-packager
+wait_for_user "iOS app with Hermes is ready for testing"
+
+echo
+echo "┌──────────────────────────────┐"
+echo "│  Clean up for Fabric builds  │"
+echo "└──────────────────────────────┘"
+echo
+
+popd 1> /dev/null
+prepare
+
+echo
+echo "┌─────────────────────────────┐"
+echo "│  Build Android with Fabric  │"
+echo "└─────────────────────────────┘"
+echo
+
+sed -i '' 's/#newArchEnabled=true/newArchEnabled=true/' android/gradle.properties
+pushd android 1> /dev/null
+# Due to a bug in Gradle, we need to run this task separately
+./gradlew packageReactNdkDebugLibs
+popd 1> /dev/null
+npm run android --no-packager
+wait_for_user "Android app with Fabric is ready for testing"
+
+echo
+echo "┌─────────────────────────┐"
+echo "│  Build iOS with Fabric  │"
+echo "└─────────────────────────┘"
+echo
+
+sed -i '' 's/:turbomodule_enabled => false/:turbomodule_enabled => true/' ios/Podfile
+pod_install ios
+npm run ios --no-packager
+wait_for_user "iOS app with Fabric is ready for testing"
+
+echo
+echo "┌──────────────────────────────────┐"
+echo "│  Build iOS with Fabric + Hermes  │"
+echo "└──────────────────────────────────┘"
+echo
+
+sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
+pod_install ios
+npm run ios --no-packager
+wait_for_user "iOS app with Fabric + Hermes is ready for testing"
+
+popd 1> /dev/null

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -10,7 +10,7 @@ function pod_install {
 }
 
 function prepare {
-  [[ -z "$(jobs -p)" ]] || kill $(jobs -p)
+  terminate_dev_server
   git checkout .
   npm run set-react-version ${VERSION}
   npm run clean
@@ -24,6 +24,10 @@ function start_dev_server {
   yarn start &> metro.server.log &
 }
 
+function terminate_dev_server {
+  [[ -z "$(jobs -p)" ]] || kill $(jobs -p)
+}
+
 function wait_for_user {
   echo
   if [[ -n "$1" ]]; then
@@ -33,6 +37,8 @@ function wait_for_user {
   read -n 1 -r -s -p "Press any key to continue..."
   echo
 }
+
+trap terminate_dev_server EXIT
 
 if command -v ccache 1> /dev/null; then
   export USE_CCACHE=1

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -45,6 +45,7 @@ if command -v ccache 1> /dev/null; then
   export ANDROID_CCACHE=$(which ccache)
   export CCACHE_DIR=$HOME/.cache/ccache
   export PATH=$(dirname $(dirname $ANDROID_CCACHE))/opt/ccache/libexec:$PATH
+  mkdir -p $CCACHE_DIR
 fi
 
 pushd $(git rev-parse --show-toplevel) 1> /dev/null

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -57,7 +57,7 @@ echo "│  Build Android  │"
 echo "└─────────────────┘"
 echo
 
-npm run android --no-packager
+npm run android -- --no-packager
 wait_for_user "Android app is ready for testing"
 
 echo
@@ -67,7 +67,7 @@ echo "└─────────────┘"
 echo
 
 pod_install ios
-npm run ios --no-packager
+npm run ios -- --no-packager
 wait_for_user "iOS app is ready for testing"
 
 echo
@@ -78,7 +78,7 @@ echo
 
 sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios --no-packager
+npm run ios -- --no-packager
 wait_for_user "iOS app with Hermes is ready for testing"
 
 echo
@@ -101,7 +101,7 @@ pushd android 1> /dev/null
 # Due to a bug in Gradle, we need to run this task separately
 ./gradlew packageReactNdkDebugLibs
 popd 1> /dev/null
-npm run android --no-packager
+npm run android -- --no-packager
 wait_for_user "Android app with Fabric is ready for testing"
 
 echo
@@ -112,7 +112,7 @@ echo
 
 sed -i '' 's/:turbomodule_enabled => false/:turbomodule_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios --no-packager
+npm run ios -- --no-packager
 wait_for_user "iOS app with Fabric is ready for testing"
 
 echo
@@ -123,7 +123,7 @@ echo
 
 sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios --no-packager
+npm run ios -- --no-packager
 wait_for_user "iOS app with Fabric + Hermes is ready for testing"
 
 popd 1> /dev/null

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,8 +5578,8 @@ __metadata:
     react-native-test-app: "workspace:."
     react-native-windows: ^0.68.8
   peerDependencies:
-    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0
-    react-native: ^0.0.0-0 || 0.62 - 0.69 || 1000.0.0
+    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~18.0.0 || ~18.1.0
+    react-native: ^0.0.0-0 || 0.62 - 0.70 || 1000.0.0
     react-native-macos: ^0.0.0-0 || 0.62 - 0.64 || ^0.66 || ^0.68
     react-native-windows: ^0.0.0-0 || 0.62 - 0.69
   languageName: unknown
@@ -10816,8 +10816,8 @@ fsevents@^2.3.2:
     "@react-native-community/cli-platform-android": ">=4.10.0"
     "@react-native-community/cli-platform-ios": ">=4.10.0"
     mustache: ^4.0.0
-    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~17.0.2 || ~18.0.0
-    react-native: ^0.0.0-0 || 0.62 - 0.69 || 1000.0.0
+    react: ~16.11.0 || ~16.13.1 || ~17.0.1 || ~18.0.0 || ~18.1.0
+    react-native: ^0.0.0-0 || 0.62 - 0.70 || 1000.0.0
     react-native-macos: ^0.0.0-0 || 0.62 - 0.64 || ^0.66 || ^0.68
     react-native-windows: ^0.0.0-0 || 0.62 - 0.69
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declares support for react-native 0.70.

Blocked by:

- [x] #843
- [x] #1009
- [x] #1044
- [x] #1049

Resolves #996.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Use the new script to test all the flags:

```sh
scripts/test-matrix.sh 0.70
```

- [X] Android - Fabric: disabled
- [x] Android - Fabric: **enabled**
- [X] iOS - Fabric: disabled / Hermes: disabled
- [x] iOS - Fabric: disabled / Hermes: **enabled**
- [x] iOS - Fabric: **enabled** / Hermes: disabled
- [x] iOS - Fabric: **enabled** / Hermes: **enabled**
- [ ] ~~macOS~~
- [ ] ~~Windows - NuGet: disabled~~
- [ ] ~~Windows - NuGet: **enabled**~~

### Screenshots

| Platform | App | +Hermes | +Fabric | +Fabric +Hermes |
| --: | :-: | :-: | :-: | :-: |
| Android | n/a | ![Screenshot_1661187434](https://user-images.githubusercontent.com/4123478/185977266-b07ee8c0-e449-4da8-b1a4-11020c180e24.png) | n/a | ![Screenshot_1661188439](https://user-images.githubusercontent.com/4123478/185980261-46582bde-6752-449f-8877-bf30e07aeebe.png) |
| iOS | ![Simulator Screen Shot - iPhone 13 - 2022-08-22 at 18 57 16](https://user-images.githubusercontent.com/4123478/185977395-d327b30e-5ef7-4168-a292-d92c079731a2.png) | ![image](https://user-images.githubusercontent.com/4123478/185977864-0607fa73-1be0-4555-9fa3-5fe0bd4b2828.png) | ![image](https://user-images.githubusercontent.com/4123478/185980772-154b310f-90da-4098-b862-a6b8e4002e39.png) | ![image](https://user-images.githubusercontent.com/4123478/185981347-56755f6b-d9ae-40f3-a02f-861c884f3d2a.png) |