### PR TITLE
ci: bump `darenm/Setup-VSTest` to 1.2

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -47,7 +47,7 @@ runs:
         bundler-cache: true
     - name: Set up VSTest.console.exe
       if: ${{ inputs.platform == 'windows' }}
-      uses: darenm/Setup-VSTest@v1
+      uses: darenm/Setup-VSTest@v1.2
     - name: Generate cache key
       id: cache-key-generator
       run: |


### PR DESCRIPTION
### Description

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.