### PR TITLE
fix(android): crash when switching to dev server

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -4,8 +4,11 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.util.Log
+import com.facebook.hermes.reactexecutor.HermesExecutor
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.PackageList
 import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMarker
@@ -150,6 +153,12 @@ class TestAppReactNativeHost(
         return reactInstanceManager
     }
 
+    override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory {
+        SoLoader.init(application, false)
+        HermesExecutor.loadLibrary()
+        return HermesExecutorFactory()
+    }
+
     override fun getJSIModulePackage(): JSIModulePackage? {
         return if (BuildConfig.ReactTestApp_useFabric) {
             FabricJSIModulePackage(this)
@@ -165,7 +174,7 @@ class TestAppReactNativeHost(
 
     override fun getUseDeveloperSupport() = source == BundleSource.Server
 
-    override fun getPackages() = PackageList(application).packages
+    override fun getPackages(): List<ReactPackage> = PackageList(application).packages
 
     private fun addCustomDevOptions(devSupportManager: DevSupportManager) {
         val bundleOption = application.resources.getString(

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -10,6 +10,7 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSIModulePackage
+import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants


### PR DESCRIPTION
### Description

App crashes when switching from embedded JS to dev server.

Normally, when the app launches, it tries to load JSC first and throws because `libjsc.so` is missing. React Native handles this exception and retries with Hermes. When we reload, this whole process is repeated, but the Catalyst instance that used to handl exceptions is now gone, leading to an unhandled exception crash.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Build the bundle + app:
   ```
   cd example
   yarn build:android
   yarn android
   ```
2. After the app has opened, start Metro dev server: `yarn start`
3. In the app, tap on the 🍔 menu and select "Load from dev server"

App shouldn't crash after the 3rd step.