### PR TITLE
chore: address CVE-2022-37616

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,9 +3077,9 @@ __metadata:
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.7.5, @xmldom/xmldom@npm:~0.7.0":
-  version: 0.7.5
-  resolution: "@xmldom/xmldom@npm:0.7.5"
-  checksum: 8d7ec35c1ef6183b4f621df08e01d7e61f244fb964a4719025e65fe6ac06fac418919be64fb40fe5908e69158ef728f2d936daa082db326fe04603012b5f2a84
+  version: 0.7.6
+  resolution: "@xmldom/xmldom@npm:0.7.6"
+  checksum: 3c31dcd909aaefd65090033bd45e0aca42d636a9ae43c7313f4be87de570d046abba28362810d63c0718d6f08a9ce5f8da27b87437afc24d2290b6d4e75a6eee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

For more details, see https://github.com/advisories/GHSA-9pgh-qqpf-7wqj

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a