### PR TITLE
chore: address unnecessary trailing comma error

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/manifest/Manifest.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import com.squareup.moshi.JsonClass
 
 /* ktlint-disable trailing-comma */
+/* ktlint-disable trailing-comma-on-declaration-site */
 
 @JsonClass(generateAdapter = true)
 data class Component(

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -105,6 +105,7 @@ function getLanguage(output) {
             "import com.squareup.moshi.JsonClass",
             "",
             "/* ktlint-disable trailing-comma */",
+            "/* ktlint-disable trailing-comma-on-declaration-site */",
             "",
           ].join("\n"),
         },


### PR DESCRIPTION
### Description

Latest ktlint renamed the rule `trailing-comma` -> `trailing-comma-on-declaration-site`.

Failing here: https://github.com/microsoft/react-native-test-app/runs/8010499142?check_suite_focus=true

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.