### PR TITLE
feat(windows): autolink NuGet dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
+    "fast-xml-parser": "^4.0.0",
     "prompts": "^2.4.0",
     "semver": "^7.3.5",
     "uuid": "^8.3.2",

--- a/windows/ReactTestApp/ReactTestApp.vcxproj
+++ b/windows/ReactTestApp/ReactTestApp.vcxproj
@@ -226,13 +226,17 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props'))" />
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
   </Target>
+  <PropertyGroup Label="ReactNativeWindowsProps">
+    <ReactNativeWindowsVersion Condition="'$(ReactNativeWindowsVersion)' == ''">$(ReactNativeWindowsNpmVersion)</ReactNativeWindowsVersion>
+  </PropertyGroup>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.1000.0.0\build\native\Microsoft.ReactNative.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.1000.0.0\build\native\Microsoft.ReactNative.Cxx.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
     <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)' == 'true'" />
     <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
     <Import Project="$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets')" />
+    <!-- ReactTestApp additional targets -->
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/windows/ReactTestApp/packages.config
+++ b/windows/ReactTestApp/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.211028.7" targetFramework="native"/>
   <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->
   <package id="nlohmann.json" version="3.10.4" targetFramework="native"/>
+  <!-- additional packages -->
 </packages>

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -100,6 +100,7 @@ function findUserProjects(projectDir, projects = []) {
  * Visual Studio (?) currently does not download transitive dependencies. This
  * is a workaround until `react-native-windows` autolinking adds support.
  *
+ * @see {@link https://github.com/microsoft/react-native-windows/issues/9578}
  * @returns {[string, string][]}
  */
 function getNuGetDependencies() {
@@ -184,14 +185,14 @@ function getNuGetDependencies() {
   }
 
   // Remove dependencies managed by us
-  [
-    "microsoft.reactnative",
-    "microsoft.reactnative.cxx",
-    "microsoft.ui.xaml",
-    "microsoft.windows.cppwinrt",
-    "reactnative.hermes.windows",
-    "nlohmann.json",
-  ].forEach((id) => delete packageRefs[id]);
+  const config = path.join(__dirname, "ReactTestApp", "packages.config");
+  const matches = fs
+    .readFileSync(config, textFileReadOptions)
+    .matchAll(/package id="(.+?)"/g);
+  for (const m of matches) {
+    const id = m[1].toLowerCase();
+    delete packageRefs[id];
+  }
 
   return Object.values(packageRefs);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5807,6 +5807,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:^4.0.0":
+  version: 4.0.12
+  resolution: "fast-xml-parser@npm:4.0.12"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: afb800fdc39d3c53ce0be76dd57afafc5556790a798524c98bdb984af2adc0d35360d05d1360cdb37db3f6de1fa754ae5596f16934c60b490b22ffb47948846d
+  languageName: node
+  linkType: hard
+
 "fastest-levenshtein@npm:^1.0.12":
   version: 1.0.12
   resolution: "fastest-levenshtein@npm:1.0.12"
@@ -10913,6 +10924,7 @@ fsevents@^2.3.2:
     chalk: ^4.1.0
     eslint: ^8.0.0
     eslint-plugin-jest: ^27.0.0
+    fast-xml-parser: ^4.0.0
     jest: ^27.0.0
     memfs: ^3.3.0
     prettier: ^2.3.1
@@ -12351,6 +12363,13 @@ resolve@^2.0.0-next.3:
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
   checksum: 1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Attempt to autolink NuGet dependencies. For example, `react-native-svg` requires `Win2D.uwp` but it does not get installed automatically.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Add `react-native-svg` to the example app, and build the Windows app:

```diff
diff --git a/example/package.json b/example/package.json
index 58a365d..81cad78 100644
--- a/example/package.json
+++ b/example/package.json
@@ -33,6 +33,7 @@
     "react-native": "^0.68.2",
     "react-native-macos": "^0.68.3",
     "react-native-safe-area-context": "^4.3.4",
+    "react-native-svg": "^12.5.0",
     "react-native-test-app": "workspace:.",
     "react-native-windows": "^0.68.8"
   },
```

Verify that this works for 0.64 as well.