### PR TITLE
fix(ios): crash on startup on device because sanitizers are enabled

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -285,7 +285,7 @@ PODS:
   - React-jsinspector (0.68.3)
   - React-logger (0.68.3):
     - glog
-  - react-native-safe-area-context (4.3.4):
+  - react-native-safe-area-context (4.4.1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -549,7 +549,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: a5043e9e1e1bd13b80b58b228c6901b3721a4f54
   React-jsinspector: 86e89b9f135787a2e8eb74b3fc00ec61e9a80ae1
   React-logger: f790bd10f86b38012e108fb4b564023602702270
-  react-native-safe-area-context: dfe5aa13bee37a0c7e8059d14f72ffc076d120e9
+  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   React-perflogger: fa15d1d29ff7557ee25ea48f7f59e65896fb3215
   React-RCTActionSheet: e83515333352a3cc19c146e3c7a63a8a9269da8f
   React-RCTAnimation: 8032daa2846e3db7ac28c4c5a207d0bfb5e1e3ad

--- a/ios/ReactTestApp/ReactTestApp.debug.xcconfig
+++ b/ios/ReactTestApp/ReactTestApp.debug.xcconfig
@@ -1,7 +1,7 @@
 #include "ReactTestApp.common.xcconfig"
 
-CLANG_ADDRESS_SANITIZER = YES
-CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES
+CLANG_ADDRESS_SANITIZER[sdk=*simulator*] = YES
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER[sdk=*simulator*] = YES
 DEBUG_INFORMATION_FORMAT = dwarf
 ENABLE_TESTABILITY = YES
 GCC_DYNAMIC_NO_PIC = NO
@@ -9,7 +9,7 @@ GCC_OPTIMIZATION_LEVEL = 0
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)
 MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE
 ONLY_ACTIVE_ARCH = YES
-OTHER_CFLAGS = $(inherited) -fsanitize=bounds
-OTHER_LDFLAGS = $(inherited) -fsanitize=bounds
+OTHER_CFLAGS[sdk=*simulator*] = $(inherited) -fsanitize=bounds
+OTHER_LDFLAGS[sdk=*simulator*] = $(inherited) -fsanitize=bounds
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
 SWIFT_OPTIMIZATION_LEVEL = -Onone


### PR DESCRIPTION
### Description

To enable sanitizers on device, it's not enough to enable them in config. We need to enable them in the build scheme instead:

    Edit Scheme… > Run > Diagnostics > Runtime Sanitization

![image](https://user-images.githubusercontent.com/4123478/193823874-5ee342dc-cc3f-47d1-9ffd-8843ea3c8ed0.png)

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
cd example
pod install --project-directory=ios
open ios/Example.xcworkspace
```

Plug in an iOS device and target it. The app should not crash on startup.

Target a simulator and make sure that it also doesn't crash on startup.