### PR TITLE
chore: `set-react-version` should remove packages

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -251,14 +251,12 @@ if (!isValidVersion(version)) {
 
   const manifests = ["package.json", "example/package.json"];
   for (const manifestPath of manifests) {
-    const manifest = /** @type {{ devDependencies: Record<string, string>}} */ (
+    const manifest = /** @type {{ devDependencies: Record<string, string | undefined>}} */ (
       readJSONFile(manifestPath)
     );
     for (const packageName of keys(profile)) {
       const version = profile[packageName];
-      if (version) {
-        manifest["devDependencies"][packageName] = version;
-      }
+      manifest["devDependencies"][packageName] = version;
     }
 
     const tmpFile = `${manifestPath}.tmp`;


### PR DESCRIPTION
### Description

`set-react-version` should remove packages if the specified version does not exist.

Trying to target, say 0.71, can fail because react-native-macos 0.68 is still installed.

It's also currently the cause of failing nightlies: https://github.com/microsoft/react-native-test-app/actions/runs/3843735554

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`react-native-macos` 0.71 currently does not exist. Run `npm run set-react-version 0.71` and verify that `react-native-macos` was removed from both `package.json` and `example/package.json`.