### PR TITLE
fix(android): bump NDK to r23c

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -10,11 +10,12 @@ ext {
     targetSdkVersion = 29
 
     def reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
+    def useAndroidPlugin_7_2 = reactNativeVersion > 0 && reactNativeVersion < 7100
 
     // We need only set `ndkVersion` when building react-native from source.
     if (rootProject.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion = rootProject.properties["ANDROID_NDK_VERSION"]
-    } else if (System.properties["os.arch"] == "aarch64" && reactNativeVersion < 7100) {
+    } else if (System.properties["os.arch"] == "aarch64" && useAndroidPlugin_7_2) {
         // NDK r23c has been patched to support Apple M1 and is default in AGP
         // 7.3.0. Prior to 0.71, we still need to set `ndkVersion` because we'll
         // be using AGP 7.2.2 (see `androidPluginVersion` below).
@@ -24,7 +25,7 @@ ext {
         ndkVersion = "23.1.7779620"
     }
 
-    androidPluginVersion = reactNativeVersion < 7100
+    androidPluginVersion = useAndroidPlugin_7_2
         ? "7.2.2"
         : "7.3.0"
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -18,7 +18,10 @@ ext {
         // NDK r23c has been patched to support Apple M1 and is default in AGP
         // 7.3.0. Prior to 0.71, we still need to set `ndkVersion` because we'll
         // be using AGP 7.2.2 (see `androidPluginVersion` below).
-        ndkVersion = "23.2.8568313"
+        // Note that even though newer 23.x versions exist, we'll stick to AGP's
+        // default. See also
+        // https://developer.android.com/studio/releases/gradle-plugin#compatibility-7-3-0
+        ndkVersion = "23.1.7779620"
     }
 
     androidPluginVersion = reactNativeVersion < 7100

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -14,9 +14,10 @@ ext {
     // We need only set `ndkVersion` when building react-native from source.
     if (rootProject.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion = rootProject.properties["ANDROID_NDK_VERSION"]
-    } else if (System.properties["os.arch"] == "aarch64" || reactNativeVersion >= 7100) {
-        // NDK r23c has been patched to support Apple M1 and will be default in
-        // 0.71: https://github.com/facebook/react-native/pull/35066
+    } else if (System.properties["os.arch"] == "aarch64" && reactNativeVersion < 7100) {
+        // NDK r23c has been patched to support Apple M1 and is default in AGP
+        // 7.3.0. Prior to 0.71, we still need to set `ndkVersion` because we'll
+        // be using AGP 7.2.2 (see `androidPluginVersion` below).
         ndkVersion = "23.2.8568313"
     }
 

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -9,16 +9,18 @@ ext {
     minSdkVersion = 23
     targetSdkVersion = 29
 
+    def reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
+
     // We need only set `ndkVersion` when building react-native from source.
     if (rootProject.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion = rootProject.properties["ANDROID_NDK_VERSION"]
-    } else if (System.properties["os.arch"] == "aarch64") {
-        // Android NDK added support for Apple M1 in r24:
-        // https://github.com/android/ndk/wiki/Changelog-r24
-        ndkVersion = "24.0.8215888"
+    } else if (System.properties["os.arch"] == "aarch64" || reactNativeVersion >= 7100) {
+        // NDK r23c has been patched to support Apple M1 and will be default in
+        // 0.71: https://github.com/facebook/react-native/pull/35066
+        ndkVersion = "23.2.8568313"
     }
 
-    androidPluginVersion = getPackageVersionNumber("react-native", rootDir) < 7100
+    androidPluginVersion = reactNativeVersion < 7100
         ? "7.2.2"
         : "7.3.0"
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")


### PR DESCRIPTION
### Description

Bumps Android NDK to r23c when using AGP 7.2.2 or older.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Make sure the Android app builds with 0.64 and latest 0.70.

| 0.64 | 0.70 |
| :-: | :-: |
| ![Screenshot_1666775910](https://user-images.githubusercontent.com/4123478/197987808-d9e6a6b4-1dd2-4827-8b41-a14c78449e81.png) | ![Screenshot_1666776310](https://user-images.githubusercontent.com/4123478/197989370-ecacc82d-faa0-4f9f-8e7c-5b5c43afe0e4.png) |
