### PR TITLE
fix(ios): enable dev menu on home screen

### DIFF
--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -49,6 +49,21 @@ final class ContentViewController: UITableViewController {
         fatalError("\(#function) has not been implemented")
     }
 
+    // MARK: - UIResponder overrides
+
+    override public func motionEnded(_: UIEvent.EventSubtype, with event: UIEvent?) {
+        guard event?.subtype == .motionShake,
+              let bridge = reactInstance.bridge,
+              let settings = bridge.module(for: RCTDevSettings.self) as? RCTDevSettings,
+              settings.isShakeToShowDevMenuEnabled,
+              let devMenu = bridge.module(for: RCTDevMenu.self) as? RCTDevMenu
+        else {
+            return
+        }
+
+        devMenu.show()
+    }
+
     // MARK: - UIViewController overrides
 
     override public func viewDidLoad() {


### PR DESCRIPTION
### Description

`RCTDevMenu` currently does not appear unless it is in a React view.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

![Simulator Screen Recording - iPhone 13 - 2022-09-23 at 12 19 19](https://user-images.githubusercontent.com/4123478/191941120-f761e73d-99e5-4904-82f7-12386c466bff.gif)
