### PR TITLE
enhance: add/show default value to init command

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -18,7 +18,7 @@
       type: "text",
       name: "name",
       message: "What is the name of your test app?",
-      initial: "testapp",
+      initial: "TestApp",
       validate: Boolean,
     },
     {

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -18,6 +18,7 @@
       type: "text",
       name: "name",
       message: "What is the name of your test app?",
+      initial: "testapp",
       validate: Boolean,
     },
     {
@@ -36,6 +37,7 @@
       type: "text",
       name: "packagePath",
       message: "Where should we create the new project?",
+      initial: "example",
       validate: Boolean,
     },
   ]);


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->
I am enhancing the existing `init` that exist for the initialisation of the RNTA in a react-native repo. 
Added a default value which , user can press enter and continue to select that value.  
<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->
Resolves #1100 
### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

1. yarn add react-native-test-app --dev
2. yarn init-test-app

The initialisation prompt will be shown and default value are not shown. 
After this PR the default values will be shown as well as below 

![Screenshot 2022-09-11 at 1 27 36 PM](https://user-images.githubusercontent.com/30728574/189518175-72179808-d440-4d30-be63-7539b233536e.png)

![Screenshot 2022-09-11 at 1 27 49 PM](https://user-images.githubusercontent.com/30728574/189518186-fc54859f-2afd-4624-af31-f4c4e2adf4e1.png)