### PR TITLE
fix(apple): fix "unknown keywords" during `pod install`

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -31,3 +31,31 @@ end
 def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
+
+def use_new_architecture!(options)
+  new_arch_enabled = new_architecture_enabled?(options, 10_000_000)
+
+  if new_arch_enabled || options[:fabric_enabled]
+    Pod::UI.warn(
+      'As of writing, Fabric is still experimental and subject to change. ' \
+      'For more information, please see ' \
+      'https://reactnative.dev/docs/next/new-architecture-app-renderer-ios.'
+    )
+    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+  end
+
+  return unless new_arch_enabled
+
+  Pod::UI.warn(
+    'As of writing, TurboModule is still experimental and subject to change. ' \
+    'For more information, please see ' \
+    'https://reactnative.dev/docs/next/new-architecture-app-modules-ios.'
+  )
+
+  # At the moment, Fabric and TurboModule code are intertwined. We need to
+  # enable Fabric for some code that TurboModule relies on.
+  options[:fabric_enabled] = true
+  options[:new_arch_enabled] = true
+  options[:turbomodule_enabled] = true
+  ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+end

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -76,7 +76,9 @@ end
 
 def react_native_pods(version)
   v = version.release
-  if v == Gem::Version.new('0.0.0') || v >= Gem::Version.new('0.68')
+  if v == Gem::Version.new('0.0.0') || v >= Gem::Version.new('0.70')
+    'use_react_native-0.70'
+  elsif v >= Gem::Version.new('0.68')
     'use_react_native-0.68'
   elsif v >= Gem::Version.new('0.64')
     'use_react_native-0.64'

--- a/ios/use_react_native-0.68.rb
+++ b/ios/use_react_native-0.68.rb
@@ -2,32 +2,6 @@ require 'open3'
 
 require_relative('pod_helpers')
 
-def use_new_architecture!(options)
-  new_arch_enabled = new_architecture_enabled?(options, 10_000_000)
-
-  if new_arch_enabled || options[:fabric_enabled]
-    Pod::UI.warn(
-      'As of writing, Fabric is still experimental and subject to change. ' \
-      'For more information, please see ' \
-      'https://reactnative.dev/docs/next/new-architecture-app-renderer-ios.'
-    )
-    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-  end
-
-  return unless new_arch_enabled
-
-  Pod::UI.warn(
-    'As of writing, TurboModule is still experimental and subject to change. ' \
-    'For more information, please see ' \
-    'https://reactnative.dev/docs/next/new-architecture-app-modules-ios.'
-  )
-  # At the moment, Fabric and TurboModule code are intertwined. We need to
-  # enable Fabric for some code that TurboModule relies on.
-  options[:fabric_enabled] = true
-  options[:turbomodule_enabled] = true
-  ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-end
-
 def include_react_native!(options)
   react_native = options[:path]
   flipper_versions = options[:rta_flipper_versions]

--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -39,11 +39,11 @@ def include_react_native!(options)
 
   if target_platform == :ios && flipper_versions
     Pod::UI.warn(
-      'use_flipper is deprecated from 0.70+; use the flipper_configuration ' \
+      'use_flipper is deprecated from 0.70; use the flipper_configuration ' \
       'option in the use_test_app! function instead if you don\'t need to ' \
       'support older versions of react-native.'
     )
-    options[:flipper_configuration] = FlipperConfiguration.enabled(["Debug"], flipper_versions)
+    options[:flipper_configuration] = FlipperConfiguration.enabled(['Debug'], flipper_versions)
   end
 
   use_new_architecture!(options)

--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -1,0 +1,66 @@
+require 'open3'
+
+require_relative('pod_helpers')
+
+def use_new_architecture!(options)
+  new_arch_enabled = new_architecture_enabled?(options, 10_000_000)
+
+  if new_arch_enabled || options[:fabric_enabled]
+    Pod::UI.warn(
+      'As of writing, Fabric is still experimental and subject to change. ' \
+      'For more information, please see ' \
+      'https://reactnative.dev/docs/next/new-architecture-app-renderer-ios.'
+    )
+    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+  end
+
+  return unless new_arch_enabled
+
+  Pod::UI.warn(
+    'As of writing, TurboModule is still experimental and subject to change. ' \
+    'For more information, please see ' \
+    'https://reactnative.dev/docs/next/new-architecture-app-modules-ios.'
+  )
+  # At the moment, Fabric and TurboModule code are intertwined. We need to
+  # enable Fabric for some code that TurboModule relies on.
+  options[:fabric_enabled] = true
+  options[:new_arch_enabled] = true
+  options[:turbomodule_enabled] = true
+  ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+end
+
+def include_react_native!(options)
+  react_native = options[:path]
+  flipper_versions = options[:rta_flipper_versions]
+  project_root = options[:rta_project_root]
+  target_platform = options[:rta_target_platform]
+
+  require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
+
+  if target_platform == :ios && flipper_versions
+    Pod::UI.warn(
+      'use_flipper is deprecated from 0.70+; use the flipper_configuration ' \
+      'option in the use_test_app! function instead if you don\'t need to ' \
+      'support older versions of react-native.'
+    )
+    options[:flipper_configuration] = FlipperConfiguration.enabled(["Debug"], flipper_versions)
+  end
+
+  use_new_architecture!(options)
+  use_react_native!(options.except(:turbomodule_enabled,
+                                   :rta_flipper_versions,
+                                   :rta_project_root,
+                                   :rta_target_platform))
+
+  # If we're using react-native@main, we'll also need to prepare
+  # `react-native-codegen`.
+  codegen = File.join(project_root, react_native, 'packages', 'react-native-codegen')
+  Open3.popen3('yarn build', :chdir => codegen) if File.directory?(codegen)
+
+  lambda { |installer|
+    react_native_post_install(installer)
+    if defined?(__apply_Xcode_12_5_M1_post_install_workaround)
+      __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    end
+  }
+end

--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -2,33 +2,6 @@ require 'open3'
 
 require_relative('pod_helpers')
 
-def use_new_architecture!(options)
-  new_arch_enabled = new_architecture_enabled?(options, 10_000_000)
-
-  if new_arch_enabled || options[:fabric_enabled]
-    Pod::UI.warn(
-      'As of writing, Fabric is still experimental and subject to change. ' \
-      'For more information, please see ' \
-      'https://reactnative.dev/docs/next/new-architecture-app-renderer-ios.'
-    )
-    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-  end
-
-  return unless new_arch_enabled
-
-  Pod::UI.warn(
-    'As of writing, TurboModule is still experimental and subject to change. ' \
-    'For more information, please see ' \
-    'https://reactnative.dev/docs/next/new-architecture-app-modules-ios.'
-  )
-  # At the moment, Fabric and TurboModule code are intertwined. We need to
-  # enable Fabric for some code that TurboModule relies on.
-  options[:fabric_enabled] = true
-  options[:new_arch_enabled] = true
-  options[:turbomodule_enabled] = true
-  ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-end
-
 def include_react_native!(options)
   react_native = options[:path]
   flipper_versions = options[:rta_flipper_versions]

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -92,23 +92,24 @@ class TestTestApp < Minitest::Test
   end
 
   def test_react_native_pods
-    assert_equal('use_react_native-0.68', react_native_pods(Gem::Version.new('1000.0.0')))
-
-    assert_equal('use_react_native-0.68', react_native_pods(Gem::Version.new('0.68.0')))
-    assert_equal('use_react_native-0.68', react_native_pods(Gem::Version.new('0.68.0-rc.1')))
-
-    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.67.3')))
-    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.66.4')))
-    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.65.1')))
-
-    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.64.3')))
-    assert_equal('use_react_native-0.64', react_native_pods(Gem::Version.new('0.64.0')))
-
-    assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('0.63.4')))
-    assert_equal('use_react_native-0.63', react_native_pods(Gem::Version.new('0.63.0')))
-
-    assert_equal('use_react_native-0.62', react_native_pods(Gem::Version.new('0.62.2')))
-    assert_equal('use_react_native-0.62', react_native_pods(Gem::Version.new('0.62.0')))
+    [
+      ['1000.0.0', '0.70'],
+      ['0.70.0', '0.70'],
+      ['0.70.0-rc.1', '0.70'],
+      ['0.68.0', '0.68'],
+      ['0.68.0-rc.1', '0.68'],
+      ['0.67.3', '0.64'],
+      ['0.66.4', '0.64'],
+      ['0.65.1', '0.64'],
+      ['0.64.3', '0.64'],
+      ['0.64.0', '0.64'],
+      ['0.63.4', '0.63'],
+      ['0.63.0', '0.63'],
+      ['0.62.2', '0.62'],
+      ['0.62.0', '0.62'],
+    ].each do |target, profile|
+      assert_equal("use_react_native-#{profile}", react_native_pods(Gem::Version.new(target)))
+    end
 
     assert_raises(RuntimeError) do
       react_native_pods(Gem::Version.new('0.61.5'))


### PR DESCRIPTION
### Description

Fixes "unknown keywords" during `pod install`:

```
[!] use_flipper is deprecated, use the flipper_configuration option in the use_react_native function
[!] Invalid `Podfile` file: unknown keywords: :turbomodule_enabled, :rta_flipper_versions, :rta_project_root, :rta_target_platform.
 #  from /Users/runner/work/react-native-test-app/react-native-test-app/example/ios/Podfile:13
 #  -------------------------------------------
 #  
 >  use_test_app! options do |target|
 #    target.tests do
 #  -------------------------------------------
```

See full build log: https://github.com/microsoft/react-native-test-app/runs/7478804395?check_suite_focus=true

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
```