### PR TITLE
chore: bump eslint-plugin-react to 7.31.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,8 +5352,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react@npm:^7.26.0":
-  version: 7.30.1
-  resolution: "eslint-plugin-react@npm:7.30.1"
+  version: 7.31.1
+  resolution: "eslint-plugin-react@npm:7.31.1"
   dependencies:
     array-includes: ^3.1.5
     array.prototype.flatmap: ^1.3.0
@@ -5371,7 +5371,7 @@ __metadata:
     string.prototype.matchall: ^4.0.7
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 553fb9ece6beb7c14cf6f84670c786c8ac978c2918421994dcc4edd2385302022e5d5ac4a39fafdb35954e29cecddefed61758040c3c530cafcf651f674a9d51
+  checksum: 6217d4c4e36c8fea24facd0cdcf22b2fd38a3603db94ec7c0a6f430046c8564b6c6884e0a9d4a4b8766201f66e8b18af594002210421bf9b6623b1fc32e15a3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bump `eslint-plugin-react` to 7.31.1. Renovate is fails to for some reason.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.