### PR TITLE
fix(ios): fix `pod install` failing on 0.71

### DIFF
--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -45,7 +45,7 @@ def include_react_native!(options)
   Open3.popen3('node scripts/build.js', :chdir => codegen) if File.directory?(codegen)
 
   lambda { |installer|
-    react_native_post_install(installer)
+    react_native_post_install(installer, react_native)
     if defined?(__apply_Xcode_12_5_M1_post_install_workaround)
       __apply_Xcode_12_5_M1_post_install_workaround(installer)
     end


### PR DESCRIPTION
### Description

Fix `pod install` failing on 0.71 when `node_modules` isn't in parent directory.

```
[!] An error occurred while processing the post-install hook of the Podfile.

No such file or directory @ rb_sysopen - ../node_modules/react-native/package.json

/~/node_modules/react-native/scripts/react_native_pods.rb:212:in `read'
/~/node_modules/react-native/scripts/react_native_pods.rb:212:in `react_native_post_install'
/~/node_modules/react-native-test-app/ios/use_react_native-0.70.rb:48:in `block in include_react_native!'
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
git clone https://github.com/react-native-webview/react-native-webview.git
cd react-native-webview
git checkout new-arch-ios
```

Bump react-native to 0.71.0-rc.5:

```diff
diff --git a/package.json b/package.json
index 333373c..dc74b06 100644
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/invariant": "^2.2.30",
     "@types/jest": "^26.0.0",
     "@types/react": "18.0.24",
-    "@types/react-native": "0.70.8",
     "@types/selenium-webdriver": "4.0.9",
     "@typescript-eslint/eslint-plugin": "2.1.0",
     "@typescript-eslint/parser": "2.1.0",
@@ -58,12 +57,10 @@
     "eslint-plugin-react-hooks": "^4.5.0",
     "eslint-plugin-react-native": "3.7.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.67.0",
-    "react": "18.1.0",
-    "react-native": "0.70.6",
-    "react-native-macos": "0.66.57",
-    "react-native-test-app": "2.1.1",
-    "react-native-windows": "0.70.4",
+    "metro-react-native-babel-preset": "^0.73.5",
+    "react": "18.2.0",
+    "react-native": "0.71.0-rc.5",
+    "react-native-test-app": "2.2.0",
     "selenium-appium": "1.0.2",
     "selenium-webdriver": "4.0.0-alpha.7",
     "semantic-release": "15.13.24",
@@ -88,11 +85,6 @@
     "react-native-webview.podspec",
     "react-native.config.js"
   ],
-  "resolutions": {
-    "@react-native-community/cli": "^9.2.1",
-    "@react-native-community/cli-platform-android": "^9.2.1",
-    "@react-native-community/cli-platform-ios": "^9.2.1"
-  },
   "codegenConfig": {
     "name": "RNCWebViewSpec",
     "type": "all",
```

Patch react-native-test-app. Then run:

```
cd example/ios
pod install
```