### PR TITLE
fix(ios): support multitasking on iPad

### DIFF
--- a/ios/ReactTestApp/Info.plist
+++ b/ios/ReactTestApp/Info.plist
@@ -80,12 +80,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>


### PR DESCRIPTION
### Description

iPad Multitasking support requires all four orientations.

Resolves #1031.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

See #1031.