### PR TITLE
chore(docs): update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
 # React Native Test App
 
-[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&color=007acc&labelColor=444444&logoColor=007acc)](https://vscode.dev/github/microsoft/react-native-test-app)
+![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen) [![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&color=007acc&labelColor=444444&logoColor=007acc)](https://vscode.dev/github/microsoft/react-native-test-app)
 [![build](https://github.com/microsoft/react-native-test-app/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/microsoft/react-native-test-app/actions/workflows/build.yml)
 [![npm version](https://img.shields.io/npm/v/react-native-test-app)](https://www.npmjs.com/package/react-native-test-app)
 
-- [Quick Start](#quick-start)
+- [Quick Start](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start)
 - [Configuring the Test App](#configuring-the-test-app)
+- [Migrate an Existing Test App](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App)
 - [Known Issues](#known-issues)
 
-React Native Test App provides test apps for all platforms as a package. It
+React Native Test App (RNTA) provides test apps for all platforms as a package. It
 handles the native bits for you so you can focus on what's important: your
 product.
 
 If you want to learn how RNTA is used at Microsoft, and see a demo of how to add
 it to an existing library - you can watch the
 ["Improve all the repos – exploring Microsoft’s DevExp"](https://youtu.be/DAEnPV78rQc?t=499)
-talk by @kelset and @tido64 from React Native Europe 2021.
+talk by [@kelset](https://github.com/kelset) and [@tido64](https://github.com/tido64) from React Native Europe 2021.
 
-For more about
+In the wiki, you can read more about
 [the motivation](https://github.com/microsoft/react-native-test-app/wiki#motivation)
 and [the design](https://github.com/microsoft/react-native-test-app/wiki/Design)
-of this tool, you can refer to the wiki.
+of this tool.
 
 ## Quick Start
+
+*If you want to migrate an existing test app for a library, follow the [dedicated guide in the wiki](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App).*
 
 Install `react-native-test-app` as a dev dependency. We will use the wizard to
 generate your test app:
@@ -35,7 +38,7 @@ yarn init-test-app
 In this example, we will create a project named "sample" in `sample` with test
 apps for all platforms:
 
-```
+```sh
 ✔ What is the name of your test app? … sample
 ? Which platforms do you need test apps for? ›
 Instructions:
@@ -57,136 +60,13 @@ cd sample
 yarn
 ```
 
-Once the dependencies are installed, follow the platform specific instructions
-below.
-
-### Android
-
-Bundle the JS code and assets by running:
-
-```sh
-yarn build:android
-```
-
-If you're going to use the development server, you can skip this step.
-
-To start the Android app, run:
-
-```sh
-yarn android
-```
-
-Alternatively, you can also run the app within Android Studio by pointing it to
-the `android` folder.
-
-### iOS
-
-Bundle the JS code and assets by running:
-
-```sh
-yarn build:ios
-```
-
-If you're going to use the development server, you can skip this step.
-
-Before you can run the iOS app, you must first install its native dependencies:
-
-```sh
-pod install --project-directory=ios
-```
-
-This command is also responsible for generating the Xcode project. To start the
-iOS app, run:
-
-```sh
-yarn ios
-```
-
-Alternatively, you can also run the app within Xcode by opening the Xcode
-workspace:
-
-```sh
-open ios/Sample.xcworkspace
-```
-
-> **Note:** If you made changes to `app.json` or any other assets, you should
-> re-run `pod install` to make sure that the changes are included in the Xcode
-> project.
-
-### macOS
-
-Bundle the JS code and assets by running:
-
-```sh
-yarn build:ios
-```
-
-If you're going to use the development server, you can skip this step.
-
-Before you can run the macOS app, you must first install its native
-dependencies:
-
-```sh
-pod install --project-directory=macos
-```
-
-This command is also responsible for generating the Xcode project. To start the
-macOS app, run:
-
-```sh
-yarn macos
-```
-
-Alternatively, you can also run the app within Xcode by opening the Xcode
-workspace:
-
-```sh
-open macos/Sample.xcworkspace
-```
-
-> **Note:** If you made changes to `app.json` or any other assets, you should
-> re-run `pod install` to make sure that the changes are included in the Xcode
-> project.
-
-### Windows
-
-Bundle the JS code and assets by running:
-
-```sh
-yarn build:ios
-```
-
-Before you can run the Windows app, you must first generate it:
-
-```sh
-npx install-windows-test-app --use-nuget
-```
-
-To start the Windows app, run:
-
-```sh
-yarn windows
-```
-
-Alternatively, you can also run the app within Visual Studio by opening the
-solution file:
-
-```
-start windows/Sample.sln
-```
-
-If you choose to use Visual Studio, remember to first set the target platform to
-`x64`. It is set to `ARM` by default.
-
-> **Note:** If you made changes to `app.json` or any other assets, you should
-> re-run `install-windows-test-app` to make sure that the changes are included
-> in the Visual Studio project.
+Once the dependencies are installed, follow the [platform specific instructions](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start#platform-specific-instructions) in the wiki.
 
 ## Configuring the Test App
 
 All configuration of the test app is done via `app.json` (otherwise known as the
-manifest). You can learn more about that in
-[the wiki](https://github.com/microsoft/react-native-test-app/wiki/Manifest-%28app.json%29).
+manifest). You can learn more about that
+[in the dedicated wiki section](https://github.com/microsoft/react-native-test-app/wiki/Manifest-%28app.json%29).
 
 Additionally, you can find platform specific documentation below:
 
@@ -196,6 +76,15 @@ Additionally, you can find platform specific documentation below:
 
 ## Known Issues
 
-For a list of known issues and workarounds, please go to the
-[Troubleshooting](https://github.com/microsoft/react-native-test-app/wiki/Troubleshooting)
-page in the wiki.
+For a list of known issues and workarounds, please refer to the
+[Troubleshooting wiki](https://github.com/microsoft/react-native-test-app/wiki/Troubleshooting).
+
+## Contributing
+
+Thank you for your interest in this project! We welcome all contributions and suggestions!
+
+Take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## License
+
+`react-native-test-app` is [MIT licensed](./LICENSE).


### PR DESCRIPTION
### Description

This PR is a follow up from a conversation we had last week about improving the state of the README, and add references to the migrating guide in it.

To make it shorter, I also moved the quick start guide to its [own wiki page](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start). In the migration wiki I've also added a few more notes about certain things we had to do for blur (you can see them at the bottom of [this section](https://github.com/microsoft/react-native-test-app/wiki/Migrate-an-Existing-Test-App#configure-the-test-app)).

### Platforms affected

N/A

### Test plan

N/A
