### PR TITLE
fix(ios): proper fix for alerts + `UIScene` included in 0.72

### DIFF
--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -26,9 +26,9 @@ IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
 }
 
 // MARK: - [0.70.0] Alerts don't show when using UIScene
-// See https://github.com/facebook/react-native/pull/34562
+// See https://github.com/facebook/react-native/pull/35716
 
-#if !TARGET_OS_OSX && REACT_NATIVE_VERSION < 7100
+#if !TARGET_OS_OSX && REACT_NATIVE_VERSION < 7200
 
 #import <React/RCTAlertController.h>
 #import <React/RCTUtils.h>


### PR DESCRIPTION
### Description

Extend the monkey patch for alerts + `UIScene` till 0.72.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a