### PR TITLE
fix(android): fix crash when initial props is set

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/TestApp.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
+import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.manifest.ManifestProvider
 import com.microsoft.reacttestapp.react.ReactBundleNameProvider
 import com.microsoft.reacttestapp.react.TestAppReactNativeHost
@@ -24,6 +25,10 @@ class TestApp : Application(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+
+        // We need to initialize SoLoader early because ManifestProvider may
+        // need to use WritableNativeMap when parsing initial properties.
+        SoLoader.init(this, false)
 
         manifestProviderInternal = ManifestProvider.create(this)
         val (manifest, _) = manifestProvider.fromResources()

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -85,7 +85,6 @@ class TestAppReactNativeHost(
         reactInstanceManager.addReactInstanceEventListener(reactInstanceListener)
 
         beforeReactNativeInit()
-        SoLoader.init(application, false)
         reactInstanceManager.createReactContextInBackground()
 
         if (BuildConfig.DEBUG) {


### PR DESCRIPTION
### Description

Fix crash trying to parse initial properties. The crash occurs because we're trying to instantiate a `WritableNativeMap`, which requires `SoLoader` to be initialized.

Resolves #1205.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Add initial props to a component:

```diff
diff --git a/example/app.json b/example/app.json
index ef69fa7..aa8229f 100644
--- a/example/app.json
+++ b/example/app.json
@@ -5,7 +5,10 @@
   "components": [
     {
       "appKey": "Example",
-      "displayName": "App"
+      "displayName": "App",
+      "initialProperties": {
+        "concurrentRoot": true
+      }
     },
     {
       "appKey": "Example",
```

Build/run the Android app:

```
cd example
yarn android
```