### PR TITLE
ci: set up Ccache earlier

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -8,6 +8,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up Ccache
+      if: ${{ inputs.platform == 'ios' || inputs.platform == 'macos' }}
+      run: |
+        if ! command -v ccache 1> /dev/null; then
+          brew install ccache
+        fi
+
+        CCACHE_HOME=$(dirname $(dirname $(which ccache)))/opt/ccache
+
+        echo "CCACHE_DIR=$(git rev-parse --show-toplevel)/.ccache" >> $GITHUB_ENV
+
+        echo "CC=${CCACHE_HOME}/libexec/clang" >> $GITHUB_ENV
+        echo "CXX=${CCACHE_HOME}/libexec/clang++" >> $GITHUB_ENV
+        echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
+
+        ccache --zero-stats 1> /dev/null
+      shell: bash
     - name: Set up Node.js
       uses: actions/setup-node@v3.4.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     # nightly builds against react-native@nightly at 5:00
     - cron: 0 5 * * *
+env:
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
 jobs:
   lint-commit:
     name: "lint commit message"

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,7 @@
 tap 'homebrew/cask-versions'
 brew 'clang-format'
 brew 'ktlint'
-brew 'node'
+brew 'n'
 brew 'swiftformat'
 brew 'swiftlint'
 brew 'yarn'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -285,11 +285,11 @@ PODS:
   - React-jsinspector (0.68.3)
   - React-logger (0.68.3):
     - glog
-  - react-native-safe-area-context (4.3.1):
+  - react-native-safe-area-context (4.3.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
-    - React
+    - React-Core
     - ReactCommon/turbomodule/core
   - React-perflogger (0.68.3)
   - React-RCTActionSheet (0.68.3):
@@ -549,7 +549,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: a5043e9e1e1bd13b80b58b228c6901b3721a4f54
   React-jsinspector: 86e89b9f135787a2e8eb74b3fc00ec61e9a80ae1
   React-logger: f790bd10f86b38012e108fb4b564023602702270
-  react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
+  react-native-safe-area-context: b456e1c40ec86f5593d58b275bd0e9603169daca
   React-perflogger: fa15d1d29ff7557ee25ea48f7f59e65896fb3215
   React-RCTActionSheet: e83515333352a3cc19c146e3c7a63a8a9269da8f
   React-RCTAnimation: 8032daa2846e3db7ac28c4c5a207d0bfb5e1e3ad

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,18 +1,17 @@
 PODS:
   - boost (1.76.0)
-  - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.68.27)
-  - FBReactNativeSpec (0.68.27):
+  - FBLazyVector (0.68.45)
+  - FBReactNativeSpec (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.27)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Core (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
+    - RCTRequired (= 0.68.45)
+    - RCTTypeSafety (= 0.68.45)
+    - React-Core (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2021.06.28.00-v2):
@@ -26,267 +25,267 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.27)
-  - RCTTypeSafety (0.68.27):
-    - FBLazyVector (= 0.68.27)
+  - RCTRequired (0.68.45)
+  - RCTTypeSafety (0.68.45):
+    - FBLazyVector (= 0.68.45)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.27)
-    - React-Core (= 0.68.27)
-  - React (0.68.27):
-    - React-Core (= 0.68.27)
-    - React-Core/DevSupport (= 0.68.27)
-    - React-Core/RCTWebSocket (= 0.68.27)
-    - React-RCTActionSheet (= 0.68.27)
-    - React-RCTAnimation (= 0.68.27)
-    - React-RCTBlob (= 0.68.27)
-    - React-RCTImage (= 0.68.27)
-    - React-RCTLinking (= 0.68.27)
-    - React-RCTNetwork (= 0.68.27)
-    - React-RCTSettings (= 0.68.27)
-    - React-RCTText (= 0.68.27)
-    - React-RCTVibration (= 0.68.27)
-  - React-callinvoker (0.68.27)
-  - React-Codegen (0.68.27):
-    - FBReactNativeSpec (= 0.68.27)
+    - RCTRequired (= 0.68.45)
+    - React-Core (= 0.68.45)
+  - React (0.68.45):
+    - React-Core (= 0.68.45)
+    - React-Core/DevSupport (= 0.68.45)
+    - React-Core/RCTWebSocket (= 0.68.45)
+    - React-RCTActionSheet (= 0.68.45)
+    - React-RCTAnimation (= 0.68.45)
+    - React-RCTBlob (= 0.68.45)
+    - React-RCTImage (= 0.68.45)
+    - React-RCTLinking (= 0.68.45)
+    - React-RCTNetwork (= 0.68.45)
+    - React-RCTSettings (= 0.68.45)
+    - React-RCTText (= 0.68.45)
+    - React-RCTVibration (= 0.68.45)
+  - React-callinvoker (0.68.45)
+  - React-Codegen (0.68.45):
+    - FBReactNativeSpec (= 0.68.45)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.27)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Core (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-Core (0.68.27):
+    - RCTRequired (= 0.68.45)
+    - RCTTypeSafety (= 0.68.45)
+    - React-Core (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-Core (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.27)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-Core/Default (= 0.68.45)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.27):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
-    - Yoga
-  - React-Core/Default (0.68.27):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
-    - Yoga
-  - React-Core/DevSupport (0.68.27):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.27)
-    - React-Core/RCTWebSocket (= 0.68.27)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-jsinspector (= 0.68.27)
-    - React-perflogger (= 0.68.27)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.27):
+  - React-Core/CoreModulesHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.27):
+  - React-Core/Default (0.68.45):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
+    - Yoga
+  - React-Core/DevSupport (0.68.45):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.45)
+    - React-Core/RCTWebSocket (= 0.68.45)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-jsinspector (= 0.68.45)
+    - React-perflogger (= 0.68.45)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.27):
+  - React-Core/RCTAnimationHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.27):
+  - React-Core/RCTBlobHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.27):
+  - React-Core/RCTImageHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.27):
+  - React-Core/RCTLinkingHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.27):
+  - React-Core/RCTNetworkHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.27):
+  - React-Core/RCTSettingsHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.27):
+  - React-Core/RCTTextHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.27):
+  - React-Core/RCTVibrationHeaders (0.68.45):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.27)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsiexecutor (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
     - Yoga
-  - React-CoreModules (0.68.27):
+  - React-Core/RCTWebSocket (0.68.45):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Codegen (= 0.68.27)
-    - React-Core/CoreModulesHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-RCTImage (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-cxxreact (0.68.27):
+    - React-Core/Default (= 0.68.45)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsiexecutor (= 0.68.45)
+    - React-perflogger (= 0.68.45)
+    - Yoga
+  - React-CoreModules (0.68.45):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.45)
+    - React-Codegen (= 0.68.45)
+    - React-Core/CoreModulesHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-RCTImage (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-cxxreact (0.68.45):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-jsinspector (= 0.68.27)
-    - React-logger (= 0.68.27)
-    - React-perflogger (= 0.68.27)
-    - React-runtimeexecutor (= 0.68.27)
-  - React-jsi (0.68.27):
+    - React-callinvoker (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-jsinspector (= 0.68.45)
+    - React-logger (= 0.68.45)
+    - React-perflogger (= 0.68.45)
+    - React-runtimeexecutor (= 0.68.45)
+  - React-jsi (0.68.45):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.27)
-  - React-jsi/Default (0.68.27):
+    - React-jsi/Default (= 0.68.45)
+  - React-jsi/Default (0.68.45):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.27):
+  - React-jsiexecutor (0.68.45):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-perflogger (= 0.68.27)
-  - React-jsinspector (0.68.27)
-  - React-logger (0.68.27):
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-perflogger (= 0.68.45)
+  - React-jsinspector (0.68.45)
+  - React-logger (0.68.45):
     - glog
-  - React-perflogger (0.68.27)
-  - React-RCTActionSheet (0.68.27):
-    - React-Core/RCTActionSheetHeaders (= 0.68.27)
-  - React-RCTAnimation (0.68.27):
+  - React-perflogger (0.68.45)
+  - React-RCTActionSheet (0.68.45):
+    - React-Core/RCTActionSheetHeaders (= 0.68.45)
+  - React-RCTAnimation (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTAnimationHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTBlob (0.68.27):
+    - RCTTypeSafety (= 0.68.45)
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTAnimationHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTBlob (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTBlobHeaders (= 0.68.27)
-    - React-Core/RCTWebSocket (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-RCTNetwork (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTImage (0.68.27):
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTBlobHeaders (= 0.68.45)
+    - React-Core/RCTWebSocket (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-RCTNetwork (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTImage (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTImageHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-RCTNetwork (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTLinking (0.68.27):
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTLinkingHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTNetwork (0.68.27):
+    - RCTTypeSafety (= 0.68.45)
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTImageHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-RCTNetwork (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTLinking (0.68.45):
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTLinkingHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTNetwork (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTNetworkHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTSettings (0.68.27):
+    - RCTTypeSafety (= 0.68.45)
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTNetworkHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTSettings (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.27)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTSettingsHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-RCTText (0.68.27):
-    - React-Core/RCTTextHeaders (= 0.68.27)
-  - React-RCTVibration (0.68.27):
+    - RCTTypeSafety (= 0.68.45)
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTSettingsHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-RCTText (0.68.45):
+    - React-Core/RCTTextHeaders (= 0.68.45)
+  - React-RCTVibration (0.68.45):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.27)
-    - React-Core/RCTVibrationHeaders (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - ReactCommon/turbomodule/core (= 0.68.27)
-  - React-runtimeexecutor (0.68.27):
-    - React-jsi (= 0.68.27)
-  - ReactCommon/turbomodule/core (0.68.27):
+    - React-Codegen (= 0.68.45)
+    - React-Core/RCTVibrationHeaders (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - ReactCommon/turbomodule/core (= 0.68.45)
+  - React-runtimeexecutor (0.68.45):
+    - React-jsi (= 0.68.45)
+  - ReactCommon/turbomodule/core (0.68.45):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.27)
-    - React-Core (= 0.68.27)
-    - React-cxxreact (= 0.68.27)
-    - React-jsi (= 0.68.27)
-    - React-logger (= 0.68.27)
-    - React-perflogger (= 0.68.27)
+    - React-callinvoker (= 0.68.45)
+    - React-Core (= 0.68.45)
+    - React-cxxreact (= 0.68.45)
+    - React-jsi (= 0.68.45)
+    - React-logger (= 0.68.45)
+    - React-perflogger (= 0.68.45)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React-Core
     - React-jsi
@@ -295,7 +294,6 @@ PODS:
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native-macos/third-party-podspecs/boost.podspec`)
-  - boost-for-react-native (from `../node_modules/react-native-macos/third-party-podspecs/boost-for-react-native.podspec`)
   - DoubleConversion (from `../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec`)
   - Example-Tests (from `..`)
   - FBLazyVector (from `../node_modules/react-native-macos/Libraries/FBLazyVector`)
@@ -339,8 +337,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   boost:
     :podspec: "../node_modules/react-native-macos/third-party-podspecs/boost.podspec"
-  boost-for-react-native:
-    :podspec: "../node_modules/react-native-macos/third-party-podspecs/boost-for-react-native.podspec"
   DoubleConversion:
     :podspec: "../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec"
   Example-Tests:
@@ -410,41 +406,40 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
-  boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: e9292020a13ca5047678ae768a704023e70e566a
-  FBReactNativeSpec: f3062d3e923d6eee82e5d65af27b3ed81e7a616b
+  FBLazyVector: e9fecec31e5911389abca1d80a3c5961da7ce999
+  FBReactNativeSpec: 7a64164ccbba41d15af8a1dcec2b24f214c2b7fc
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTRequired: 30471b09575f8c68d1f4183e1aed46163f519f67
-  RCTTypeSafety: b904609f16b982623e9584922f3591480d0f273f
-  React: 9a6fabec30bb011a37d805b2b21e7f31f4c88ee9
-  React-callinvoker: d1087e0016b0cd86a2971966ac0be3644a50ae05
-  React-Codegen: 523e1910237a3cba29646a1f0a0c1d82e8475627
-  React-Core: 7276a9f6b8c60d073950a00a9a8fc271e676531d
-  React-CoreModules: ee49bebe08f91e9369c72ae278c439078307c1df
-  React-cxxreact: d1f652808c979b6fcbd587227c5f502a16b2c3f4
-  React-jsi: 8a322178167ce427c5b8a0b1deba08c67b528399
-  React-jsiexecutor: 6e0d76f519fd263e3f48852b9f55cc6cdd2d86f2
-  React-jsinspector: 5402c9aa15a2d43ba4a03454d5c731415f8ebd95
-  React-logger: ff2ab34e5d67127658aee4b924914f228906a97e
-  React-perflogger: 78b16738354482ee28552541b9645532d6d9768d
-  React-RCTActionSheet: eb93ca55fdc779359f0cb781314f65e76227b0da
-  React-RCTAnimation: 9fc4d8f061c7ebfbc3f2e27e437deffcf1f144db
-  React-RCTBlob: e290409273a1feb6b125ad783fa065a8d65efff2
-  React-RCTImage: 5acbba175ab875ae1e9612aabc171758c11594ee
-  React-RCTLinking: 1acb82973bf310ab1dfec03cafabe160c047fc8e
-  React-RCTNetwork: 83f2257ea5110d057cfb3ce9349f22fa95652cac
-  React-RCTSettings: e1a375bf3981a74160c73f3cb774a7f25c16f486
-  React-RCTText: 51fa6ee3112c95732b65e77f5a3924e64b09f641
-  React-RCTVibration: a1864710bd451461aeca8028907baba362e750f4
-  React-runtimeexecutor: 0cf62a1832afed07e82e34d3e20e0a854d00a372
-  ReactCommon: ee40fae3b09c05cdbd4b1aa44601456659ae1632
+  RCTRequired: 27693cc871a00ec64ab645632855bb267815a92f
+  RCTTypeSafety: 799e2c274b3248b126c7c5f4b4ec8298bf2c4b85
+  React: 8e85e599366082700ff11d226b9d2dfe7894fabf
+  React-callinvoker: b711c5af2714763e52b3dd6f79b9bcf4e5fbbc3f
+  React-Codegen: 1830a9b5673835ab63ca55fabc1270867ef66b9d
+  React-Core: 2a935dea4b19238966d2ca9bed44a1f70c7c9c8b
+  React-CoreModules: aa5a183528dd349b262e338b661221a07d57aa14
+  React-cxxreact: d4f2ec955d14578e2317de8ec4a3662ff86480b3
+  React-jsi: 4fb32768eff290d7e28443fef9790193e349538d
+  React-jsiexecutor: 3aaf74a4e10b2603351ae919ac556d362585ec48
+  React-jsinspector: 5377c8149971be2fbb780b6f71b2d69e7b8897f1
+  React-logger: c0a319cb2128e5006ab2a55db30801565497fcdd
+  React-perflogger: c1a7f13647ca3723b53809bbae206ea481099558
+  React-RCTActionSheet: 9765fee9db62cfc6ebe91b42b2afd3fcd1389d43
+  React-RCTAnimation: d3fa4dc5290f91ec001d9b29c2700f3bac922b9a
+  React-RCTBlob: 1e7eb06f38b8b8daef89552e2c7b14b7e59c5f01
+  React-RCTImage: a3f307fea1edfaa75c50d99196c4cd22b11b6f10
+  React-RCTLinking: e5f8c36eb797b5b1959ea0925293e9fef51dd64e
+  React-RCTNetwork: 0dc9939a9577df89a563cf795a9c91dba73b1cb7
+  React-RCTSettings: 73697ba45f537208fd7e74454835368a479f7207
+  React-RCTText: baaa57e0e9e2324967018ac1f34313f885d3cb3b
+  React-RCTVibration: c3dc17464ccd085eb5ac41aaa28fc154698cefb5
+  React-runtimeexecutor: 312e8e8ec9457e2507901947cbd0e6d77342fb77
+  ReactCommon: 99cb4bfc12722d43a0b33fc30000ccb9ede37bb5
   ReactTestApp-DevSupport: 19f2e33511690a213253175a9ca541d10456cb95
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
-  Yoga: e82a287fa6b235b49ac814ff3528f73621919770
+  Yoga: 7ed465c91fd55de39d4835467d52e18927007821
 
 PODFILE CHECKSUM: 39314e677d5ddf7e1e4c81e5e81f66cddabd661a
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10736,8 +10736,8 @@ fsevents@^2.3.2:
   linkType: hard
 
 "react-native-macos@npm:^0.68.3":
-  version: 0.68.44
-  resolution: "react-native-macos@npm:0.68.44"
+  version: 0.68.45
+  resolution: "react-native-macos@npm:0.68.45"
   dependencies:
     "@jest/create-cache-key-function": ^27.0.1
     "@react-native-community/cli": ^7.0.3
@@ -10776,7 +10776,7 @@ fsevents@^2.3.2:
     react: 17.0.2
   bin:
     react-native-macos: cli.js
-  checksum: 48e67124555612d241961c8d76dc0c597d9468b73b8da22c73e72e7b7b0c01f5cd6b0d8e2c12d1d0cb0e61b1b5c2cdecb328fc43e2112164f62f18912df9c231
+  checksum: 3e15a7ec52e948434afc8631b336d75e053831d81ec14f8e09ee8e7427cfe74096e85aebd3172ba8daf998576890cf4daf1b89a4ec4786755dc85dc113813d64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Set up Ccache earlier to capture `pod install` artifacts, and allow expansion to Android later.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.