### PR TITLE
ci(android): enable Android nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - trunk
   pull_request:
   schedule:
-    # nightly builds against react-native@nightly at 5:00
+    # Nightly builds against react-native@nightly at 5:00
     - cron: 0 5 * * *
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -220,7 +220,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -231,6 +230,7 @@ jobs:
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
+          git apply scripts/android-nightly.patch
           npm run set-react-version -- nightly
         shell: bash
       - name: Install npm dependencies
@@ -242,6 +242,9 @@ jobs:
           npx jest
         working-directory: example
       - name: Bundle JavaScript
+        # Metro on nightlies currently fails with "SHA-1 for file index.js is
+        # not computed" so we'll skip this step for now.
+        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
         run: |
           # `npm run` fails with "Workspaces not supported for global packages"
           # on Windows if we don't use `yarn` here. ¯\_(ツ)_/¯
@@ -249,6 +252,8 @@ jobs:
         shell: bash
         working-directory: example
       - name: Build
+        # Nightlies currently fail on Windows because of wrong path separators.
+        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
         uses: ./.github/actions/gradle
         with:
           project-root: example

--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -178,10 +178,9 @@ describe("react-native config", () => {
         project: expect.objectContaining({
           ios: {
             sourceDir: expect.stringContaining(sourceDir),
-            xcodeProject: {
-              name: "Example.xcworkspace",
-              isWorkspace: true,
-            },
+            xcodeProject: fs.existsSync("ios/Pods")
+              ? { name: "Example.xcworkspace", isWorkspace: true }
+              : null,
           },
         }),
       });

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -1,0 +1,48 @@
+diff --git a/example/App.js b/example/App.js
+index c9cd14d..f63758d 100644
+--- a/example/App.js
++++ b/example/App.js
+@@ -2,6 +2,7 @@
+ import React, { useCallback, useMemo, useState } from "react";
+ import {
+   NativeModules,
++  SafeAreaView,
+   ScrollView,
+   StatusBar,
+   StyleSheet,
+@@ -10,7 +11,6 @@ import {
+   useColorScheme,
+   View,
+ } from "react-native";
+-import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+ // @ts-expect-error
+ import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
+ import { Colors, Header } from "react-native/Libraries/NewAppScreen";
+@@ -169,7 +169,6 @@ const App = ({ concurrentRoot }) => {
+   );
+ 
+   return (
+-    <SafeAreaProvider>
+       <SafeAreaView style={styles.body}>
+         <StatusBar barStyle={isDarkMode ? "light-content" : "dark-content"} />
+         <ScrollView
+@@ -192,7 +191,6 @@ const App = ({ concurrentRoot }) => {
+           </View>
+         </ScrollView>
+       </SafeAreaView>
+-    </SafeAreaProvider>
+   );
+ };
+ 
+diff --git a/example/package.json b/example/package.json
+index a51d4cf..512b9c6 100644
+--- a/example/package.json
++++ b/example/package.json
+@@ -32,7 +32,6 @@
+     "react": "17.0.2",
+     "react-native": "^0.68.2",
+     "react-native-macos": "^0.68.3",
+-    "react-native-safe-area-context": "^4.3.4",
+     "react-native-test-app": "workspace:.",
+     "react-native-windows": "^0.68.8"
+   },


### PR DESCRIPTION
### Description

Enable nightly builds of Android. 

I had to disable `react-native-safe-area-context` because it isn't compatible with `main`.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.

- Metro bundling fails on Windows: https://github.com/microsoft/react-native-test-app/actions/runs/3394536512/jobs/5643324322
- More Windows build failure: https://github.com/microsoft/react-native-test-app/actions/runs/3394749753/jobs/5643706090
- Success: https://github.com/microsoft/react-native-test-app/actions/runs/3394985724/jobs/5644263478