### PR TITLE
chore: prevent Renovate from bumping `androidx.appcompat`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -374,7 +374,7 @@ dependencies {
         // androidx.appcompat:appcompat:1.4.0+ breaks TextInput. This was fixed
         // in react-native 0.68. For more details, see
         // https://github.com/facebook/react-native/issues/31572.
-        implementation "androidx.appcompat:appcompat:1.3.1"
+        implementation(["androidx.appcompat", "appcompat", "1.3.1"].join(":"))
     } else {
         implementation libraries.androidAppCompat
     }


### PR DESCRIPTION
### Description

For react-native <0.68, `androidx.appcompat:appcompat` is pinned to 1.3.1 to prevent crashes. Renovate tries to bump it here: https://github.com/microsoft/react-native-test-app/pull/1150/files#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.67
yarn
cd example
yarn android
```

![Screenshot_1666086573](https://user-images.githubusercontent.com/4123478/196397660-59689ba5-2a4c-4d05-8877-dbd1ecf38b09.png)
