### PR TITLE
fix(ios): confirm URL before loading it

### DIFF
--- a/ios/ReactTestApp/QRCodeScannerViewController.swift
+++ b/ios/ReactTestApp/QRCodeScannerViewController.swift
@@ -143,6 +143,7 @@ extension Notification.Name {
 }
 
 extension UIAlertAction {
+    // swiftlint:disable:next identifier_name
     static func No(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         UIAlertAction(
             title: NSLocalizedString("No", comment: "Negative"),
@@ -151,6 +152,7 @@ extension UIAlertAction {
         )
     }
 
+    // swiftlint:disable:next identifier_name
     static func Yes(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         UIAlertAction(
             title: NSLocalizedString("Yes", comment: "Affirmative"),

--- a/ios/ReactTestApp/QRCodeScannerViewController.swift
+++ b/ios/ReactTestApp/QRCodeScannerViewController.swift
@@ -116,7 +116,7 @@ final class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutp
                     message: stringValue,
                     preferredStyle: .alert
                 )
-                alert.addAction(UIAlertAction.Yes() { _ in
+                alert.addAction(UIAlertAction.Yes { _ in
                     NotificationCenter.default.post(
                         name: .didReceiveRemoteBundleURL,
                         object: presentingViewController,
@@ -144,7 +144,7 @@ extension Notification.Name {
 
 extension UIAlertAction {
     static func No(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
-        return UIAlertAction(
+        UIAlertAction(
             title: NSLocalizedString("No", comment: "Negative"),
             style: .cancel,
             handler: handler
@@ -152,7 +152,7 @@ extension UIAlertAction {
     }
 
     static func Yes(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
-        return UIAlertAction(
+        UIAlertAction(
             title: NSLocalizedString("Yes", comment: "Affirmative"),
             style: .default,
             handler: handler

--- a/ios/ReactTestApp/QRCodeScannerViewController.swift
+++ b/ios/ReactTestApp/QRCodeScannerViewController.swift
@@ -51,7 +51,9 @@ final class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutp
         super.viewWillAppear(animated)
 
         if captureSession.isRunnable {
-            captureSession.startRunning()
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.captureSession.startRunning()
+            }
             feedback.prepare()
         } else {
             let alert = UIAlertController(
@@ -103,11 +105,27 @@ final class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutp
 
             feedback.notificationOccurred(.success)
 
-            NotificationCenter.default.post(
-                name: .didReceiveRemoteBundleURL,
-                object: self,
-                userInfo: ["url": urlComponents]
-            )
+            guard let presentingViewController = presentingViewController else {
+                assertionFailure()
+                return
+            }
+
+            DispatchQueue.main.async {
+                let alert = UIAlertController(
+                    title: "Is this the right URL?",
+                    message: stringValue,
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction.Yes() { _ in
+                    NotificationCenter.default.post(
+                        name: .didReceiveRemoteBundleURL,
+                        object: presentingViewController,
+                        userInfo: ["url": urlComponents]
+                    )
+                })
+                alert.addAction(UIAlertAction.No())
+                presentingViewController.present(alert, animated: true)
+            }
         }
     }
 }
@@ -122,6 +140,24 @@ extension AVCaptureSession {
 
 extension Notification.Name {
     static let didReceiveRemoteBundleURL = Notification.Name("didReceiveRemoteBundleURL")
+}
+
+extension UIAlertAction {
+    static func No(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(
+            title: NSLocalizedString("No", comment: "Negative"),
+            style: .cancel,
+            handler: handler
+        )
+    }
+
+    static func Yes(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(
+            title: NSLocalizedString("Yes", comment: "Affirmative"),
+            style: .default,
+            handler: handler
+        )
+    }
 }
 
 extension UIDevice {


### PR DESCRIPTION
### Description

Ask the user to confirm the URL before loading.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Open the app
2. Shake and select "Scan QR Code"
3. Scan any QR code

![RPReplay_Final1663240100](https://user-images.githubusercontent.com/4123478/190389708-1515a2a0-a165-4185-8da0-1cf3a11ee991.gif)
