### PR TITLE
fix(apple): Don't ignore warnings in 'React-Core'

### DIFF
--- a/ios/ReactTestApp/React+Fabric.mm
+++ b/ios/ReactTestApp/React+Fabric.mm
@@ -1,8 +1,5 @@
 #import "React+Fabric.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability-completeness"
-
 #ifdef USE_FABRIC
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
@@ -11,8 +8,6 @@
 #else
 #import <React/RCTRootView.h>
 #endif  // USE_FABRIC
-
-#pragma clang diagnostic pop
 
 RTAView *RTACreateReactRootView(RCTBridge *bridge,
                                 NSString *moduleName,


### PR DESCRIPTION
### Description

#1259 added code to ignore some clang warnings. https://github.com/microsoft/react-native-macos/pull/1612 should fix those warnings so we no longer need to ignore them.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version canary-macos
yarn
cd example
pod install --project-directory=macos
../scripts/xcodebuild.sh macos/Example.xcworkspace build-for-testing
```
