### PR TITLE
ci: `set-output` is deprecated

### DIFF
--- a/.github/actions/cocoapods/action.yml
+++ b/.github/actions/cocoapods/action.yml
@@ -14,9 +14,9 @@ runs:
       id: cache-key-generator
       run: |
         if [[ -f ${{ inputs.working-directory }}/${{ inputs.project-directory }}/Podfile.lock ]]; then
-          echo "::set-output name=cache-key::$(node scripts/shasum.mjs ${{ inputs.working-directory }}/${{ inputs.project-directory }}/Podfile.lock)"
+          echo "cache-key=$(node scripts/shasum.mjs ${{ inputs.working-directory }}/${{ inputs.project-directory }}/Podfile.lock)" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=cache-key::false'
+          echo 'cache-key=false' >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Cache /${{ inputs.working-directory }}/${{ inputs.project-directory }}/Pods

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -14,9 +14,9 @@ runs:
       id: build-root-directory-finder
       run: |
         if [[ -f android/build.gradle ]]; then
-          echo "::set-output name=build-root-directory::${{ inputs.project-root }}/android"
+          echo "build-root-directory=${{ inputs.project-root }}/android" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=build-root-directory::${{ inputs.project-root }}"
+          echo "build-root-directory=${{ inputs.project-root }}" >> $GITHUB_OUTPUT
         fi
       shell: bash
       working-directory: ${{ inputs.project-root }}

--- a/.github/actions/init-test-app/action.yml
+++ b/.github/actions/init-test-app/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: Generate cache key
       id: cache-key-generator
-      run: echo "::set-output name=cache-key::$(node scripts/shasum.mjs yarn.lock)"
+      run: echo "cache-key=$(node scripts/shasum.mjs yarn.lock)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache /.yarn/cache
       uses: actions/cache@v3

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -52,9 +52,9 @@ runs:
       id: cache-key-generator
       run: |
         if [[ -f example/${{ inputs.platform }}/Podfile.lock ]]; then
-          echo "::set-output name=cache-key::$(node scripts/shasum.mjs example/${{ inputs.platform }}/Podfile.lock)"
+          echo "cache-key=$(node scripts/shasum.mjs example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=cache-key::false'
+          echo 'cache-key=false' >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Cache /.ccache

--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: Generate cache key
       id: cache-key-generator
-      run: echo "::set-output name=cache-key::$(node scripts/shasum.mjs yarn.lock)"
+      run: echo "cache-key=$(node scripts/shasum.mjs yarn.lock)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache /.yarn/cache
       uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,9 +197,9 @@ jobs:
         id: configure
         run: |
           if [[ ${{ matrix.template }} == ios ]]; then
-            echo '::set-output name=project-directory::.'
+            echo 'project-directory=.' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=project-directory::ios'
+            echo 'project-directory=ios' >> $GITHUB_OUTPUT
           fi
       - name: Install Pods
         run: |
@@ -361,9 +361,9 @@ jobs:
         id: configure
         run: |
           if [[ ${{ matrix.template }} == macos ]]; then
-            echo '::set-output name=project-directory::.'
+            echo 'project-directory=.' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=project-directory::macos'
+            echo 'project-directory=macos' >> $GITHUB_OUTPUT
           fi
       - name: Install Pods
         run: |

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -226,7 +226,7 @@ jobs:
           appx_manifest=$(find ${{ github.event.inputs.architecture }}/Debug -name AppxManifest.xml -type f | head -1)
           app_name=$(basename $(dirname ${appx_manifest}))
           cp ${appx_manifest} AppPackages/${app_name}/*
-          echo "::set-output name=app-name::${app_name}"
+          echo "app-name=${app_name}" >> $GITHUB_OUTPUT
         shell: bash
         working-directory: ${{ github.event.inputs.projectRoot }}/windows
       - name: Upload build artifact

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -10,6 +10,10 @@ on:
         description: "Supported device types are `device`, `emulator`, `simulator`"
         required: true
         default: "simulator"
+      distribution:
+        description: "Distribution config string, e.g. `local` or `firebase:<appId>`"
+        required: true
+        default: "local"
       packageManager:
         description: "Binary name of the package manager used in the current repo"
         required: true
@@ -54,6 +58,7 @@ jobs:
           name: android-artifact
           path: ${{ github.event.inputs.projectRoot }}/android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+          retention-days: 14
   build-ios:
     name: "Build iOS"
     if: ${{ github.event.inputs.platform == 'ios' }}
@@ -62,6 +67,7 @@ jobs:
       CERTIFICATE_FILE: build-certificate.p12
       KEYCHAIN_FILE: app-signing.keychain-db
       PROVISION_PATH: "Library/MobileDevice/Provisioning Profiles/Provisioning_Profile.mobileprovision"
+      XCARCHIVE_FILE: app.xcarchive
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,19 +78,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=ios
-        working-directory: ${{ github.event.inputs.projectRoot }}
-      - name: Disable Clang sanitizers
-        run: |
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcconfig=node_modules/.generated/ios/ReactTestApp/ReactTestApp.debug.xcconfig
-          if [[ -f "${xcconfig}" ]]; then
-            sed -i '' 's/CLANG_ADDRESS_SANITIZER = YES/CLANG_ADDRESS_SANITIZER = NO/g' "${xcconfig}"
-            sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' "${xcconfig}"
-            sed -i '' 's/-fsanitize=bounds//g' "${xcconfig}"
-          fi
+        run: pod install --project-directory=ios --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Install Apple signing certificate and provisioning profile
         if: ${{ github.event.inputs.deviceType == 'device' }}
@@ -93,56 +87,35 @@ jobs:
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        run: |
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
-          mkdir -p "$(dirname "${HOME}/${PROVISION_PATH}")"
-
-          echo -n "${BUILD_CERTIFICATE_BASE64}" | base64 --decode --output "${RUNNER_TEMP}/${CERTIFICATE_FILE}"
-          echo -n "${BUILD_PROVISION_PROFILE_BASE64}" | base64 --decode --output "${HOME}/${PROVISION_PATH}"
-
-          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security set-keychain-settings -lut 21600 "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-
-          security import "${RUNNER_TEMP}/${CERTIFICATE_FILE}" -k "${RUNNER_TEMP}/${KEYCHAIN_FILE}" -t cert -f pkcs12 -P "${P12_PASSWORD}" -A -T '/usr/bin/codesign' -T '/usr/bin/security'
-          security set-key-partition-list -S apple-tool:,apple: -k ${KEYCHAIN_PASSWORD} "${RUNNER_TEMP}/${KEYCHAIN_FILE}" 1> /dev/null
-          security list-keychain -d user -s "${RUNNER_TEMP}/${KEYCHAIN_FILE}" login.keychain
+        run: npx --prefix . rnx-build-apple install-certificate
       - name: Build iOS app
-        run: |
-          if [[ ${{ github.event.inputs.deviceType }} == 'device' ]]; then
-            destination='generic/platform=iOS'
-            code_signing=''
-          else
-            destination='generic/platform=iOS Simulator'
-            code_signing='CODE_SIGNING_ALLOWED=NO'
-          fi
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -destination "${destination}" -configuration Debug -derivedDataPath DerivedData ${code_signing} COMPILER_INDEX_STORE_ENABLE=NO build
+        run: npx --prefix . rnx-build-apple build-ios --scheme ${{ github.event.inputs.scheme }} --device-type ${{ github.event.inputs.deviceType }} --archs ${{ github.event.inputs.architecture }}
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Remove Apple signing certificate and provisioning profile
+        # Always run this job step, even if previous ones fail. See also
+        # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
         if: ${{ always() && github.event.inputs.deviceType == 'device' }}
-        run: |
-          # Always run this job step, even if previous ones fail. See also
-          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#required-clean-up-on-self-hosted-runners
-          security delete-keychain "${RUNNER_TEMP}/${KEYCHAIN_FILE}"
-          rm -f "${RUNNER_TEMP}/${CERTIFICATE_FILE}" "${HOME}/${PROVISION_PATH}"
+        run: npx --prefix . rnx-build-apple uninstall-certificate
       - name: Prepare build artifact
+        id: prepare-build-artifact
         run: |
-          output_path=DerivedData/Build/Products
-          app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
-          # bsdtar corrupts files when archiving due to APFS sparse files. A
-          # workaround is to use GNU Tar instead. See also:
-          #   - https://github.com/actions/cache/issues/403
-          #   - https://github.com/actions/virtual-environments/issues/2619
-          gtar -cvf ios-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-          shasum --algorithm 256 ios-artifact.tar
+          if [[ ${{ github.event.inputs.distribution }} == 'local' ]]; then
+            app=$(find ${XCARCHIVE_FILE}/Products/Applications -maxdepth 1 -name '*.app' -type d | head -1)
+            npx --prefix . rnx-build-apple archive ios-artifact.tar "${app}"
+            echo 'filename=ios-artifact.tar' >> $GITHUB_OUTPUT
+          else
+            xcodebuild -exportArchive -archivePath ${XCARCHIVE_FILE} -exportPath export -exportOptionsPlist ExportOptions.plist 2>&1
+            ipa=$(find export -maxdepth 1 -name '*.ipa' -type d | head -1)
+            echo "filename=${ipa}" >> $GITHUB_OUTPUT
+          fi
         working-directory: ${{ github.event.inputs.projectRoot }}/ios
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
           name: ios-artifact
-          path: ${{ github.event.inputs.projectRoot }}/ios/ios-artifact.tar
+          path: ${{ github.event.inputs.projectRoot }}/ios/${{ steps.prepare-build-artifact.outputs.filename }}
           if-no-files-found: error
+          retention-days: 14
   build-macos:
     name: "Build macOS"
     if: ${{ github.event.inputs.platform == 'macos' }}
@@ -157,35 +130,16 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
-        run: pod install --project-directory=macos
-        working-directory: ${{ github.event.inputs.projectRoot }}
-      - name: Disable Clang sanitizers
-        run: |
-          # We need to disable Clang sanitizers otherwise the app will crash on
-          # startup trying to load Clang sanitizer libraries that would only
-          # exist if Xcode was attached.
-          xcconfig=node_modules/.generated/macos/ReactTestApp/ReactTestApp.debug.xcconfig
-          if [[ -f "${xcconfig}" ]]; then
-            sed -i '' 's/CLANG_ADDRESS_SANITIZER = YES/CLANG_ADDRESS_SANITIZER = NO/g' "${xcconfig}"
-            sed -i '' 's/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = YES/CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO/g' "${xcconfig}"
-            sed -i '' 's/-fsanitize=bounds//g' "${xcconfig}"
-          fi
+        run: pod install --project-directory=macos --verbose
         working-directory: ${{ github.event.inputs.projectRoot }}
       - name: Build macOS app
-        run: |
-          xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-          xcodebuild -workspace ${xcworkspace} -scheme ${{ github.event.inputs.scheme }} -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+        run: npx --prefix . rnx-build-apple build-macos --scheme ${{ github.event.inputs.scheme }}
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Prepare build artifact
         run: |
           output_path=DerivedData/Build/Products
           app=$(find ${output_path} -maxdepth 2 -name '*.app' -type d | head -1)
-          # bsdtar corrupts files when archiving due to APFS sparse files. A
-          # workaround is to use GNU Tar instead. See also:
-          #   - https://github.com/actions/cache/issues/403
-          #   - https://github.com/actions/virtual-environments/issues/2619
-          gtar -cvf macos-artifact.tar -C "$(dirname ${app})" "$(basename ${app})"
-          shasum --algorithm 256 macos-artifact.tar
+          npx --prefix . rnx-build-apple archive macos-artifact.tar "${app}"
         working-directory: ${{ github.event.inputs.projectRoot }}/macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
@@ -193,6 +147,7 @@ jobs:
           name: macos-artifact
           path: ${{ github.event.inputs.projectRoot }}/macos/macos-artifact.tar
           if-no-files-found: error
+          retention-days: 14
   build-windows:
     name: "Build Windows"
     if: ${{ github.event.inputs.platform == 'windows' }}
@@ -235,3 +190,25 @@ jobs:
           name: windows-artifact
           path: ${{ github.event.inputs.projectRoot }}/windows/AppPackages/${{ steps.prepare-build-artifact.outputs.app-name }}
           if-no-files-found: error
+          retention-days: 14
+  distribute:
+    name: "Distribute build"
+    needs: [build-android, build-ios]
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.inputs.distribution != 'local' && !cancelled() && !failure() }} # `success()` excludes skipped jobs
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.event.inputs.platform }}-artifact
+      - name: Display structure of build artifact
+        run: ls -R
+      - name: Upload to Firebase
+        if: ${{ startsWith(github.event.inputs.distribution, 'firebase:') }}
+        env:
+          FIREBASE_APP_ID: ${{ github.event.inputs.distribution }}
+          GOOGLE_APPLICATION_CREDENTIALS: credentials.json
+        run: |
+          artifact=$(find . -maxdepth 1 -type f | head -1)
+          echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 --decode > ${GOOGLE_APPLICATION_CREDENTIALS}
+          npx --package firebase-tools@11 firebase appdistribution:distribute "${artifact}" --app ${FIREBASE_APP_ID:9} --release-notes "${{ github.ref_name }}"


### PR DESCRIPTION
### Description

More information here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also took the opportunity to update the `rnx-build.yml` workflow from rnx-kit.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.