### PR TITLE
chore: use ccache's symlinks instead of own script

### DIFF
--- a/scripts/clang
+++ b/scripts/clang
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec ccache /usr/bin/clang "$@"

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 if [[ -z $DEBUG ]]; then
   brew install clang-format
-  curl --silent --show-error --remote-name https://raw.githubusercontent.com/llvm/llvm-project/release/10.x/clang/tools/clang-format/clang-format-diff.py
+  curl --silent --show-error --remote-name https://raw.githubusercontent.com/llvm/llvm-project/release/14.x/clang/tools/clang-format/clang-format-diff.py
 fi
 git diff --unified=0 --no-color @^ \
   | python clang-format-diff.py -p1 -regex '.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hh|hpp|m|mm|inc)' -sort-includes \

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -43,13 +43,18 @@ build_cmd=$(
 )
 
 if [[ "$CCACHE_DISABLE" != "1" ]]; then
-  ccache_libexec="/usr/local/opt/ccache/libexec"
-  if [[ ! -d "$ccache_libexec" ]]; then
+  if ! command -v ccache 1> /dev/null; then
     brew install ccache
   fi
 
-  export CC="$(git rev-parse --show-toplevel)/scripts/clang"
+  CCACHE_HOME=$(dirname $(dirname $(which ccache)))/opt/ccache
+
   export CCACHE_DIR="$(git rev-parse --show-toplevel)/.ccache"
+
+  export CC="${CCACHE_HOME}/libexec/clang"
+  export CXX="${CCACHE_HOME}/libexec/clang++"
+  export CMAKE_C_COMPILER_LAUNCHER=$(which ccache)
+  export CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
 
   ccache --zero-stats 1> /dev/null
 fi


### PR DESCRIPTION
### Description

Use ccache's symlinks instead of own script

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.