### PR TITLE
chore: configure release channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,8 +177,8 @@
   },
   "release": {
     "branches": [
-      "releases/+([0-9]).x",
-      "trunk"
+      { "name": "trunk", "channel": "latest" },
+      { "name": "releases/1.x", "range": "1.x", "channel": "release-1.x" }
     ],
     "tagFormat": "${version}",
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -177,8 +177,15 @@
   },
   "release": {
     "branches": [
-      { "name": "trunk", "channel": "latest" },
-      { "name": "releases/1.x", "range": "1.x", "channel": "release-1.x" }
+      {
+        "name": "trunk",
+        "channel": "latest"
+      },
+      {
+        "name": "releases/1.x",
+        "range": "1.x",
+        "channel": "release-1.x"
+      }
     ],
     "tagFormat": "${version}",
     "plugins": [


### PR DESCRIPTION
### Description

Main branch was not properly tagged as `@latest`. It _should_ be with the next release, though it's kinda hard to test.

The documentation can be found here: https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a