### PR TITLE
ci(ios): fix `MODULE_NOT_FOUND` during nightly builds

### DIFF
--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -42,7 +42,7 @@ def include_react_native!(options)
   # If we're using react-native@main, we'll also need to prepare
   # `react-native-codegen`.
   codegen = File.join(project_root, react_native, 'packages', 'react-native-codegen')
-  Open3.popen3('yarn build', :chdir => codegen) if File.directory?(codegen)
+  Open3.popen3('node scripts/build.js', :chdir => codegen) if File.directory?(codegen)
 
   lambda { |installer|
     react_native_post_install(installer)


### PR DESCRIPTION
### Description

See build log: https://github.com/microsoft/react-native-test-app/actions/runs/3270820800/jobs/5379886716

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
yarn ios
```

Build should succeed.