### PR TITLE
fix(windows): fix random Windows build failure

### DIFF
--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -713,6 +713,21 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
     });
   }
 
+  // TODO: Remove when we drop support for 0.69.
+  // Patch building with Visual Studio 2022. For more details, see
+  // https://github.com/microsoft/react-native-windows/pull/10373
+  if (rnWindowsVersionNumber < 7000) {
+    const helpers = path.join(
+      rnWindowsPath,
+      "Microsoft.ReactNative",
+      "Utils",
+      "Helpers.h"
+    );
+    copyAndReplace(helpers, helpers, {
+      "inline typename T asEnum": "inline T asEnum",
+    });
+  }
+
   if (useNuGet) {
     const nugetConfigPath =
       findNearest(


### PR DESCRIPTION
### Description

Windows builds randomly fail and may succeed if requeued: https://github.com/microsoft/react-native-test-app/actions/runs/3582401394/jobs/6026585132

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
# Make note of the original signature of `asEnum()`
cat node_modules/react-native-windows/Microsoft.ReactNative/Utils/Helpers.h

# Generate the VS solution (this can be run on Macs as well)
yarn install-windows-test-app --no-autolink

# Verify that the signature of `asEnum()` as been fixed
cat node_modules/react-native-windows/Microsoft.ReactNative/Utils/Helpers.h
```

CI should pass.