### PR TITLE
fix(apple): address script build phase warning in Xcode 14

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		1936CB1C2768EC280085FD98 /* Validate Manifest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		19E2AE7C27693278007B06CA /* Validate Manifest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
### Description

Addresses the "Run script build phase 'Validate Manifest' will be run during every build..." warning in Xcode 14.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Build RNTA with Xcode 14.