### PR TITLE
fix(android): ensure Gradle patch is applied to correct CLI

### DIFF
--- a/scripts/patch-cli-platform-android.js
+++ b/scripts/patch-cli-platform-android.js
@@ -9,7 +9,8 @@ try {
   const nativeModulesScript = path.join(
     path.dirname(
       require.resolve(
-        "@react-native-community/cli-platform-android/package.json"
+        "@react-native-community/cli-platform-android/package.json",
+        { paths: [process.cwd()] }
       )
     ),
     "native_modules.gradle"


### PR DESCRIPTION
### Description

`@react-native-community/cli-platform-android` may be resolved to the wrong copy if there are duplicates.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

For some reason, this reproduces only with 0.64:

```
npm set-react-version 0.64
yarn
cd example/android
./gradlew assembleDebug
```