### PR TITLE
fix(android): allow custom Kotlin version

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -10,13 +10,18 @@ ext {
     targetSdkVersion = 29
 
     // We need only set `ndkVersion` when building react-native from source.
-    if (hasProperty("ANDROID_NDK_VERSION")) {
-        ndkVersion ANDROID_NDK_VERSION
+    if (rootProject.hasProperty("ANDROID_NDK_VERSION")) {
+        ndkVersion = rootProject.properties["ANDROID_NDK_VERSION"]
     } else if (System.properties["os.arch"] == "aarch64") {
         // Android NDK added support for Apple M1 in r24:
         // https://github.com/android/ndk/wiki/Changelog-r24
         ndkVersion = "24.0.8215888"
     }
+
+    androidPluginVersion = "7.2.2"
+    kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")
+        ? rootProject.properties["KOTLIN_VERSION"]
+        : "1.7.10"
 
     /**
      * Dependabot requires a `dependencies.gradle` to evaluate Java
@@ -34,15 +39,12 @@ ext {
         androidRecyclerView         : "androidx.recyclerview:recyclerview:1.2.1",
         androidSwipeRefreshLayout   : "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
         junit                       : "junit:junit:4.13.2",
-        kotlinReflect               : "org.jetbrains.kotlin:kotlin-reflect:1.7.10",
-        kotlinStdlibJdk7            : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10",
-        kotlinStdlibJdk8            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10",
+        kotlinReflect               : "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}",
+        kotlinStdlibJdk7            : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}",
+        kotlinStdlibJdk8            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}",
         materialComponents          : "com.google.android.material:material:1.6.1",
         mockitoInline               : "org.mockito:mockito-inline:4.6.1",
         moshiKotlin                 : "com.squareup.moshi:moshi-kotlin:1.13.0",
         moshiKotlinCodegen          : "com.squareup.moshi:moshi-kotlin-codegen:1.13.0",
     ]
-
-    androidPluginVersion = "7.2.2"
-    kotlinVersion = versionOf(libraries.kotlinStdlibJdk7)
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -40,3 +40,6 @@ android.enableJetifier=true
 
 # Uncomment the line below if building react-native from source
 #ANDROID_NDK_VERSION=21.4.7075529
+
+# Version of Kotlin to build against.
+#KOTLIN_VERSION=1.7.10


### PR DESCRIPTION
### Description

Allow users to specify their own Kotlin version.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Set Kotlin version to 1.6.21, and modify `dependencies.gradle` to output some lines for us:

```diff
diff --git a/android/dependencies.gradle b/android/dependencies.gradle
index 2aea14b..983fec9 100644
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -47,4 +47,8 @@ ext {
         moshiKotlin                 : "com.squareup.moshi:moshi-kotlin:1.13.0",
         moshiKotlinCodegen          : "com.squareup.moshi:moshi-kotlin-codegen:1.13.0",
     ]
+
+    System.println(libraries.kotlinReflect)
+    System.println(libraries.kotlinStdlibJdk7)
+    System.println(libraries.kotlinStdlibJdk8)
 }
diff --git a/example/android/gradle.properties b/example/android/gradle.properties
index f188b68..7180797 100644
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -42,4 +42,4 @@ android.enableJetifier=true
 #ANDROID_NDK_VERSION=21.4.7075529

 # Version of Kotlin to build against.
-#KOTLIN_VERSION=1.7.10
+KOTLIN_VERSION=1.6.21
```

Build:

```sh
cd example/android
./gradlew assembleDebug
```

Verify the output:

```
% ./gradlew assembleDebug
Configuration on demand is an incubating feature.

> Configure project :
org.jetbrains.kotlin:kotlin-reflect:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

> Configure project :app
org.jetbrains.kotlin:kotlin-reflect:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

> Configure project :support
org.jetbrains.kotlin:kotlin-reflect:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

> Task :react-native-safe-area-context:compileDebugKotlin
w: /~/example/node_modules/react-native-safe-area-context/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.kt: (50, 23): 'getter for uiImplementation: UIImplementation!' is deprecated. Deprecated in Java

BUILD SUCCESSFUL in 58s
89 actionable tasks: 21 executed, 68 up-to-date
```