### PR TITLE
chore: make example app more informational

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,7 @@
     },
     {
       "matchPackageNames": [
+        "@types/react-native",
         "react-native",
         "react-native-macos",
         "react-native-windows"

--- a/example/App.js
+++ b/example/App.js
@@ -1,3 +1,4 @@
+// @ts-check
 import React, { useCallback, useMemo, useState } from "react";
 import {
   ScrollView,
@@ -10,10 +11,12 @@ import {
 } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { Colors, Header } from "react-native/Libraries/NewAppScreen";
+// @ts-expect-error
 import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
 
 function getHermesVersion() {
   return (
+    // @ts-expect-error
     global.HermesInternal?.getRuntimeProperties?.()["OSS Release Version"] ??
     false
   );
@@ -24,6 +27,14 @@ function getReactNativeVersion() {
   return coreVersion.prerelease
     ? version + `-${coreVersion.prerelease}`
     : version;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {"Off" | "On"}
+ */
+function isOnOrOff(value) {
+  return value ? "On" : "Off";
 }
 
 function useStyles() {
@@ -69,6 +80,10 @@ function useStyles() {
   }, [colorScheme]);
 }
 
+/**
+ * @param {{ children: string; value: string | boolean; }} props
+ * @returns
+ */
 const Feature = ({ children, value }) => {
   const styles = useStyles();
   return (
@@ -88,6 +103,10 @@ const Separator = () => {
   return <View style={styles.separator} />;
 };
 
+/**
+ * @param {{ concurrentRoot?: boolean; }} props
+ * @returns
+ */
 const App = ({ concurrentRoot }) => {
   const isDarkMode = useColorScheme() === "dark";
   const styles = useStyles();
@@ -119,11 +138,11 @@ const App = ({ concurrentRoot }) => {
           <View style={styles.group}>
             <Feature value={getReactNativeVersion()}>React Native</Feature>
             <Separator />
-            <Feature value={Boolean(hermesVersion)}>Hermes</Feature>
+            <Feature value={isOnOrOff(hermesVersion)}>Hermes</Feature>
             <Separator />
-            <Feature value={isFabric}>Fabric</Feature>
+            <Feature value={isOnOrOff(isFabric)}>Fabric</Feature>
             <Separator />
-            <Feature value={isFabric && Boolean(concurrentRoot)}>
+            <Feature value={isOnOrOff(isFabric && concurrentRoot)}>
               Concurrent React
             </Feature>
           </View>

--- a/example/App.js
+++ b/example/App.js
@@ -80,10 +80,7 @@ function useStyles() {
   }, [colorScheme]);
 }
 
-/**
- * @param {{ children: string; value: string | boolean; }} props
- * @returns
- */
+/** @type {React.FunctionComponent<{ children: string; value: string | boolean; }>} */
 const Feature = ({ children, value }) => {
   const styles = useStyles();
   return (
@@ -103,10 +100,7 @@ const Separator = () => {
   return <View style={styles.separator} />;
 };
 
-/**
- * @param {{ concurrentRoot?: boolean; }} props
- * @returns
- */
+/** @type {React.FunctionComponent<{ concurrentRoot?: boolean; }>} */
 const App = ({ concurrentRoot }) => {
   const isDarkMode = useColorScheme() === "dark";
   const styles = useStyles();

--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { AppRegistry } from "react-native";
 import App from "./App";
 import { name as appName } from "./app.json";

--- a/example/package.json
+++ b/example/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@types/jest": "^27.0.0",
+    "@types/react-native": "^0.68.0",
     "jest": "^27.0.0",
     "metro-react-native-babel-preset": "^0.67.0",
     "mkdirp": "^1.0.0",

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-native"
+  },
+  "include": [
+    "App.js",
+    "index.js"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.5
+  resolution: "@types/prop-types@npm:15.7.5"
+  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
+"@types/react-native@npm:^0.68.0":
+  version: 0.68.3
+  resolution: "@types/react-native@npm:0.68.3"
+  dependencies:
+    "@types/react": ^17
+  checksum: e9ca9e5038499044f33a6f1f1f65f3a2a8877e793552e24a8ab0f86f6ac04e193992ea8c5a6457ee3e76fc41d7c52f81a104ca90dd61d0924d8295c8d046a622
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^17":
+  version: 17.0.48
+  resolution: "@types/react@npm:17.0.48"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: b683fa33f751ced0b8c8715df9f40de15513c1d7ce66064a75cdfb8805cc913b0b214a2e7022ef0b724bd62a1e8651d040cd265dd0452bde03cca9b8e495742d
+  languageName: node
+  linkType: hard
+
 "@types/retry@npm:^0.12.0":
   version: 0.12.1
   resolution: "@types/retry@npm:0.12.1"
@@ -2807,6 +2834,13 @@ __metadata:
     "@types/glob": "*"
     "@types/node": "*"
   checksum: b47fa302f46434cba704d20465861ad250df79467d3d289f9d6490d3aeeb41e8cb32dd80bd1a8fd833d1e185ac719fbf9be12e05ad9ce9be094d8ee8f1405347
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.2
+  resolution: "@types/scheduler@npm:0.16.2"
+  checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
   languageName: node
   linkType: hard
 
@@ -4650,6 +4684,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csstype@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "csstype@npm:3.1.0"
+  checksum: 644e986cefab86525f0b674a06889cfdbb1f117e5b7d1ce0fc55b0423ecc58807a1ea42ecc75c4f18999d14fc42d1d255f84662a45003a52bb5840e977eb2ffd
+  languageName: node
+  linkType: hard
+
 "dargs@npm:^7.0.0":
   version: 7.0.0
   resolution: "dargs@npm:7.0.0"
@@ -5526,6 +5567,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.0.0
     "@types/jest": ^27.0.0
+    "@types/react-native": ^0.68.0
     jest: ^27.0.0
     metro-react-native-babel-preset: ^0.67.0
     mkdirp: ^1.0.0


### PR DESCRIPTION
### Description

Display build parameters in the example app for a better overview. This makes it easier to create screenshots for new versions of react-native.

See also #997 for the current issue with screenshots.

The Fabric detector is borrowed from [ScrollViewStickyHeader.js](https://github.com/facebook/react-native/blob/d35aab45b9a2cb79f234fd0d599cc50793866ee2/Libraries/Components/ScrollView/ScrollViewStickyHeader.js#L188-L192)

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

| Android | iOS | iOS with Fabric | macOS |
| :-: | :-: | :-: | :-: |
| ![Screenshot_1660819993](https://user-images.githubusercontent.com/4123478/185379978-aa95cfe4-05e9-4267-bce9-92a6eff0c40c.png) | ![image](https://user-images.githubusercontent.com/4123478/185381241-d2c6113b-8356-4650-89e2-4208408e97f8.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 15 29 48](https://user-images.githubusercontent.com/4123478/184897597-51858866-b765-4581-9f71-b6eee0fad918.png) | ![image](https://user-images.githubusercontent.com/4123478/185381765-a7d053b5-24ba-4804-9307-cea36c0b691f.png) |