### PR TITLE
fix(apple): ignore warnings in 'React-Core'

### DIFF
--- a/ios/ReactTestApp/React+Fabric.mm
+++ b/ios/ReactTestApp/React+Fabric.mm
@@ -1,5 +1,8 @@
 #import "React+Fabric.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
 #ifdef USE_FABRIC
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
@@ -8,6 +11,8 @@
 #else
 #import <React/RCTRootView.h>
 #endif  // USE_FABRIC
+
+#pragma clang diagnostic pop
 
 RTAView *RTACreateReactRootView(RCTBridge *bridge,
                                 NSString *moduleName,

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -22,7 +22,7 @@ import { readJSONFile } from "./helpers.js";
 
 const VALID_TAGS = ["canary-macos", "canary-windows", "main", "nightly"];
 const REACT_NATIVE_VERSIONS = {
-  "canary-macos": "^0.66",
+  "canary-macos": "^0.68",
 };
 
 /**


### PR DESCRIPTION
### Description

`react-native-macos` canary builds are failing: https://github.com/microsoft/react-native-test-app/actions/runs/3870626206/jobs/6597699770

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version canary-macos
yarn
cd example
pod install --project-directory=macos
../scripts/xcodebuild.sh macos/Example.xcworkspace build-for-testing
```