### PR TITLE
fix(ios): add button to start QR code scanner

### DIFF
--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -60,6 +60,13 @@ final class ContentViewController: UITableViewController {
 
         title = manifest.displayName
 
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "qrcode.viewfinder"),
+            style: .plain,
+            target: self,
+            action: #selector(scanForQRCode)
+        )
+
         let components = manifest.components ?? []
         if components.isEmpty {
             NotificationCenter.default.addObserver(
@@ -113,7 +120,7 @@ final class ContentViewController: UITableViewController {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(scanForQRCode(_:)),
+            selector: #selector(scanForQRCode),
             name: ReactInstance.scanForQRCodeNotification,
             object: nil
         )
@@ -255,7 +262,7 @@ final class ContentViewController: UITableViewController {
 
 extension ContentViewController {
     @objc
-    private func scanForQRCode(_: Notification) {
+    private func scanForQRCode() {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in


### PR DESCRIPTION
### Description

Adds a button to start the QR code scanner in the navigation bar.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

![RPReplay_Final1663673251](https://user-images.githubusercontent.com/4123478/191246891-9669369b-3bb3-4b1a-a4b8-92ee4d393bd1.gif)
