### PR TITLE
fix(android): use Android Gradle Plugin 7.3.0 on 0.71+

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -75,6 +75,8 @@ project.ext.react = [
 project.ext.signingConfigs = getSigningConfigs()
 
 android {
+    namespace "com.microsoft.reacttestapp"
+
     compileSdkVersion project.ext.compileSdkVersion
 
     if (project.hasProperty("ndkVersion")) {
@@ -202,7 +204,7 @@ android {
                         dependsOn("preReleaseBuild")
                     }
                 }
-            } else {
+            } else if (reactNativeVersion < 7100) {
                 // Due to a bug in AGP, we have to explicitly set a dependency
                 // between configureCMakeDebug* tasks and the preBuild tasks. This can
                 // be removed once this issue is resolved:

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -18,7 +18,9 @@ ext {
         ndkVersion = "24.0.8215888"
     }
 
-    androidPluginVersion = "7.2.2"
+    androidPluginVersion = getPackageVersionNumber("react-native", rootDir) < 7100
+        ? "7.2.2"
+        : "7.3.0"
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")
         ? rootProject.properties["KOTLIN_VERSION"]
         : "1.7.10"

--- a/android/support/build.gradle
+++ b/android/support/build.gradle
@@ -8,6 +8,8 @@ repositories {
 }
 
 android {
+    namespace "com.microsoft.reacttestapp.support"
+
     def androidDir = "${buildscript.sourceFile.getParent()}/../"
     apply(from: "${androidDir}/dependencies.gradle")
     apply(from: "${androidDir}/test-app-util.gradle")

--- a/android/support/src/main/AndroidManifest.xml
+++ b/android/support/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.microsoft.reacttestapp.support" />
+<manifest />


### PR DESCRIPTION
### Description

Use Android Gradle Plugin 7.3.0 on 0.71+. See also https://github.com/facebook/react-native/commit/9f6711fda084d95d422a3ec9aed82bce87459463.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Make sure 0.64 and 0.68 builds. To test 7.3, you can artifically lower the requirements so that it gets used on 0.70.