### PR TITLE
fix(apple): fix blank views after reloading

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,7 @@
       "matchPackagePrefixes": ["com.squareup.moshi"]
     },
     {
-      "matchPackageNames": ["react"],
+      "matchPackageNames": ["com.facebook.react:hermes-engine", "react"],
       "enabled": false
     },
     {

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -54,13 +54,6 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(onJavaScriptLoading(_:)),
-            name: .RCTJavaScriptWillStartLoading,
-            object: nil
-        )
-
-        NotificationCenter.default.addObserver(
-            self,
             selector: #selector(onJavaScriptLoaded(_:)),
             name: .RCTJavaScriptDidLoad,
             object: nil
@@ -224,19 +217,6 @@ final class ReactInstance: NSObject, RCTBridgeDelegate {
                 )
             })
             #endif
-        }
-    }
-
-    @objc
-    private func onJavaScriptLoading(_ notification: Notification) {
-        guard self.bridge != nil else {
-            // This is a cold boot. The bridge will be set in initReact(onDidInitialize:).
-            return
-        }
-
-        let bridge = notification.userInfo?["bridge"] as? RCTBridge
-        if bridge != self.bridge {
-            self.bridge = bridge
         }
     }
 


### PR DESCRIPTION
### Description

New React root views are blank after reloading at least once.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Build and run the iOS app
2. Shake (^⌘Z) and reload, or toggle "Remote Debugging" (which will trigger a reload)
3. Navigate back
4. Press to open "App"

The new screen should not be blank.

![toggle-debugging](https://user-images.githubusercontent.com/4123478/185647204-b2edd8f1-0945-4fcb-b473-0f18e946265e.gif)
