### PR TITLE
ci(macos): regenerate files before arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,9 +329,17 @@ jobs:
         run: |
           ../scripts/xcodebuild.sh macos/Example.xcworkspace test-without-building
         working-directory: example
-      - name: Build ARM
+      - name: Prepare for arm64 build
         run: |
           rm -fr macos/build
+        working-directory: example
+      - name: Install Pods
+        uses: ./.github/actions/cocoapods
+        with:
+          project-directory: macos
+          working-directory: example
+      - name: Build arm64
+        run: |
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build ARCHS=arm64
         working-directory: example
     timeout-minutes: 60


### PR DESCRIPTION
### Description

`react-native-macos` nightly builds are failing due to missing generated file:

```
error: Build input file cannot be found: '/Users/runner/work/react-native-test-app/react-native-test-app/example/macos/build/generated/ios/FBReactNativeSpec/FBReactNativeSpec-generated.mm'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it? (in target 'React-Codegen' from project 'Pods')
```

Full build log: https://github.com/microsoft/react-native-test-app/actions/runs/3927036449/jobs/6713288183

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

CI should pass.