### PR TITLE
fix(android): `HermesExecutor.loadLibrary()` was only recently introduced in 0.68

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import com.facebook.hermes.reactexecutor.HermesExecutor
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.PackageList
 import com.facebook.react.ReactInstanceManager
@@ -156,7 +155,6 @@ class TestAppReactNativeHost(
 
     override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory {
         SoLoader.init(application, false)
-        HermesExecutor.loadLibrary()
         return HermesExecutorFactory()
     }
 


### PR DESCRIPTION
### Description

And we don't actually need to call it. Only `SoLoader` needs to be initialized here.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

- Make sure that we can still switch from embedded JS bundle to dev server (and back).
- Verify that 0.64 still builds.
    ```
    npm run set-react-version 0.64
    yarn
    cd example
    yarn android
    ```