### PR TITLE
chore: disable Yarn trying to patch TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .vs/
 .watchman-*
 .yarn/*
+!.yarn/plugins/
 !.yarn/releases/
 Pods/
 android/**/build/

--- a/.yarn/plugins/@yarnpkg/plugin-compat.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-compat.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  name: "@yarnpkg/plugin-compat",
+  factory: () => ({}),
+};


### PR DESCRIPTION
### Description

Yarn tries to patch TypeScript to support PnP, but can fail when a new version of TypeScript is released. We don't use PnP.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`yarn install` should not complain about incompatible TypeScript version.