### PR TITLE
ci(ios): disable Flipper when building templates [skip ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           fi
       - name: Install Pods
         run: |
-          pod install --project-directory=${{ steps.configure.outputs.project-directory }}
+          USE_FLIPPER=0 pod install --project-directory=${{ steps.configure.outputs.project-directory }}
         working-directory: template-example
       - name: Build
         run: |

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -576,7 +576,7 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              "use_flipper!",
+              "use_flipper! unless ENV['USE_FLIPPER'] == '0'",
               "",
               `workspace '${name}.xcworkspace'`,
               "",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -576,7 +576,7 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              "use_flipper! unless ENV['USE_FLIPPER'] == '0'",
+              "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
               "",
               `workspace '${name}.xcworkspace'`,
               "",

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -12,7 +12,7 @@ Object {
     },
     "Podfile": "require_relative '../test_app'
 
-use_flipper!
+use_flipper! false if ENV['USE_FLIPPER'] == '0'
 
 workspace 'Test.xcworkspace'
 
@@ -133,7 +133,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper! false if ENV['USE_FLIPPER'] == '0'
 
 workspace 'Test.xcworkspace'
 
@@ -303,7 +303,7 @@ Object {
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper! false if ENV['USE_FLIPPER'] == '0'
 
 workspace 'Test.xcworkspace'
 
@@ -435,7 +435,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper! false if ENV['USE_FLIPPER'] == '0'
 
 workspace 'Test.xcworkspace'
 
@@ -586,7 +586,7 @@ applyTestAppSettings(settings)
     },
     "ios/Podfile": "require_relative '../../test_app'
 
-use_flipper!
+use_flipper! false if ENV['USE_FLIPPER'] == '0'
 
 workspace 'Test.xcworkspace'
 


### PR DESCRIPTION
### Description

See #1194

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Template builds shouldn't take 30 minutes: https://github.com/microsoft/react-native-test-app/actions/runs/3445742959/jobs/5749810025