### PR TITLE
fix(apple): `validate-manifest` might find the wrong `app.json`

### DIFF
--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -95,14 +95,15 @@ function validateManifest(manifestPath) {
  * @param {("file" | "stdout")=} outputMode Whether to output to `file` or `stdout`
  */
 function validate(outputMode = "stdout") {
-  const manifestPath = findFile(APP_JSON);
+  const projectRoot = process.env["PODS_ROOT"] || process.cwd();
+  const manifestPath = findFile(APP_JSON, projectRoot);
   const manifest = validateManifest(manifestPath);
   if (typeof manifest === "number") {
     process.exitCode = manifest;
     return;
   }
 
-  const nodeModulesPath = findFile(NODE_MODULES);
+  const nodeModulesPath = findFile(NODE_MODULES, projectRoot);
   if (!nodeModulesPath) {
     console.error(
       `Failed to find '${NODE_MODULES}'. Please make sure you've installed npm dependencies.`


### PR DESCRIPTION
### Description

In a repo structured as below, `validate-manifest.js` currently finds the `app.json` at root instead of the one under `/example`.

    async-storage
    ├── app.json
    ├── example
    │   ├── app.json
    │   └── ios
    │       └── Podfile
    ├── node_modules
    │   └── .generated/ios/ReactTestApp.xcodeproj
    └── src

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
git clone https://github.com/react-native-async-storage/async-storage.git
cd async-storage
# bump react-native-test-app to 1.4.3
yarn
yarn start:ios
```