### PR TITLE
fix(windows): `validate-manifest` might find the wrong `app.json`

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source .env\nnode -e 'require(\"react-native-test-app/scripts/validate-manifest\").validate(\"file\")'\n";
+			shellScript = "source .env\nnode -e \"require('react-native-test-app/scripts/validate-manifest').validate('file', '$PODS_ROOT')\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source .env\nnode -e 'require(\"react-native-test-app/scripts/validate-manifest\").validate(\"file\")'\n";
+			shellScript = "source .env\nnode -e \"require('react-native-test-app/scripts/validate-manifest').validate('file', '$PODS_ROOT')\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -93,9 +93,9 @@ function validateManifest(manifestPath) {
 
 /**
  * @param {("file" | "stdout")=} outputMode Whether to output to `file` or `stdout`
+ * @param {string=} projectRoot Path to root of project
  */
-function validate(outputMode = "stdout") {
-  const projectRoot = process.env["PODS_ROOT"] || process.cwd();
+function validate(outputMode = "stdout", projectRoot = process.cwd()) {
   const manifestPath = findFile(APP_JSON, projectRoot);
   const manifest = validateManifest(manifestPath);
   if (typeof manifest === "number") {

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -536,7 +536,7 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
   fs.mkdirSync(projectFilesDestPath, { recursive: true });
   fs.mkdirSync(destPath, { recursive: true });
 
-  require("../scripts/validate-manifest").validate("file");
+  require("../scripts/validate-manifest").validate("file", destPath);
 
   const manifestFilePath = findNearest("app.json", destPath);
   const {


### PR DESCRIPTION
### Description

Similar to #1005, but this one occurs during `install-windows-test-app`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
git clone https://github.com/react-native-async-storage/async-storage.git
cd async-storage
# bump react-native-test-app to 1.4.4
yarn
yarn install-windows-test-app -p example/windows --no-autolink
```