### PR TITLE
ci(android): disable Gradle cache

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -24,5 +24,6 @@ runs:
       uses: gradle/gradle-build-action@v2.3.3
       with:
         gradle-version: wrapper
+        cache-disabled: true # causes bad resolutions to reappear
         arguments: ${{ inputs.arguments }}
         build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}


### PR DESCRIPTION
### Description

Because it causes bad resolutions to reappear. See build log: https://github.com/microsoft/react-native-test-app/actions/runs/3446021259/jobs/5750420875

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a