### PR TITLE
fix(android): support new package names

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -17,7 +17,9 @@ if (autodetectReactNativeVersion || enableNewArchitecture) {
 
     react {
         reactNativeDir = reactNativePath
-        codegenDir = file(findNodeModulesPath("react-native-codegen", reactNativePath))
+        codegenDir = file(
+            findNodeModulesPath("@react-native/codegen", reactNativePath)  // >= 0.72
+                ?: findNodeModulesPath("react-native-codegen", reactNativePath))  // < 0.72
     }
 
     // We don't want the React plugin to bundle.

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -45,7 +45,8 @@ ext.applyTestAppSettings = { DefaultSettings settings ->
         .projectDir = file("${testAppDir}/android/support")
 
     def reactNativeGradlePlugin =
-        findNodeModulesPath("react-native-gradle-plugin", settings.rootDir)
+        findNodeModulesPath("@react-native/gradle-plugin", settings.rootDir)  // >= 0.72
+            ?: findNodeModulesPath("react-native-gradle-plugin", settings.rootDir)  // < 0.72
     if (reactNativeGradlePlugin != null) {
         settings.includeBuild(reactNativeGradlePlugin)
     }


### PR DESCRIPTION
### Description

Core recently renamed a bunch of packages:

- `react-native-codegen` -> `@react-native/codegen`
- `react-native-gradle-plugin` -> `@react-native/gradle-plugin`

Failing nightly: https://github.com/microsoft/react-native-test-app/actions/runs/3852497253/jobs/6564667357

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example/android
./gradlew clean assembleDebug
```