### PR TITLE
ci(ios): switch to iOS nightlies [skip ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,12 +137,7 @@ jobs:
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          # `nightly` currently doesn't build due to use of version numbers that
-          # are incompatible with CocoaPods. See
-          # https://github.com/facebook/react-native/issues/30036 and
-          # https://github.com/microsoft/react-native-macos/issues/620 for more
-          # details.
-          npm run set-react-version -- main
+          npm run set-react-version -- nightly
           rm example/ios/Podfile.lock
       - name: Install npm dependencies
         uses: ./.github/actions/yarn

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -6,6 +6,7 @@
 .gradle/
 .idea/
 .vs/
+.xcode.env
 Pods/
 build/
 dist/

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -268,6 +268,11 @@ def make_project!(xcodeproj, project_root, target_platform, options)
   end
 
   # Note the location of Node so we can use it later in script phases
+  File.open(File.join(project_root, '.xcode.env'), 'w') do |f|
+    node_bin = `which node`
+    node_bin.strip!
+    f.write("export NODE_BINARY=#{node_bin}\n")
+  end
   File.open(File.join(destination, '.env'), 'w') do |f|
     node_bin = `dirname $(which node)`
     node_bin.strip!


### PR DESCRIPTION
### Description

Switch iOS nightly builds to using react-native nightlies.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/react-native-test-app/actions/runs/3423055574/jobs/5701209568