### PR TITLE
ci: avoid two copies of `.yarnrc.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-jest": "^27.0.0",
     "jest": "^27.0.0",
+    "js-yaml": "^4.1.0",
     "memfs": "^3.3.0",
     "prettier": "^2.3.1",
     "react": "17.0.2",

--- a/scripts/copy-yarnrc.mjs
+++ b/scripts/copy-yarnrc.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// @ts-check
+
+import yaml from "js-yaml";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Copies specied `.yarnrc.yaml`.
+ * @param {string} src
+ * @param {string} dst
+ */
+function main(src, dst) {
+  [src, dst].forEach((str) => {
+    if (!str || typeof str !== "string") {
+      throw new Error(`Invalid argument: ${str}`);
+    }
+  });
+
+  const yml = fs.readFileSync(src, { encoding: "utf-8" });
+  const rc = /** @type {Record<string, string | undefined>} */ (yaml.load(yml));
+
+  rc["nmHoistingLimits"] = undefined;
+  if (rc.yarnPath) {
+    rc["yarnPath"] = path.join(path.dirname(src), rc.yarnPath);
+  }
+
+  fs.writeFileSync(dst, yaml.dump(rc));
+}
+
+const { [2]: source, [3]: destination = ".yarnrc.yml" } = process.argv;
+main(source, destination);

--- a/scripts/install-test-template.sh
+++ b/scripts/install-test-template.sh
@@ -38,14 +38,7 @@ yarn
 GIT_IGNORE_FILE=".gitignore" npx react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
 
 pushd template-example 1> /dev/null
-
-{
-  echo 'enableScripts: false'
-  echo 'enableTelemetry: false'
-  echo 'nodeLinker: node-modules'
-  echo 'npmRegistryServer: "https://registry.npmjs.org"'
-  echo 'yarnPath: ../.yarn/releases/yarn-3.1.1.cjs'
-} >> .yarnrc.yml
+node ../scripts/copy-yarnrc.mjs ../.yarnrc.yml
 
 script="s/\"react-native-test-app\": \".*\"/\"react-native-test-app\": \"..\/react-native-test-app-$version.tgz\"/"
 if sed --version &> /dev/null; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -10992,6 +10992,7 @@ fsevents@^2.3.2:
     eslint-plugin-jest: ^27.0.0
     fast-xml-parser: ^4.0.0
     jest: ^27.0.0
+    js-yaml: ^4.1.0
     memfs: ^3.3.0
     prettier: ^2.3.1
     prompts: ^2.4.0


### PR DESCRIPTION
### Description

Avoid having two copies of `.yarnrc.yaml`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a