### PR TITLE
ci: enable publishing from release branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
   },
   "release": {
     "branches": [
+      "releases/+([0-9]).x",
       "trunk"
     ],
     "tagFormat": "${version}",


### PR DESCRIPTION
### Description

Enable publishing from release branches. Releases branches will follow the pattern `releases/N.x`, where `N` is the major version number.

Branch protection rules have also been set up: https://github.com/microsoft/react-native-test-app/settings/branches

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
% npx semantic-release --dry-run
[3:13:45 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.5
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/github"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[3:13:45 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[3:13:52 PM] [semantic-release] › ⚠  Run automated release from branch releases/1.x on repository https://github.com/microsoft/react-native-test-app.git in dry-run mode
```