### PR TITLE
chore: fix ccache not being used when compiling Hermes

### DIFF
--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -44,6 +44,8 @@ if command -v ccache 1> /dev/null; then
   export USE_CCACHE=1
   export ANDROID_CCACHE=$(which ccache)
   export CCACHE_DIR=$HOME/.cache/ccache
+  export CMAKE_C_COMPILER_LAUNCHER=$ANDROID_CCACHE
+  export CMAKE_CXX_COMPILER_LAUNCHER=$ANDROID_CCACHE
   export PATH=$(dirname $(dirname $ANDROID_CCACHE))/opt/ccache/libexec:$PATH
   mkdir -p $CCACHE_DIR
 fi


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
# Set up ccache
export USE_CCACHE=1
export ANDROID_CCACHE=$(which ccache)
export CCACHE_DIR=$HOME/.cache/ccache
export CMAKE_C_COMPILER_LAUNCHER=$ANDROID_CCACHE
export CMAKE_CXX_COMPILER_LAUNCHER=$ANDROID_CCACHE
export PATH=$(dirname $(dirname $ANDROID_CCACHE))/opt/ccache/libexec:$PATH
mkdir -p $CCACHE_DIR

# Install react-native 0.70
npm run set-react-version 0.70
yarn

# Enable new architecture
cd example/android
sed -i '' 's/#newArchEnabled=true/newArchEnabled=true/' gradle.properties

# Build Hermes
CCACHE_DIR=$HOME/.cache/ccache ccache --zero-stats
./gradlew packageReactNdkDebugLibs
CCACHE_DIR=$HOME/.cache/ccache ccache -s
```

Before:

```
% CCACHE_DIR=$HOME/.cache/ccache ccache -s
Summary:
  Hits:             259 / 3483 (7.44 %)
    Direct:         257 / 3567 (7.20 %)
    Preprocessed:     2 / 3270 (0.06 %)
  Misses:          3224
    Direct:        3310
    Preprocessed:  3268
  Uncacheable:      433
Primary storage:
  Hits:             516 / 7094 (7.27 %)
  Misses:          6578
  Cache size (GB): 0.78 / 5.00 (15.56 %)

Use the -v/--verbose option for more details.
```

After:

```
% CCACHE_DIR=$HOME/.cache/ccache ccache -s
Summary:
  Hits:            2907 / 3227 (90.08 %)
    Direct:        2904 / 3311 (87.71 %)
    Preprocessed:     3 /  367 (0.82 %)
  Misses:           320
    Direct:         407
    Preprocessed:   364
  Uncacheable:      175
Primary storage:
  Hits:            5811 / 6582 (88.29 %)
  Misses:           771
  Cache size (GB): 0.78 / 5.00 (15.61 %)

Use the -v/--verbose option for more details.
```