### PR TITLE
fix(apple): `pwd` may "shift" if the .podspec was symlinked

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -11,7 +11,8 @@ def resolve_module(request)
   @module_cache ||= {}
   return @module_cache[request] if @module_cache.key?(request)
 
-  package_json = find_file("node_modules/#{request}/package.json", Pathname.pwd)
+  package_json = find_file("node_modules/#{request}/package.json",
+                           Pod::Config.instance.installation_root)
   raise "Cannot find module '#{request}'" if package_json.nil?
 
   @module_cache[request] = package_json.dirname.to_s


### PR DESCRIPTION
### Description

@tom-un discovered that `pwd` may "shift" if a .podspec was symlinked into the project.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a