### PR TITLE
chore(macos): workaround for react-native-macos@main

### DIFF
--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -12,6 +12,12 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
+  # TODO: Remove this block when react-native-macos catches up to core.
+  unless defined?(FlipperConfiguration)
+    require_relative('use_react_native-0.68')
+    return include_react_native!(options)
+  end
+
   if target_platform == :ios && flipper_versions
     Pod::UI.warn(
       'use_flipper is deprecated from 0.70; use the flipper_configuration ' \


### PR DESCRIPTION
### Description

react-native-macos nightlies currently fail because profile 0.70 is being applied to it ([example](https://github.com/microsoft/react-native-test-app/runs/7912110411?check_suite_focus=true)).

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
# Verify that react-native-macos@main builds

npm run set-react-version canary-macos
yarn
cd example
pod install --project-directory=macos

# Verify that react-native@0.70 builds

npm run set-react-version 0.70
npm run clean
yarn
cd example
pod install --project-directory=ios
```