### PR TITLE
chore(windows): remove unused parameter to `parseResources`

### DIFF
--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -25,8 +25,8 @@ describe("generateSolution", () => {
     process.chdir(cwd);
   });
 
-  test("throws if destination path is missing/invalid", () => {
-    expect(() => generateSolution("", options)).toThrow(
+  test("exits if destination path is missing/invalid", () => {
+    expect(generateSolution("", options)).toBe(
       "Missing or invalid destination path"
     );
   });

--- a/test/windows-test-app/getBundleResources.test.js
+++ b/test/windows-test-app/getBundleResources.test.js
@@ -28,7 +28,7 @@ describe("getBundleResources", () => {
       assetItems,
       assetItemFilters,
       assetFilters,
-    } = getBundleResources("app.json", path.resolve(""));
+    } = getBundleResources("app.json");
 
     expect(appName).toBe("Example");
     expect(appxManifest).toBe("windows\\Package.appxmanifest");
@@ -64,7 +64,7 @@ describe("getBundleResources", () => {
       }),
     });
 
-    expect(getBundleResources("app.json", path.resolve(""))).toEqual({
+    expect(getBundleResources("app.json")).toEqual({
       appName: "ReactTestApp",
       appxManifest: "windows\\Example\\Package.appxmanifest",
       assetItems: "",
@@ -77,7 +77,7 @@ describe("getBundleResources", () => {
   test("handles missing manifest", () => {
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 
-    expect(getBundleResources("", "")).toEqual({
+    expect(getBundleResources("")).toEqual({
       appName: "ReactTestApp",
       appxManifest: "windows/Package.appxmanifest",
       assetItems: "",
@@ -96,7 +96,7 @@ describe("getBundleResources", () => {
 
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 
-    expect(getBundleResources("app.json", path.resolve(""))).toEqual({
+    expect(getBundleResources("app.json")).toEqual({
       appName: "ReactTestApp",
       appxManifest: "windows/Package.appxmanifest",
       assetItems: "",
@@ -123,10 +123,7 @@ describe("getBundleResources", () => {
       }),
     });
 
-    const { packageCertificate } = getBundleResources(
-      "app.json",
-      path.resolve("")
-    );
+    const { packageCertificate } = getBundleResources("app.json");
     expect(packageCertificate).toMatchInlineSnapshot(`
       "<AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
           <PackageCertificateKeyFile>$(ProjectRootDir)\\\\windows\\\\ReactTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>

--- a/test/windows-test-app/parseResources.test.js
+++ b/test/windows-test-app/parseResources.test.js
@@ -12,10 +12,10 @@ describe("parseResources", () => {
   afterEach(() => mockFiles());
 
   test("returns empty strings for no resources", () => {
-    expect(parseResources(undefined, "", "")).toEqual(empty);
-    expect(parseResources([], "", "")).toEqual(empty);
-    expect(parseResources({}, "", "")).toEqual(empty);
-    expect(parseResources({ windows: [] }, "", "")).toEqual(empty);
+    expect(parseResources(undefined, "")).toEqual(empty);
+    expect(parseResources([], "")).toEqual(empty);
+    expect(parseResources({}, "")).toEqual(empty);
+    expect(parseResources({ windows: [] }, "")).toEqual(empty);
   });
 
   test("returns references to existing assets", () => {
@@ -27,8 +27,7 @@ describe("parseResources", () => {
 
     const { assetItems, assetItemFilters, assetFilters } = parseResources(
       ["dist/assets", "dist/main.jsbundle"],
-      ".",
-      "node_modules/.generated/windows/ReactTestApp"
+      "."
     );
     expect(assetItems).toMatchInlineSnapshot(`
 "<CopyFileToFolders Include=\\"$(ProjectRootDir)\\\\dist\\\\assets\\\\node_modules\\\\arnold\\\\portrait.png\\">
@@ -62,13 +61,9 @@ describe("parseResources", () => {
   test("skips missing assets", () => {
     const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
 
-    expect(
-      parseResources(
-        ["dist/assets", "dist/main.bundle"],
-        ".",
-        "node_modules/.generated/windows/ReactTestApp"
-      )
-    ).toEqual(empty);
+    expect(parseResources(["dist/assets", "dist/main.bundle"], ".")).toEqual(
+      empty
+    );
 
     expect(warnSpy).toHaveBeenCalledWith(
       "warning: resource with path 'dist/assets' was not found"


### PR DESCRIPTION
### Description

Remove unused parameter to `parseResources`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

n/a