### PR TITLE
fix(apple): fix "ReactTestApp-Resources spec is empty" error

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -159,8 +159,9 @@ def resources_pod(project_root, target_platform, platforms)
 
   app_dir = File.dirname(app_manifest)
   resources = resolve_resources(app_manifest(project_root), target_platform)
+  return if resources.nil? || resources.empty?
 
-  if !resources.nil? && resources.any? { |r| !File.exist?(File.join(app_dir, r)) }
+  if resources.any? { |r| !File.exist?(File.join(app_dir, r)) }
     Pod::UI.notice(
       'One or more resources were not found and will not be included in the project. ' \
       'If they are found later and you want to include them, run `pod install` again.'

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -150,8 +150,16 @@ class TestTestApp < Minitest::Test
         with_resources
         with_platform_resources
       ].each do |fixture|
-        assert_equal('.', resources_pod(fixture_path(fixture), target, platforms))
-        assert_equal('..', resources_pod(fixture_path(fixture, target.to_s), target, platforms))
+        podspec_path = resources_pod(fixture_path(fixture), target, platforms)
+        inner_podspec_path = resources_pod(fixture_path(fixture, target.to_s), target, platforms)
+
+        if fixture.to_s.include?('without')
+          assert_nil(podspec_path)
+          assert_nil(inner_podspec_path)
+        else
+          assert_equal('.', podspec_path)
+          assert_equal('..', inner_podspec_path)
+        end
       end
     end
 
@@ -176,12 +184,16 @@ class TestTestApp < Minitest::Test
         fixture_path('without_resources', target.to_s),
       ].each do |project_root|
         podspec_path = resources_pod(project_root, target, platforms)
+
+        if project_root.to_s.include?('without')
+          assert_nil(podspec_path)
+          next
+        end
+
         manifest_path = app_manifest_path(project_root, podspec_path)
         manifest = JSON.parse(File.read(manifest_path))
 
-        if project_root.to_s.include?('without')
-          assert_empty(manifest['resources'])
-        elsif project_root.to_s.include?('with_platform_resources')
+        if project_root.to_s.include?('with_platform_resources')
           assert_equal(platform_resources, manifest['resources'].sort)
         else
           assert_equal(resources, manifest['resources'].sort)


### PR DESCRIPTION
### Description

Fixes "ReactTestApp-Resources spec is empty" error.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Remove all resources from `app.json` and run `pod install`:

```diff
diff --git a/example/app.json b/example/app.json
index ef69fa7..b144e8d 100644
--- a/example/app.json
+++ b/example/app.json
@@ -14,21 +14,5 @@
     }
   ],
   "resources": {
-    "android": [
-      "dist/res",
-      "dist/main.android.jsbundle"
-    ],
-    "ios": [
-      "dist/assets",
-      "dist/main.ios.jsbundle"
-    ],
-    "macos": [
-      "dist/assets",
-      "dist/main.macos.jsbundle"
-    ],
-    "windows": [
-      "dist/assets",
-      "dist/main.windows.bundle"
-    ]
   }
 }
```