### PR TITLE
feat(android): populate home screen with AppRegistry entries

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -158,6 +158,15 @@ android {
                     abiFilters(*project.ext.react.architectures)
                 }
             }
+        } else {
+            externalNativeBuild {
+                cmake {
+                    arguments "-DANDROID_STL=c++_shared",
+                              "-DREACT_COMMON_DIR=${reactNativePath}/ReactCommon",
+                              "-DREACT_JNILIBS_DIR=${buildDir}/outputs/jniLibs"
+                    cppFlags "-std=c++17"
+                }
+            }
         }
     }
 
@@ -221,6 +230,32 @@ android {
                     }
                 }
             }
+        }
+    } else {
+        externalNativeBuild {
+            cmake {
+                path "${projectDir}/src/main/jni/CMakeLists.txt"
+            }
+        }
+
+        def version = getPackageVersion("react-native", rootDir)
+        def allAar = file("${reactNativePath}/android/com/facebook/react/react-native/${version}/react-native-${version}.aar")
+
+        def prepareDebugJSI = tasks.register("prepareDebugJSI", Copy) {
+            def debugAar = file("${reactNativePath}/android/com/facebook/react/react-native/${version}/react-native-${version}-debug.aar")
+            from(zipTree(debugAar.exists() ? debugAar : allAar).matching({ it.include "**/libjsi.so" }))
+            into("${buildDir}/outputs/jniLibs/debug")
+        }
+
+        def prepareReleaseJSI = tasks.register("prepareReleaseJSI", Copy) {
+            def releaseAar = file("${reactNativePath}/android/com/facebook/react/react-native/${version}/react-native-${version}-release.aar")
+            from(zipTree(releaseAar.exists() ? releaseAar : allAar).matching({ it.include "**/libjsi.so" }))
+            into("${buildDir}/outputs/jniLibs/release")
+        }
+
+        afterEvaluate {
+            preDebugBuild.dependsOn(prepareDebugJSI)
+            preReleaseBuild.dependsOn(prepareReleaseJSI)
         }
     }
 

--- a/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
+++ b/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
@@ -9,7 +9,6 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 import com.microsoft.reacttestapp.MainActivity
 import com.microsoft.reacttestapp.R
-import com.microsoft.reacttestapp.testApp
 
 fun MainActivity.canUseCamera(): Boolean {
     return ContextCompat.checkSelfPermission(
@@ -27,7 +26,7 @@ fun MainActivity.scanForQrCode() {
                     .setTitle(R.string.is_this_the_right_url)
                     .setMessage(it)
                     .setPositiveButton(R.string.yes) { _: DialogInterface, _: Int ->
-                        testApp.reloadJSFromServer(this, it)
+                        reloadJSFromServer(it)
                     }
                     .setNegativeButton(R.string.no) { _: DialogInterface, _: Int ->
                         // Nothing to do

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
@@ -1,16 +1,32 @@
 package com.microsoft.reacttestapp.component
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.annotation.UiThread
 import androidx.recyclerview.widget.RecyclerView
 import com.microsoft.reacttestapp.R
 
 class ComponentListAdapter(
     private val layoutInflater: LayoutInflater,
-    private val components: List<ComponentViewModel>,
+    private var components: List<ComponentViewModel>,
     private val listener: (ComponentViewModel, Int) -> Unit
 ) : RecyclerView.Adapter<ComponentListAdapter.ComponentViewHolder>() {
+
+    @UiThread
+    fun clear() {
+        val itemCount = components.size
+        components = listOf()
+        notifyItemRangeRemoved(0, itemCount)
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    @UiThread
+    fun setComponents(components: List<ComponentViewModel>) {
+        this.components = components
+        notifyDataSetChanged()
+    }
 
     override fun getItemCount() = components.size
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/AppRegistry.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/AppRegistry.kt
@@ -1,0 +1,23 @@
+package com.microsoft.reacttestapp.react
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.soloader.SoLoader
+
+/**
+ * The corresponding C++ implementation is in `android/app/src/main/jni/AppRegistry.cpp`
+ */
+class AppRegistry {
+    companion object {
+        init {
+            SoLoader.loadLibrary("reacttestapp_appmodules")
+        }
+
+        fun getAppKeys(context: ReactApplicationContext): Array<String> {
+            val appKeys = AppRegistry().getAppKeys(context.javaScriptContextHolder.get())
+                ?: return arrayOf()
+            return appKeys.filterIsInstance<String>().toTypedArray()
+        }
+    }
+
+    private external fun getAppKeys(jsiPtr: Long): Array<Any>?
+}

--- a/android/app/src/main/jni/Android.mk
+++ b/android/app/src/main/jni/Android.mk
@@ -12,12 +12,13 @@ include $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni/Android-rncli.mk
 include $(CLEAR_VARS)
 
 LOCAL_PATH := $(THIS_DIR)
+REACTTESTAPP_PATH := $(LOCAL_PATH)/../../../../..
 
 # You can customize the name of your application .so file here.
 LOCAL_MODULE := reacttestapp_appmodules
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACTTESTAPP_PATH)
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp) $(REACTTESTAPP_PATH)/common/AppRegistry.cpp
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 # If you wish to add a custom TurboModule or Fabric component in your app you

--- a/android/app/src/main/jni/AppRegistry.cpp
+++ b/android/app/src/main/jni/AppRegistry.cpp
@@ -1,0 +1,20 @@
+#include "AppRegistry.h"
+
+#include "common/AppRegistry.h"
+
+extern "C" {
+
+JNIEXPORT jobjectArray JNICALL Java_com_microsoft_reacttestapp_react_AppRegistry_getAppKeys(
+    JNIEnv *env, jclass clazz, jlong jsiPtr)
+{
+    auto runtime = reinterpret_cast<facebook::jsi::Runtime *>(jsiPtr);
+    auto appKeys = ReactTestApp::GetAppKeys(*runtime);
+    auto numKeys = static_cast<int>(appKeys.size());
+    auto result = env->NewObjectArray(numKeys, env->FindClass("java/lang/String"), nullptr);
+    for (int i = 0; i < numKeys; ++i) {
+        env->SetObjectArrayElement(result, i, env->NewStringUTF(appKeys[i].c_str()));
+    }
+    return result;
+}
+
+}  // extern "C"

--- a/android/app/src/main/jni/AppRegistry.h
+++ b/android/app/src/main/jni/AppRegistry.h
@@ -1,0 +1,13 @@
+#ifndef ANDROID_JNI_APPREGISTRY_
+#define ANDROID_JNI_APPREGISTRY_
+
+#include <jni.h>
+
+extern "C" {
+
+JNIEXPORT jobjectArray JNICALL Java_com_microsoft_reacttestapp_react_AppRegistry_getAppKeys(
+    JNIEnv *env, jclass clazz, jlong jsiPtr);
+
+}  // extern "C"
+
+#endif  // ANDROID_JNI_APPREGISTRY_

--- a/android/app/src/main/jni/CMakeLists.txt
+++ b/android/app/src/main/jni/CMakeLists.txt
@@ -2,4 +2,34 @@ cmake_minimum_required(VERSION 3.13)
 
 project(reacttestapp_appmodules)
 
-include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)
+set(THIS_LIBRARY reacttestapp_appmodules)
+
+set(REACTTESTAPP_ROOT ../../../../..)
+set(REACTTESTAPP_SOURCE_FILES
+  ${REACTTESTAPP_ROOT}/common/AppRegistry.cpp
+  ${REACTTESTAPP_ROOT}/common/AppRegistry.h
+  AppRegistry.cpp
+  AppRegistry.h
+)
+
+if(DEFINED REACT_ANDROID_DIR)
+  include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)
+  target_sources(${THIS_LIBRARY} PRIVATE ${REACTTESTAPP_SOURCE_FILES})
+else()
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(BUILD_VARIANT debug)
+  else()
+    set(BUILD_VARIANT release)
+  endif()
+  set(JSI_LIBRARY ${REACT_JNILIBS_DIR}/${BUILD_VARIANT}/jni/${ANDROID_ABI}/libjsi.so)
+
+  if(EXISTS ${JSI_LIBRARY})
+    add_library(${THIS_LIBRARY} SHARED ${REACTTESTAPP_SOURCE_FILES})
+    target_include_directories(${THIS_LIBRARY} PRIVATE ${REACT_COMMON_DIR}/jsi)
+    target_link_libraries(${THIS_LIBRARY} ${JSI_LIBRARY})
+  else()
+    add_library(${THIS_LIBRARY} SHARED ${REACTTESTAPP_SOURCE_FILES})
+  endif()
+endif()
+
+target_include_directories(${THIS_LIBRARY} PRIVATE ${REACTTESTAPP_ROOT})

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -134,11 +134,16 @@ ext.getManifest = {
     return manifest
 }
 
-ext.getPackageVersionNumber = { packageName, baseDir ->
+ext.getPackageVersion = { packageName, baseDir ->
     def packagePath = findNodeModulesPath(packageName, baseDir)
     def packageJson = file("${packagePath}/package.json")
     def manifest = new JsonSlurper().parseText(packageJson.text)
-    def (major, minor, patch) = manifest["version"].findAll(/\d+/)
+    return manifest["version"]
+}
+
+ext.getPackageVersionNumber = { packageName, baseDir ->
+    def version = getPackageVersion(packageName, baseDir)
+    def (major, minor, patch) = version.findAll(/\d+/)
     return (major as int) * 10000 + (minor as int) * 100 + (patch as int)
 }
 


### PR DESCRIPTION
### Description

Similar to #482, but for Android.

Resolves #189.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

See test plan in #482.

~~Flipper crashes on startup with this change. I'm not sure why, but downgrading it to 0.105 resolves the issue.~~ The `SIGILL` comes from the device trying to load different `.so` files on startup, but the app should load fine. Bump to 0.164 to make it go away.

This needs to be tested on:

- [x] 0.64 (no `libjsi.so`, should show blank screen)
- [x] 0.68 (has release `libjsi.so`)
- [x] 0.69 (has debug/release `libjsi.so`)
- [x] 0.69 + new arch (uses `ndkBuild`, `libjsi.so` already linked)
- [x] 0.70 (has debug/release `libjsi.so`)
- [x] 0.70 + new arch (uses `cmake`, `libjsi.so` already linked)

Note that for new arch, you will need to force resolve rn-cli to 9.x for autolinking.

![device-2022-09-21-145225](https://user-images.githubusercontent.com/4123478/191508871-b56c9efa-545a-483c-8b6a-c7da11922de2.gif)
