### PR TITLE
ci: fix Windows builds not finding Visual Studio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     - cron: 0 4 * * 1-5
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
+  VisualStudioVersion: "17.0"
 jobs:
   lint-commit:
     name: "lint commit message"


### PR DESCRIPTION
### Description

Fix Windows builds failing as of https://github.com/microsoft/react-native-windows/commit/ab0a4495e00ee478031b30f04cfb6ba05a642955.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Windows build should be green.