### PR TITLE
fix(android): bump Android AppCompat Library to 1.4.2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -201,7 +201,14 @@ dependencies {
     implementation libraries.kotlinStdlibJdk8
     implementation libraries.kotlinReflect
 
-    implementation libraries.androidAppCompat
+    if (reactNativeVersion < 6800) {
+        // androidx.appcompat:appcompat:1.4.0+ breaks TextInput. This was fixed
+        // in react-native 0.68. For more details, see
+        // https://github.com/facebook/react-native/issues/31572.
+        implementation "androidx.appcompat:appcompat:1.3.1"
+    } else {
+        implementation libraries.androidAppCompat
+    }
     implementation libraries.androidCoreKotlinExtensions
     implementation libraries.androidRecyclerView
     implementation libraries.androidSwipeRefreshLayout

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -15,11 +15,7 @@ ext {
      * See https://github.com/dependabot/feedback/issues/345.
      */
     libraries = [
-        // androidx.appcompat:appcompat:1.4.0 breaks TextInput. For now, we
-        // need to lock it to 1.3.1 until the fix is released with the next
-        // version of react-native. For more details, see
-        // https://github.com/facebook/react-native/issues/31572.
-        androidAppCompat            : "androidx.appcompat:appcompat:1.3.1",
+        androidAppCompat            : "androidx.appcompat:appcompat:1.4.2",
         androidCoreKotlinExtensions : "androidx.core:core-ktx:1.8.0",
         androidEspressoCore         : "androidx.test.espresso:espresso-core:3.4.0",
         androidJUnit                : "androidx.test.ext:junit:1.1.3",


### PR DESCRIPTION
### Description

Bumps Android AppCompat Library to 1.4.2. Prior to 0.68, we would get a crash when trying to use `TextInput`.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Add `TextInput` to the example app:

```diff
diff --git a/example/App.js b/example/App.js
index e57ccd8..a2c2400 100644
--- a/example/App.js
+++ b/example/App.js
@@ -5,6 +5,7 @@ import {
   StatusBar,
   StyleSheet,
   Text,
+  TextInput,
   useColorScheme,
   View,
 } from "react-native";
@@ -46,6 +47,7 @@ const Section = ({ children, title }) => {
 };

 const App = () => {
+  const [text, onChangeText] = React.useState("TextInput test");
   const isDarkMode = useColorScheme() === "dark";

   const backgroundStyle = {
@@ -60,6 +62,11 @@ const App = () => {
         style={backgroundStyle}
       >
         <Header />
+        <TextInput
+          style={styles.input}
+          onChangeText={onChangeText}
+          value={text}
+        />
         <View
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
```

Then build and run the app:

```
cd example
yarn android
```

![Screenshot_1658323295](https://user-images.githubusercontent.com/4123478/179992789-92d8ea67-7b43-4319-9db4-62b743c624fa.png)
