### PR TITLE
fix(ios): allow apps to run as-is on Apple silicon Macs

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,14 +5,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.68.2)
-  - FBReactNativeSpec (0.68.2):
+  - FBLazyVector (0.68.3)
+  - FBReactNativeSpec (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Core (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
+    - RCTRequired (= 0.68.3)
+    - RCTTypeSafety (= 0.68.3)
+    - React-Core (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -89,201 +89,201 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.2)
-  - RCTTypeSafety (0.68.2):
-    - FBLazyVector (= 0.68.2)
+  - RCTRequired (0.68.3)
+  - RCTTypeSafety (0.68.3):
+    - FBLazyVector (= 0.68.3)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.2)
-    - React-Core (= 0.68.2)
-  - React (0.68.2):
-    - React-Core (= 0.68.2)
-    - React-Core/DevSupport (= 0.68.2)
-    - React-Core/RCTWebSocket (= 0.68.2)
-    - React-RCTActionSheet (= 0.68.2)
-    - React-RCTAnimation (= 0.68.2)
-    - React-RCTBlob (= 0.68.2)
-    - React-RCTImage (= 0.68.2)
-    - React-RCTLinking (= 0.68.2)
-    - React-RCTNetwork (= 0.68.2)
-    - React-RCTSettings (= 0.68.2)
-    - React-RCTText (= 0.68.2)
-    - React-RCTVibration (= 0.68.2)
-  - React-callinvoker (0.68.2)
-  - React-Codegen (0.68.2):
-    - FBReactNativeSpec (= 0.68.2)
+    - RCTRequired (= 0.68.3)
+    - React-Core (= 0.68.3)
+  - React (0.68.3):
+    - React-Core (= 0.68.3)
+    - React-Core/DevSupport (= 0.68.3)
+    - React-Core/RCTWebSocket (= 0.68.3)
+    - React-RCTActionSheet (= 0.68.3)
+    - React-RCTAnimation (= 0.68.3)
+    - React-RCTBlob (= 0.68.3)
+    - React-RCTImage (= 0.68.3)
+    - React-RCTLinking (= 0.68.3)
+    - React-RCTNetwork (= 0.68.3)
+    - React-RCTSettings (= 0.68.3)
+    - React-RCTText (= 0.68.3)
+    - React-RCTVibration (= 0.68.3)
+  - React-callinvoker (0.68.3)
+  - React-Codegen (0.68.3):
+    - FBReactNativeSpec (= 0.68.3)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Core (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-Core (0.68.2):
+    - RCTRequired (= 0.68.3)
+    - RCTTypeSafety (= 0.68.3)
+    - React-Core (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-Core (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-Core/Default (= 0.68.3)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.2):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
-    - Yoga
-  - React-Core/Default (0.68.2):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
-    - Yoga
-  - React-Core/DevSupport (0.68.2):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.2)
-    - React-Core/RCTWebSocket (= 0.68.2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-jsinspector (= 0.68.2)
-    - React-perflogger (= 0.68.2)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.2):
+  - React-Core/CoreModulesHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.2):
+  - React-Core/Default (0.68.3):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
+    - Yoga
+  - React-Core/DevSupport (0.68.3):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.3)
+    - React-Core/RCTWebSocket (= 0.68.3)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-jsinspector (= 0.68.3)
+    - React-perflogger (= 0.68.3)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.2):
+  - React-Core/RCTAnimationHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.2):
+  - React-Core/RCTBlobHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.2):
+  - React-Core/RCTImageHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.2):
+  - React-Core/RCTLinkingHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.2):
+  - React-Core/RCTNetworkHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.2):
+  - React-Core/RCTSettingsHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.2):
+  - React-Core/RCTTextHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.2):
+  - React-Core/RCTVibrationHeaders (0.68.3):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsiexecutor (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
     - Yoga
-  - React-CoreModules (0.68.2):
+  - React-Core/RCTWebSocket (0.68.3):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/CoreModulesHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-RCTImage (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-cxxreact (0.68.2):
+    - React-Core/Default (= 0.68.3)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsiexecutor (= 0.68.3)
+    - React-perflogger (= 0.68.3)
+    - Yoga
+  - React-CoreModules (0.68.3):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.3)
+    - React-Codegen (= 0.68.3)
+    - React-Core/CoreModulesHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-RCTImage (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-cxxreact (0.68.3):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-jsinspector (= 0.68.2)
-    - React-logger (= 0.68.2)
-    - React-perflogger (= 0.68.2)
-    - React-runtimeexecutor (= 0.68.2)
-  - React-jsi (0.68.2):
+    - React-callinvoker (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-jsinspector (= 0.68.3)
+    - React-logger (= 0.68.3)
+    - React-perflogger (= 0.68.3)
+    - React-runtimeexecutor (= 0.68.3)
+  - React-jsi (0.68.3):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.2)
-  - React-jsi/Default (0.68.2):
+    - React-jsi/Default (= 0.68.3)
+  - React-jsi/Default (0.68.3):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.2):
+  - React-jsiexecutor (0.68.3):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-perflogger (= 0.68.2)
-  - React-jsinspector (0.68.2)
-  - React-logger (0.68.2):
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-perflogger (= 0.68.3)
+  - React-jsinspector (0.68.3)
+  - React-logger (0.68.3):
     - glog
   - react-native-safe-area-context (4.3.1):
     - RCT-Folly
@@ -291,71 +291,71 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.68.2)
-  - React-RCTActionSheet (0.68.2):
-    - React-Core/RCTActionSheetHeaders (= 0.68.2)
-  - React-RCTAnimation (0.68.2):
+  - React-perflogger (0.68.3)
+  - React-RCTActionSheet (0.68.3):
+    - React-Core/RCTActionSheetHeaders (= 0.68.3)
+  - React-RCTAnimation (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTAnimationHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTBlob (0.68.2):
+    - RCTTypeSafety (= 0.68.3)
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTAnimationHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTBlob (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTBlobHeaders (= 0.68.2)
-    - React-Core/RCTWebSocket (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-RCTNetwork (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTImage (0.68.2):
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTBlobHeaders (= 0.68.3)
+    - React-Core/RCTWebSocket (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-RCTNetwork (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTImage (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTImageHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-RCTNetwork (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTLinking (0.68.2):
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTLinkingHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTNetwork (0.68.2):
+    - RCTTypeSafety (= 0.68.3)
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTImageHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-RCTNetwork (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTLinking (0.68.3):
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTLinkingHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTNetwork (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTNetworkHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTSettings (0.68.2):
+    - RCTTypeSafety (= 0.68.3)
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTNetworkHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTSettings (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTSettingsHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-RCTText (0.68.2):
-    - React-Core/RCTTextHeaders (= 0.68.2)
-  - React-RCTVibration (0.68.2):
+    - RCTTypeSafety (= 0.68.3)
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTSettingsHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-RCTText (0.68.3):
+    - React-Core/RCTTextHeaders (= 0.68.3)
+  - React-RCTVibration (0.68.3):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.2)
-    - React-Core/RCTVibrationHeaders (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - ReactCommon/turbomodule/core (= 0.68.2)
-  - React-runtimeexecutor (0.68.2):
-    - React-jsi (= 0.68.2)
-  - ReactCommon/turbomodule/core (0.68.2):
+    - React-Codegen (= 0.68.3)
+    - React-Core/RCTVibrationHeaders (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - ReactCommon/turbomodule/core (= 0.68.3)
+  - React-runtimeexecutor (0.68.3):
+    - React-jsi (= 0.68.3)
+  - ReactCommon/turbomodule/core (0.68.3):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.2)
-    - React-Core (= 0.68.2)
-    - React-cxxreact (= 0.68.2)
-    - React-jsi (= 0.68.2)
-    - React-logger (= 0.68.2)
-    - React-perflogger (= 0.68.2)
+    - React-callinvoker (= 0.68.3)
+    - React-Core (= 0.68.3)
+    - React-cxxreact (= 0.68.3)
+    - React-jsi (= 0.68.3)
+    - React-logger (= 0.68.3)
+    - React-perflogger (= 0.68.3)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React-Core
     - React-jsi
@@ -521,8 +521,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
-  FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
+  FBLazyVector: 34f7420274737b6fcf2e2d9fd42641e66b4436a3
+  FBReactNativeSpec: 68c23fb2cea9393190e0815b673d742fa33d2dab
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
@@ -537,35 +537,35 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
-  RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
-  React: 176dd882de001854ced260fad41bb68a31aa4bd0
-  React-callinvoker: c2864d1818d6e64928d2faf774a3800dfc38fe1f
-  React-Codegen: 98b6f97f0a7abf7d67e4ce435c77c05b7a95cf05
-  React-Core: fdaa2916b1c893f39f02cff0476d1fb0cab1e352
-  React-CoreModules: fd8705b80699ec36c2cdd635c2ce9d874b9cfdfc
-  React-cxxreact: 1832d971f7b0cb2c7b943dc0ec962762c90c906e
-  React-jsi: 72af715135abe8c3f0dcf3b2548b71d048b69a7e
-  React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
-  React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
-  React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
+  RCTRequired: b8caca023d386d43740dfb94c2cf68f695fa5e77
+  RCTTypeSafety: ec44ea1d6ad1e5cd6447b22159ff40c2ebbd23b1
+  React: 9f8c8afb9a9d61b7a1b01a1c6fb7f0d4f902988f
+  React-callinvoker: f813eee352cfd333208e8d67a72f584f5435769d
+  React-Codegen: 771562186fec8c7830897f97ca59de683abd3184
+  React-Core: 74670b4b715083e1c9003462f3f4fe32a70ba5c5
+  React-CoreModules: 34bd5b93e5322e60102a5ad78b992c882e558022
+  React-cxxreact: adc9fc6a9333ae779bd72effaf77173bd9f22bf7
+  React-jsi: ab91137ea7d92a86e48b6f15d3a5580bea471776
+  React-jsiexecutor: a5043e9e1e1bd13b80b58b228c6901b3721a4f54
+  React-jsinspector: 86e89b9f135787a2e8eb74b3fc00ec61e9a80ae1
+  React-logger: f790bd10f86b38012e108fb4b564023602702270
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
-  React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6
-  React-RCTActionSheet: 547fe42fdb4b6089598d79f8e1d855d7c23e2162
-  React-RCTAnimation: bc9440a1c37b06ae9ebbb532d244f607805c6034
-  React-RCTBlob: a1295c8e183756d7ef30ba6e8f8144dfe8a19215
-  React-RCTImage: a30d1ee09b1334067fbb6f30789aae2d7ac150c9
-  React-RCTLinking: ffc6d5b88d1cb9aca13c54c2ec6507fbf07f2ac4
-  React-RCTNetwork: f807a2facab6cf5cf36d592e634611de9cf12d81
-  React-RCTSettings: 861806819226ed8332e6a8f90df2951a34bb3e7f
-  React-RCTText: f3fb464cc41a50fc7a1aba4deeb76a9ad8282cb9
-  React-RCTVibration: 79040b92bfa9c3c2d2cb4f57e981164ec7ab9374
-  React-runtimeexecutor: b960b687d2dfef0d3761fbb187e01812ebab8b23
-  ReactCommon: 095366164a276d91ea704ce53cb03825c487a3f2
+  React-perflogger: fa15d1d29ff7557ee25ea48f7f59e65896fb3215
+  React-RCTActionSheet: e83515333352a3cc19c146e3c7a63a8a9269da8f
+  React-RCTAnimation: 8032daa2846e3db7ac28c4c5a207d0bfb5e1e3ad
+  React-RCTBlob: fe40e206cebcb4f552e0ecdac3ef81b3baf3cb37
+  React-RCTImage: dfc0df14cbfec1ec54fdd4700b8fe3bf8127dde2
+  React-RCTLinking: ac9f65f0c8db738a6156ae7640ba92494b4770a5
+  React-RCTNetwork: cf289a0386a1bd057e5eabb8563dfe5ce0af868c
+  React-RCTSettings: 7889cfcf6c7d5738f3cb8889557a38eeea2f04ff
+  React-RCTText: fd249e1f8406fb6e35cc77a2b9ff66a3477bf41a
+  React-RCTVibration: f41f116aad644973f24653effb3db3de64fa0314
+  React-runtimeexecutor: 8cdd80915ed6dabf2221a689f1f7ddb50ea5e9f3
+  ReactCommon: 5b1b43a7d81a1ac4eec85f7c4db3283a14a3b13d
   ReactTestApp-DevSupport: 19f2e33511690a213253175a9ca541d10456cb95
   ReactTestApp-Resources: ff5f151e465e890010b417ce65ca6c5de6aeccbb
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
+  Yoga: 2f6a78c58dcc2963bd8e34d96a4246d9dff2e3a7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 2b1a64c7bbe2717d38b70f5573c321acc909ea09

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -5,14 +5,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.68.11)
-  - FBReactNativeSpec (0.68.11):
+  - FBLazyVector (0.68.27)
+  - FBReactNativeSpec (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.11)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Core (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
+    - RCTRequired (= 0.68.27)
+    - RCTTypeSafety (= 0.68.27)
+    - React-Core (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2021.06.28.00-v2):
@@ -26,267 +26,267 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.11)
-  - RCTTypeSafety (0.68.11):
-    - FBLazyVector (= 0.68.11)
+  - RCTRequired (0.68.27)
+  - RCTTypeSafety (0.68.27):
+    - FBLazyVector (= 0.68.27)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.11)
-    - React-Core (= 0.68.11)
-  - React (0.68.11):
-    - React-Core (= 0.68.11)
-    - React-Core/DevSupport (= 0.68.11)
-    - React-Core/RCTWebSocket (= 0.68.11)
-    - React-RCTActionSheet (= 0.68.11)
-    - React-RCTAnimation (= 0.68.11)
-    - React-RCTBlob (= 0.68.11)
-    - React-RCTImage (= 0.68.11)
-    - React-RCTLinking (= 0.68.11)
-    - React-RCTNetwork (= 0.68.11)
-    - React-RCTSettings (= 0.68.11)
-    - React-RCTText (= 0.68.11)
-    - React-RCTVibration (= 0.68.11)
-  - React-callinvoker (0.68.11)
-  - React-Codegen (0.68.11):
-    - FBReactNativeSpec (= 0.68.11)
+    - RCTRequired (= 0.68.27)
+    - React-Core (= 0.68.27)
+  - React (0.68.27):
+    - React-Core (= 0.68.27)
+    - React-Core/DevSupport (= 0.68.27)
+    - React-Core/RCTWebSocket (= 0.68.27)
+    - React-RCTActionSheet (= 0.68.27)
+    - React-RCTAnimation (= 0.68.27)
+    - React-RCTBlob (= 0.68.27)
+    - React-RCTImage (= 0.68.27)
+    - React-RCTLinking (= 0.68.27)
+    - React-RCTNetwork (= 0.68.27)
+    - React-RCTSettings (= 0.68.27)
+    - React-RCTText (= 0.68.27)
+    - React-RCTVibration (= 0.68.27)
+  - React-callinvoker (0.68.27)
+  - React-Codegen (0.68.27):
+    - FBReactNativeSpec (= 0.68.27)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.11)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Core (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-Core (0.68.11):
+    - RCTRequired (= 0.68.27)
+    - RCTTypeSafety (= 0.68.27)
+    - React-Core (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-Core (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.11)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-Core/Default (= 0.68.27)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.11):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
-    - Yoga
-  - React-Core/Default (0.68.11):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
-    - Yoga
-  - React-Core/DevSupport (0.68.11):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.11)
-    - React-Core/RCTWebSocket (= 0.68.11)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-jsinspector (= 0.68.11)
-    - React-perflogger (= 0.68.11)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.11):
+  - React-Core/CoreModulesHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.11):
+  - React-Core/Default (0.68.27):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
+    - Yoga
+  - React-Core/DevSupport (0.68.27):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.27)
+    - React-Core/RCTWebSocket (= 0.68.27)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-jsinspector (= 0.68.27)
+    - React-perflogger (= 0.68.27)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.11):
+  - React-Core/RCTAnimationHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.11):
+  - React-Core/RCTBlobHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.11):
+  - React-Core/RCTImageHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.11):
+  - React-Core/RCTLinkingHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.11):
+  - React-Core/RCTNetworkHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.11):
+  - React-Core/RCTSettingsHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.11):
+  - React-Core/RCTTextHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.11):
+  - React-Core/RCTVibrationHeaders (0.68.27):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.11)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsiexecutor (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
     - Yoga
-  - React-CoreModules (0.68.11):
+  - React-Core/RCTWebSocket (0.68.27):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Codegen (= 0.68.11)
-    - React-Core/CoreModulesHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-RCTImage (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-cxxreact (0.68.11):
+    - React-Core/Default (= 0.68.27)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsiexecutor (= 0.68.27)
+    - React-perflogger (= 0.68.27)
+    - Yoga
+  - React-CoreModules (0.68.27):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.27)
+    - React-Codegen (= 0.68.27)
+    - React-Core/CoreModulesHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-RCTImage (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-cxxreact (0.68.27):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-jsinspector (= 0.68.11)
-    - React-logger (= 0.68.11)
-    - React-perflogger (= 0.68.11)
-    - React-runtimeexecutor (= 0.68.11)
-  - React-jsi (0.68.11):
+    - React-callinvoker (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-jsinspector (= 0.68.27)
+    - React-logger (= 0.68.27)
+    - React-perflogger (= 0.68.27)
+    - React-runtimeexecutor (= 0.68.27)
+  - React-jsi (0.68.27):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.11)
-  - React-jsi/Default (0.68.11):
+    - React-jsi/Default (= 0.68.27)
+  - React-jsi/Default (0.68.27):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.11):
+  - React-jsiexecutor (0.68.27):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-perflogger (= 0.68.11)
-  - React-jsinspector (0.68.11)
-  - React-logger (0.68.11):
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-perflogger (= 0.68.27)
+  - React-jsinspector (0.68.27)
+  - React-logger (0.68.27):
     - glog
-  - React-perflogger (0.68.11)
-  - React-RCTActionSheet (0.68.11):
-    - React-Core/RCTActionSheetHeaders (= 0.68.11)
-  - React-RCTAnimation (0.68.11):
+  - React-perflogger (0.68.27)
+  - React-RCTActionSheet (0.68.27):
+    - React-Core/RCTActionSheetHeaders (= 0.68.27)
+  - React-RCTAnimation (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTAnimationHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTBlob (0.68.11):
+    - RCTTypeSafety (= 0.68.27)
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTAnimationHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTBlob (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTBlobHeaders (= 0.68.11)
-    - React-Core/RCTWebSocket (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-RCTNetwork (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTImage (0.68.11):
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTBlobHeaders (= 0.68.27)
+    - React-Core/RCTWebSocket (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-RCTNetwork (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTImage (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTImageHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-RCTNetwork (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTLinking (0.68.11):
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTLinkingHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTNetwork (0.68.11):
+    - RCTTypeSafety (= 0.68.27)
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTImageHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-RCTNetwork (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTLinking (0.68.27):
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTLinkingHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTNetwork (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTNetworkHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTSettings (0.68.11):
+    - RCTTypeSafety (= 0.68.27)
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTNetworkHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTSettings (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.11)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTSettingsHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-RCTText (0.68.11):
-    - React-Core/RCTTextHeaders (= 0.68.11)
-  - React-RCTVibration (0.68.11):
+    - RCTTypeSafety (= 0.68.27)
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTSettingsHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-RCTText (0.68.27):
+    - React-Core/RCTTextHeaders (= 0.68.27)
+  - React-RCTVibration (0.68.27):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.11)
-    - React-Core/RCTVibrationHeaders (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - ReactCommon/turbomodule/core (= 0.68.11)
-  - React-runtimeexecutor (0.68.11):
-    - React-jsi (= 0.68.11)
-  - ReactCommon/turbomodule/core (0.68.11):
+    - React-Codegen (= 0.68.27)
+    - React-Core/RCTVibrationHeaders (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - ReactCommon/turbomodule/core (= 0.68.27)
+  - React-runtimeexecutor (0.68.27):
+    - React-jsi (= 0.68.27)
+  - ReactCommon/turbomodule/core (0.68.27):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.11)
-    - React-Core (= 0.68.11)
-    - React-cxxreact (= 0.68.11)
-    - React-jsi (= 0.68.11)
-    - React-logger (= 0.68.11)
-    - React-perflogger (= 0.68.11)
+    - React-callinvoker (= 0.68.27)
+    - React-Core (= 0.68.27)
+    - React-cxxreact (= 0.68.27)
+    - React-jsi (= 0.68.27)
+    - React-logger (= 0.68.27)
+    - React-perflogger (= 0.68.27)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React-Core
     - React-jsi
@@ -413,38 +413,38 @@ SPEC CHECKSUMS:
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: b24790c6ef94f11c4a5cec1961ba4e7afa6783a2
-  FBReactNativeSpec: 71a7210f46ea5eca8f3b49ae545f044da57998a1
+  FBLazyVector: e9292020a13ca5047678ae768a704023e70e566a
+  FBReactNativeSpec: f3062d3e923d6eee82e5d65af27b3ed81e7a616b
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTRequired: 4832e8451d7ecb4d23deb2343d73ada0d0adcc3c
-  RCTTypeSafety: c5a6c8540b071e3e5101e2a2c921a36e1013befa
-  React: 86d585bb9bb23dd4d287636493f42581d1a4d6e2
-  React-callinvoker: c394f574d942ac6a47b61f1aa955e52747f548e3
-  React-Codegen: 631bee7dfb793cf1254eebd80f709e4f7ed6802b
-  React-Core: 62e69c60621197a345ddf0ca8da43fb6bec35452
-  React-CoreModules: a2b70019c9f41318a57e17fb81a53f55d06a1ad7
-  React-cxxreact: aa6e6952a26d38c7a58adf5bf5cf2fc0b7fcd27f
-  React-jsi: 4864e4394a88c9d3369700e999ee307b89f7e2f2
-  React-jsiexecutor: f7c8d1e34341739055adfbf24eab9a710e128f3b
-  React-jsinspector: 5cd2f0769caf54e92b8a8d2df6f664822b25609a
-  React-logger: 4872174ad87732eb5edefbdfed01e9266661c0e0
-  React-perflogger: 1c00528daacaf4e526a9a4da310c20bf91e63e45
-  React-RCTActionSheet: 6eb23254d356a261576f58304f8a9d73fb1d47ab
-  React-RCTAnimation: 3c05dd4ca63c0bc7970a725e9c40ff0fccf210a9
-  React-RCTBlob: 44030599d90259ca5a0c72dd1d6ec49ca7bb8d36
-  React-RCTImage: 4a2b44615eedb2c24f18f5e5bb5969741d4c0e19
-  React-RCTLinking: 116098af22b4d5e0ac43d3cdf5f14023abe79fb5
-  React-RCTNetwork: 97e0f9f9d547fcbac93feb2493360ca8ecc960f4
-  React-RCTSettings: eca0faa9be97a99454c901b4c43bd4661a18e5ec
-  React-RCTText: c687858db16d2f0fd5be3f1d474e8a0623510582
-  React-RCTVibration: f6f5c14863b6b2291eda14dcc0a92d821d6be14a
-  React-runtimeexecutor: cc1524ec170aeea26bfbb4f2d12eb3b6d4483e56
-  ReactCommon: 68d433c583946184832af23ad1365f56010d0da4
+  RCTRequired: 30471b09575f8c68d1f4183e1aed46163f519f67
+  RCTTypeSafety: b904609f16b982623e9584922f3591480d0f273f
+  React: 9a6fabec30bb011a37d805b2b21e7f31f4c88ee9
+  React-callinvoker: d1087e0016b0cd86a2971966ac0be3644a50ae05
+  React-Codegen: 523e1910237a3cba29646a1f0a0c1d82e8475627
+  React-Core: 7276a9f6b8c60d073950a00a9a8fc271e676531d
+  React-CoreModules: ee49bebe08f91e9369c72ae278c439078307c1df
+  React-cxxreact: d1f652808c979b6fcbd587227c5f502a16b2c3f4
+  React-jsi: 8a322178167ce427c5b8a0b1deba08c67b528399
+  React-jsiexecutor: 6e0d76f519fd263e3f48852b9f55cc6cdd2d86f2
+  React-jsinspector: 5402c9aa15a2d43ba4a03454d5c731415f8ebd95
+  React-logger: ff2ab34e5d67127658aee4b924914f228906a97e
+  React-perflogger: 78b16738354482ee28552541b9645532d6d9768d
+  React-RCTActionSheet: eb93ca55fdc779359f0cb781314f65e76227b0da
+  React-RCTAnimation: 9fc4d8f061c7ebfbc3f2e27e437deffcf1f144db
+  React-RCTBlob: e290409273a1feb6b125ad783fa065a8d65efff2
+  React-RCTImage: 5acbba175ab875ae1e9612aabc171758c11594ee
+  React-RCTLinking: 1acb82973bf310ab1dfec03cafabe160c047fc8e
+  React-RCTNetwork: 83f2257ea5110d057cfb3ce9349f22fa95652cac
+  React-RCTSettings: e1a375bf3981a74160c73f3cb774a7f25c16f486
+  React-RCTText: 51fa6ee3112c95732b65e77f5a3924e64b09f641
+  React-RCTVibration: a1864710bd451461aeca8028907baba362e750f4
+  React-runtimeexecutor: 0cf62a1832afed07e82e34d3e20e0a854d00a372
+  ReactCommon: ee40fae3b09c05cdbd4b1aa44601456659ae1632
   ReactTestApp-DevSupport: 19f2e33511690a213253175a9ca541d10456cb95
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
-  Yoga: 29710be58872297bc5505ddc7e343798359ab948
+  Yoga: e82a287fa6b235b49ac814ff3528f73621919770
 
 PODFILE CHECKSUM: 39314e677d5ddf7e1e4c81e5e81f66cddabd661a
 

--- a/ios/ReactTestApp/Info.plist
+++ b/ios/ReactTestApp/Info.plist
@@ -40,7 +40,7 @@
 		<string>msauthv3</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
-	<true/>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
@@ -75,7 +75,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
### Description

Allow apps to run as-is on Apple silicon Macs.

Note that the app will crash on startup if Clang sanitizers are enabled. There's a separate issue for making it easier to disable them here: #974.

Resolves #1047.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Disable Clang Analyzers:

```diff
diff --git a/ios/ReactTestApp/ReactTestApp.debug.xcconfig b/ios/ReactTestApp/ReactTestApp.debug.xcconfig
index bcdd92c..a5c562e 100644
--- a/ios/ReactTestApp/ReactTestApp.debug.xcconfig
+++ b/ios/ReactTestApp/ReactTestApp.debug.xcconfig
@@ -1,7 +1,5 @@
 #include "ReactTestApp.common.xcconfig"

-CLANG_ADDRESS_SANITIZER = YES
-CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES
 DEBUG_INFORMATION_FORMAT = dwarf
 ENABLE_TESTABILITY = YES
 GCC_DYNAMIC_NO_PIC = NO
@@ -9,7 +7,5 @@ GCC_OPTIMIZATION_LEVEL = 0
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
 MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE
 ONLY_ACTIVE_ARCH = YES
-OTHER_CFLAGS = $(inherited) -fsanitize=bounds
-OTHER_LDFLAGS = $(inherited) -fsanitize=bounds
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
 SWIFT_OPTIMIZATION_LEVEL = -Onone
```

Run `pod install` and open the project in Xcode:

```
cd example
pod install --project-directory=ios
open ios/Example.xcworkspace
```

Select "My Mac (Designed for iPad)":

![image](https://user-images.githubusercontent.com/4123478/186183502-068c63b5-5775-43d2-a8e5-2b5ead7905a8.png)

Build and run the app.

### Screenshots

![image](https://user-images.githubusercontent.com/4123478/186182836-734d00a3-97bf-4230-9217-f89489932a44.png)
