### PR TITLE
chore: include Xcode version in cache key

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -52,8 +52,8 @@ runs:
       id: cache-key-generator
       run: |
         if [[ -f example/${{ inputs.platform }}/Podfile.lock ]]; then
-          xcode-select --print-path > .xcode-version
-          echo "cache-key=$(node scripts/shasum.mjs .xcode-version example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
+          clang --version > .clang-version
+          echo "cache-key=$(node scripts/shasum.mjs .clang-version example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
         else
           echo 'cache-key=false' >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -52,7 +52,8 @@ runs:
       id: cache-key-generator
       run: |
         if [[ -f example/${{ inputs.platform }}/Podfile.lock ]]; then
-          echo "cache-key=$(node scripts/shasum.mjs example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
+          xcode-select --print-path > .xcode-version
+          echo "cache-key=$(node scripts/shasum.mjs .xcode-version example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
         else
           echo 'cache-key=false' >> $GITHUB_OUTPUT
         fi

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.68.4)
-  - FBReactNativeSpec (0.68.4):
+  - FBLazyVector (0.68.5)
+  - FBReactNativeSpec (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.4)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Core (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
+    - RCTRequired (= 0.68.5)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2021.06.28.00-v2):
@@ -25,273 +25,273 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.4)
-  - RCTTypeSafety (0.68.4):
-    - FBLazyVector (= 0.68.4)
+  - RCTRequired (0.68.5)
+  - RCTTypeSafety (0.68.5):
+    - FBLazyVector (= 0.68.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.4)
-    - React-Core (= 0.68.4)
-  - React (0.68.4):
-    - React-Core (= 0.68.4)
-    - React-Core/DevSupport (= 0.68.4)
-    - React-Core/RCTWebSocket (= 0.68.4)
-    - React-RCTActionSheet (= 0.68.4)
-    - React-RCTAnimation (= 0.68.4)
-    - React-RCTBlob (= 0.68.4)
-    - React-RCTImage (= 0.68.4)
-    - React-RCTLinking (= 0.68.4)
-    - React-RCTNetwork (= 0.68.4)
-    - React-RCTSettings (= 0.68.4)
-    - React-RCTText (= 0.68.4)
-    - React-RCTVibration (= 0.68.4)
-  - React-callinvoker (0.68.4)
-  - React-Codegen (0.68.4):
-    - FBReactNativeSpec (= 0.68.4)
+    - RCTRequired (= 0.68.5)
+    - React-Core (= 0.68.5)
+  - React (0.68.5):
+    - React-Core (= 0.68.5)
+    - React-Core/DevSupport (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-RCTActionSheet (= 0.68.5)
+    - React-RCTAnimation (= 0.68.5)
+    - React-RCTBlob (= 0.68.5)
+    - React-RCTImage (= 0.68.5)
+    - React-RCTLinking (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - React-RCTSettings (= 0.68.5)
+    - React-RCTText (= 0.68.5)
+    - React-RCTVibration (= 0.68.5)
+  - React-callinvoker (0.68.5)
+  - React-Codegen (0.68.5):
+    - FBReactNativeSpec (= 0.68.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.4)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Core (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-Core (0.68.4):
+    - RCTRequired (= 0.68.5)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-Core (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.4)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-Core/Default (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
-    - Yoga
-  - React-Core/Default (0.68.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
-    - Yoga
-  - React-Core/DevSupport (0.68.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.4)
-    - React-Core/RCTWebSocket (= 0.68.4)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-jsinspector (= 0.68.4)
-    - React-perflogger (= 0.68.4)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.4):
+  - React-Core/CoreModulesHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.4):
+  - React-Core/Default (0.68.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-Core/DevSupport (0.68.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-jsinspector (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.4):
+  - React-Core/RCTAnimationHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.4):
+  - React-Core/RCTBlobHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.4):
+  - React-Core/RCTImageHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.4):
+  - React-Core/RCTLinkingHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.4):
+  - React-Core/RCTNetworkHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.4):
+  - React-Core/RCTSettingsHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.4):
+  - React-Core/RCTTextHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.4):
+  - React-Core/RCTVibrationHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.4)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsiexecutor (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-CoreModules (0.68.4):
+  - React-Core/RCTWebSocket (0.68.5):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Codegen (= 0.68.4)
-    - React-Core/CoreModulesHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-RCTImage (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-cxxreact (0.68.4):
+    - React-Core/Default (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-CoreModules (0.68.5):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/CoreModulesHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTImage (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-cxxreact (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-jsinspector (= 0.68.4)
-    - React-logger (= 0.68.4)
-    - React-perflogger (= 0.68.4)
-    - React-runtimeexecutor (= 0.68.4)
-  - React-jsi (0.68.4):
+    - React-callinvoker (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsinspector (= 0.68.5)
+    - React-logger (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - React-runtimeexecutor (= 0.68.5)
+  - React-jsi (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.4)
-  - React-jsi/Default (0.68.4):
+    - React-jsi/Default (= 0.68.5)
+  - React-jsi/Default (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.4):
+  - React-jsiexecutor (0.68.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-perflogger (= 0.68.4)
-  - React-jsinspector (0.68.4)
-  - React-logger (0.68.4):
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+  - React-jsinspector (0.68.5)
+  - React-logger (0.68.5):
     - glog
-  - react-native-safe-area-context (4.4.1):
+  - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.68.4)
-  - React-RCTActionSheet (0.68.4):
-    - React-Core/RCTActionSheetHeaders (= 0.68.4)
-  - React-RCTAnimation (0.68.4):
+  - React-perflogger (0.68.5)
+  - React-RCTActionSheet (0.68.5):
+    - React-Core/RCTActionSheetHeaders (= 0.68.5)
+  - React-RCTAnimation (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTAnimationHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTBlob (0.68.4):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTAnimationHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTBlob (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTBlobHeaders (= 0.68.4)
-    - React-Core/RCTWebSocket (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-RCTNetwork (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTImage (0.68.4):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTBlobHeaders (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTImage (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTImageHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-RCTNetwork (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTLinking (0.68.4):
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTLinkingHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTNetwork (0.68.4):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTImageHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTLinking (0.68.5):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTLinkingHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTNetwork (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTNetworkHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTSettings (0.68.4):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTNetworkHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTSettings (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.4)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTSettingsHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-RCTText (0.68.4):
-    - React-Core/RCTTextHeaders (= 0.68.4)
-  - React-RCTVibration (0.68.4):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTSettingsHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTText (0.68.5):
+    - React-Core/RCTTextHeaders (= 0.68.5)
+  - React-RCTVibration (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.4)
-    - React-Core/RCTVibrationHeaders (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - ReactCommon/turbomodule/core (= 0.68.4)
-  - React-runtimeexecutor (0.68.4):
-    - React-jsi (= 0.68.4)
-  - ReactCommon/turbomodule/core (0.68.4):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTVibrationHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-runtimeexecutor (0.68.5):
+    - React-jsi (= 0.68.5)
+  - ReactCommon/turbomodule/core (0.68.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.4)
-    - React-Core (= 0.68.4)
-    - React-cxxreact (= 0.68.4)
-    - React-jsi (= 0.68.4)
-    - React-logger (= 0.68.4)
-    - React-perflogger (= 0.68.4)
+    - React-callinvoker (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-logger (= 0.68.5)
+    - React-perflogger (= 0.68.5)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React-Core
     - React-jsi
@@ -417,39 +417,39 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: 023a2028f218d648b588348bfa9261b4914b93db
-  FBReactNativeSpec: 9f4902cc009389d3704ff75de2aa513dee34d5c2
+  FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
+  FBReactNativeSpec: 0e0d384ef17a33b385f13f0c7f97702c7cd17858
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: e6003505912d056f21f64465063cf4b79418f2b9
-  RCTTypeSafety: d7ef4745c8d9c9faa65c26b4b6230fc5cd4c4424
-  React: 6692c30fb74ab29078b25c31c9841d863e08cdd9
-  React-callinvoker: fe2b234fa518d8bb7600707c536ab0a3e1f5edba
-  React-Codegen: 9964bb2422c7014894182ac50068caae05f68551
-  React-Core: a07bcd2f15ff93cddc9ceb07eddeec3d2ff8d990
-  React-CoreModules: 7fb4ee0fc35ad2b7daf775f0ef6309efdd8d3d82
-  React-cxxreact: 51a8058a35a2f02ad4175334a7cd24aa5558ced4
-  React-jsi: 69b974b418d2658a3f1799903be7cbcb8ac59755
-  React-jsiexecutor: 4f35a29798ba9d0d892a84001d11f626688dbb8e
-  React-jsinspector: 6f75220cd4b6020976d340ab21c63458dd3cad9e
-  React-logger: 7013d2499df6346e6a72802d4084badaaa82543b
-  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
-  React-perflogger: 0b0500685176e53ea582c45179a653aa82e4ae49
-  React-RCTActionSheet: 38469be9d20242f9c717e43c2983e8e3e6c640c4
-  React-RCTAnimation: 93774f3e8857e7c3c1cbbd277056d02be4496be1
-  React-RCTBlob: 6d0567d7a6561b62feb8c3b1cc33b3c591ba85ab
-  React-RCTImage: 1006a91318a6181a0256b89d2e321b6ea0e2e6e3
-  React-RCTLinking: 0b2300493c879c3bcac2d4c6b0178e8d0e5e2202
-  React-RCTNetwork: b9a33a95703651abed92490e50396d54b7270a17
-  React-RCTSettings: e6464123e5b5062fc23bb5adb51188a6061e9601
-  React-RCTText: 188d6f0ae20cd28891f59ecad41028ee2f793757
-  React-RCTVibration: a67beb7d2f3c73e9b74c4124ef61b84c601be649
-  React-runtimeexecutor: 088723cf020113e64736a709f52719dbb359c73e
-  ReactCommon: 1a4f19f3b4366feec03a98bdbb200b6085c5000f
+  RCTRequired: 0f06b6068f530932d10e1a01a5352fad4eaacb74
+  RCTTypeSafety: b0ee81f10ef1b7d977605a2b266823dabd565e65
+  React: 3becd12bd51ea8a43bdde7e09d0f40fba7820e03
+  React-callinvoker: 11abfff50e6bf7a55b3a90b4dc2187f71f224593
+  React-Codegen: f8946ce0768fb8e92e092e30944489c4b2955b2d
+  React-Core: 203cdb6ee2657b198d97d41031c249161060e6ca
+  React-CoreModules: 6eb0c06a4a223fde2cb6a8d0f44f58b67e808942
+  React-cxxreact: afb0c6c07d19adbd850747fedeac20c6832d40b9
+  React-jsi: 14d37a6db2af2c1a49f6f5c2e4ee667c364ae45c
+  React-jsiexecutor: 45c0496ca8cef6b02d9fa0274c25cf458fe91a56
+  React-jsinspector: eb202e43b3879aba9a14f3f65788aec85d4e1ea9
+  React-logger: 98f663b292a60967ebbc6d803ae96c1381183b6d
+  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
+  React-perflogger: 0458a87ea9a7342079e7a31b0d32b3734fb8415f
+  React-RCTActionSheet: 22538001ea2926dea001111dd2846c13a0730bc9
+  React-RCTAnimation: 732ce66878d4aa151d56a0d142b1105aa12fd313
+  React-RCTBlob: 9cb9e3e9a41d27be34aaf89b0e0f52c7ca415d57
+  React-RCTImage: 6bd16627eb9c4bb79903c4cdec7c551266ee1a5b
+  React-RCTLinking: e9edfc8919c8fa9a3f3c7b34362811f58a2ebba4
+  React-RCTNetwork: 880eccd21bbe2660a0b63da5ccba75c46eceeaa6
+  React-RCTSettings: 8c85d8188c97d6c6bd470af6631a6c4555b79bb3
+  React-RCTText: bbd275ee287730c5acbab1aadc0db39c25c5c64e
+  React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
+  React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
+  ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
   ReactTestApp-DevSupport: 19f2e33511690a213253175a9ca541d10456cb95
   ReactTestApp-Resources: ff5f151e465e890010b417ce65ca6c5de6aeccbb
-  Yoga: c926c8eec5c78a788b51e6c8a604825d00d694d7
+  Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
 PODFILE CHECKSUM: a0a692acf4827473693e5d8de3ca917e2e2df417
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.68.45)
-  - FBReactNativeSpec (0.68.45):
+  - FBLazyVector (0.68.62)
+  - FBReactNativeSpec (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.45)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Core (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
+    - RCTRequired (= 0.68.62)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2021.06.28.00-v2):
@@ -25,267 +25,267 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.45)
-  - RCTTypeSafety (0.68.45):
-    - FBLazyVector (= 0.68.45)
+  - RCTRequired (0.68.62)
+  - RCTTypeSafety (0.68.62):
+    - FBLazyVector (= 0.68.62)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.45)
-    - React-Core (= 0.68.45)
-  - React (0.68.45):
-    - React-Core (= 0.68.45)
-    - React-Core/DevSupport (= 0.68.45)
-    - React-Core/RCTWebSocket (= 0.68.45)
-    - React-RCTActionSheet (= 0.68.45)
-    - React-RCTAnimation (= 0.68.45)
-    - React-RCTBlob (= 0.68.45)
-    - React-RCTImage (= 0.68.45)
-    - React-RCTLinking (= 0.68.45)
-    - React-RCTNetwork (= 0.68.45)
-    - React-RCTSettings (= 0.68.45)
-    - React-RCTText (= 0.68.45)
-    - React-RCTVibration (= 0.68.45)
-  - React-callinvoker (0.68.45)
-  - React-Codegen (0.68.45):
-    - FBReactNativeSpec (= 0.68.45)
+    - RCTRequired (= 0.68.62)
+    - React-Core (= 0.68.62)
+  - React (0.68.62):
+    - React-Core (= 0.68.62)
+    - React-Core/DevSupport (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-RCTActionSheet (= 0.68.62)
+    - React-RCTAnimation (= 0.68.62)
+    - React-RCTBlob (= 0.68.62)
+    - React-RCTImage (= 0.68.62)
+    - React-RCTLinking (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - React-RCTSettings (= 0.68.62)
+    - React-RCTText (= 0.68.62)
+    - React-RCTVibration (= 0.68.62)
+  - React-callinvoker (0.68.62)
+  - React-Codegen (0.68.62):
+    - FBReactNativeSpec (= 0.68.62)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.45)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Core (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-Core (0.68.45):
+    - RCTRequired (= 0.68.62)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-Core (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.45)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-Core/Default (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.45):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
-    - Yoga
-  - React-Core/Default (0.68.45):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
-    - Yoga
-  - React-Core/DevSupport (0.68.45):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.45)
-    - React-Core/RCTWebSocket (= 0.68.45)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-jsinspector (= 0.68.45)
-    - React-perflogger (= 0.68.45)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.45):
+  - React-Core/CoreModulesHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.45):
+  - React-Core/Default (0.68.62):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-Core/DevSupport (0.68.62):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-jsinspector (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.45):
+  - React-Core/RCTAnimationHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.45):
+  - React-Core/RCTBlobHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.45):
+  - React-Core/RCTImageHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.45):
+  - React-Core/RCTLinkingHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.45):
+  - React-Core/RCTNetworkHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.45):
+  - React-Core/RCTSettingsHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.45):
+  - React-Core/RCTTextHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.45):
+  - React-Core/RCTVibrationHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.45)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsiexecutor (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-CoreModules (0.68.45):
+  - React-Core/RCTWebSocket (0.68.62):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Codegen (= 0.68.45)
-    - React-Core/CoreModulesHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-RCTImage (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-cxxreact (0.68.45):
+    - React-Core/Default (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-CoreModules (0.68.62):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/CoreModulesHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTImage (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-cxxreact (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-jsinspector (= 0.68.45)
-    - React-logger (= 0.68.45)
-    - React-perflogger (= 0.68.45)
-    - React-runtimeexecutor (= 0.68.45)
-  - React-jsi (0.68.45):
+    - React-callinvoker (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsinspector (= 0.68.62)
+    - React-logger (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - React-runtimeexecutor (= 0.68.62)
+  - React-jsi (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.45)
-  - React-jsi/Default (0.68.45):
+    - React-jsi/Default (= 0.68.62)
+  - React-jsi/Default (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.45):
+  - React-jsiexecutor (0.68.62):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-perflogger (= 0.68.45)
-  - React-jsinspector (0.68.45)
-  - React-logger (0.68.45):
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+  - React-jsinspector (0.68.62)
+  - React-logger (0.68.62):
     - glog
-  - React-perflogger (0.68.45)
-  - React-RCTActionSheet (0.68.45):
-    - React-Core/RCTActionSheetHeaders (= 0.68.45)
-  - React-RCTAnimation (0.68.45):
+  - React-perflogger (0.68.62)
+  - React-RCTActionSheet (0.68.62):
+    - React-Core/RCTActionSheetHeaders (= 0.68.62)
+  - React-RCTAnimation (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTAnimationHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTBlob (0.68.45):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTAnimationHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTBlob (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTBlobHeaders (= 0.68.45)
-    - React-Core/RCTWebSocket (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-RCTNetwork (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTImage (0.68.45):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTBlobHeaders (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTImage (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTImageHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-RCTNetwork (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTLinking (0.68.45):
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTLinkingHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTNetwork (0.68.45):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTImageHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTLinking (0.68.62):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTLinkingHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTNetwork (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTNetworkHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTSettings (0.68.45):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTNetworkHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTSettings (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.45)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTSettingsHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-RCTText (0.68.45):
-    - React-Core/RCTTextHeaders (= 0.68.45)
-  - React-RCTVibration (0.68.45):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTSettingsHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTText (0.68.62):
+    - React-Core/RCTTextHeaders (= 0.68.62)
+  - React-RCTVibration (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.45)
-    - React-Core/RCTVibrationHeaders (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - ReactCommon/turbomodule/core (= 0.68.45)
-  - React-runtimeexecutor (0.68.45):
-    - React-jsi (= 0.68.45)
-  - ReactCommon/turbomodule/core (0.68.45):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTVibrationHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-runtimeexecutor (0.68.62):
+    - React-jsi (= 0.68.62)
+  - ReactCommon/turbomodule/core (0.68.62):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.45)
-    - React-Core (= 0.68.45)
-    - React-cxxreact (= 0.68.45)
-    - React-jsi (= 0.68.45)
-    - React-logger (= 0.68.45)
-    - React-perflogger (= 0.68.45)
+    - React-callinvoker (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-logger (= 0.68.62)
+    - React-perflogger (= 0.68.62)
   - ReactTestApp-DevSupport (0.0.1-dev):
     - React-Core
     - React-jsi
@@ -408,38 +408,38 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: e9fecec31e5911389abca1d80a3c5961da7ce999
-  FBReactNativeSpec: 7a64164ccbba41d15af8a1dcec2b24f214c2b7fc
+  FBLazyVector: 476cc84f9fec4a6988871e6af22fc484de505767
+  FBReactNativeSpec: af73694b8acf5d05e2b521a5d1c3aefb489cd999
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTRequired: 27693cc871a00ec64ab645632855bb267815a92f
-  RCTTypeSafety: 799e2c274b3248b126c7c5f4b4ec8298bf2c4b85
-  React: 8e85e599366082700ff11d226b9d2dfe7894fabf
-  React-callinvoker: b711c5af2714763e52b3dd6f79b9bcf4e5fbbc3f
-  React-Codegen: 1830a9b5673835ab63ca55fabc1270867ef66b9d
-  React-Core: 2a935dea4b19238966d2ca9bed44a1f70c7c9c8b
-  React-CoreModules: aa5a183528dd349b262e338b661221a07d57aa14
-  React-cxxreact: d4f2ec955d14578e2317de8ec4a3662ff86480b3
-  React-jsi: 4fb32768eff290d7e28443fef9790193e349538d
-  React-jsiexecutor: 3aaf74a4e10b2603351ae919ac556d362585ec48
-  React-jsinspector: 5377c8149971be2fbb780b6f71b2d69e7b8897f1
-  React-logger: c0a319cb2128e5006ab2a55db30801565497fcdd
-  React-perflogger: c1a7f13647ca3723b53809bbae206ea481099558
-  React-RCTActionSheet: 9765fee9db62cfc6ebe91b42b2afd3fcd1389d43
-  React-RCTAnimation: d3fa4dc5290f91ec001d9b29c2700f3bac922b9a
-  React-RCTBlob: 1e7eb06f38b8b8daef89552e2c7b14b7e59c5f01
-  React-RCTImage: a3f307fea1edfaa75c50d99196c4cd22b11b6f10
-  React-RCTLinking: e5f8c36eb797b5b1959ea0925293e9fef51dd64e
-  React-RCTNetwork: 0dc9939a9577df89a563cf795a9c91dba73b1cb7
-  React-RCTSettings: 73697ba45f537208fd7e74454835368a479f7207
-  React-RCTText: baaa57e0e9e2324967018ac1f34313f885d3cb3b
-  React-RCTVibration: c3dc17464ccd085eb5ac41aaa28fc154698cefb5
-  React-runtimeexecutor: 312e8e8ec9457e2507901947cbd0e6d77342fb77
-  ReactCommon: 99cb4bfc12722d43a0b33fc30000ccb9ede37bb5
+  RCTRequired: 023a1e179ee2f19716f408aa6139ab1519ca7c2a
+  RCTTypeSafety: 82dd668bad65235631a88afc7767a5a2975710f6
+  React: 7aeda534cd94a13bfe4ee41c54873b6e94e4dd5c
+  React-callinvoker: 92923c7c5728d0cf923edf28993aac12ff950bdd
+  React-Codegen: c9605b3292a3089a6c08d81a4ce91f56865de6fe
+  React-Core: bbc4cd945153924b7fdd561f65848ce939781390
+  React-CoreModules: 36ef084a60778dd7e6a475bd554c8f64afc05d84
+  React-cxxreact: d778321f58d8743f6f663f5ac6da9009130931b7
+  React-jsi: 4fd996624ef520667e114fcc3d2f1867196d0f47
+  React-jsiexecutor: 1862151d3f809499c82d7f66a3ca624b4d6b49d9
+  React-jsinspector: 39348b9a3417419aea646f41cba625e1a7bbbd30
+  React-logger: 7a2e45e85d0fe59edb6d4fb2cbcbb9981ab9486e
+  React-perflogger: 20ae52b52ce2c0e1e257e0c0502f8f08a0b43ff9
+  React-RCTActionSheet: 2a62f3135a621bbf90504a28205cf5ef05b27bea
+  React-RCTAnimation: 219eb987ed34c38cbf13096062da7ddc142f0fac
+  React-RCTBlob: e3fb25043782acd848669cac9a15270f5702256c
+  React-RCTImage: fd5acd0da73155da5d3af967987861ab8296abe5
+  React-RCTLinking: 0bc10a82b83569e85c0f971e5adf5a53856989b6
+  React-RCTNetwork: 72cf76e577b16ceb90964bbbda07b2f22817de57
+  React-RCTSettings: 83d48be06041a57485e59820f23b1050560dabe6
+  React-RCTText: 79b5b9221fceb445d4299003628c0dd0300fa8e2
+  React-RCTVibration: c25bc2b1d5bea3f2fd8bd1931c3a23df604c7a57
+  React-runtimeexecutor: 71d892141f53ed18c108d97ce49083d7792c8cca
+  ReactCommon: 2ac737725b34d197ba527a4055a842374633de3d
   ReactTestApp-DevSupport: 19f2e33511690a213253175a9ca541d10456cb95
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
-  Yoga: 7ed465c91fd55de39d4835467d52e18927007821
+  Yoga: 6c7edb98bf534779ae3d0af1790018da859047c9
 
 PODFILE CHECKSUM: 39314e677d5ddf7e1e4c81e5e81f66cddabd661a
 

--- a/example/package.json
+++ b/example/package.json
@@ -32,7 +32,7 @@
     "react": "17.0.2",
     "react-native": "^0.68.2",
     "react-native-macos": "^0.68.3",
-    "react-native-safe-area-context": "^4.3.4",
+    "react-native-safe-area-context": "^4.5.0",
     "react-native-test-app": "workspace:.",
     "react-native-windows": "^0.68.8"
   },

--- a/scripts/shasum.mjs
+++ b/scripts/shasum.mjs
@@ -5,14 +5,18 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 /**
- * @param {string} filename
+ * @param {string[]} files
  * @param {string=} algorithm
  * @returns {string}
  */
-function hashFile(filename, algorithm = "sha256") {
-  const data = readFileSync(filename, { encoding: "utf-8" }).replace(/\r/g, "");
+function hashFiles(files, algorithm = "sha256") {
+  const data = files
+    .map((file) => {
+      return readFileSync(file, { encoding: "utf-8" }).replace(/\r/g, "");
+    })
+    .join("\n");
   return createHash(algorithm).update(data).digest("hex");
 }
 
-const { [2]: filename } = process.argv;
-console.log(hashFile(filename));
+const files = process.argv.slice(2);
+console.log(hashFiles(files));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5650,7 +5650,7 @@ __metadata:
     react: 17.0.2
     react-native: ^0.68.2
     react-native-macos: ^0.68.3
-    react-native-safe-area-context: ^4.3.4
+    react-native-safe-area-context: ^4.5.0
     react-native-test-app: "workspace:."
     react-native-windows: ^0.68.8
   peerDependencies:
@@ -10912,8 +10912,8 @@ fsevents@^2.3.2:
   linkType: hard
 
 "react-native-macos@npm:^0.68.3":
-  version: 0.68.61
-  resolution: "react-native-macos@npm:0.68.61"
+  version: 0.68.62
+  resolution: "react-native-macos@npm:0.68.62"
   dependencies:
     "@jest/create-cache-key-function": ^27.0.1
     "@react-native-community/cli": ^7.0.3
@@ -10953,17 +10953,17 @@ fsevents@^2.3.2:
     react: 17.0.2
   bin:
     react-native-macos: cli.js
-  checksum: 2253bc70db0dc13f4c48874b752582dae051e8a58237656feb9f027a7c04292b9326497e97a5cfcece229a21a651060b19878ac037c1c455be3c05acb7c39f37
+  checksum: cf3659310364cebee8c3231de9ba1d3921c8e5703ae7393f7105e5825e7bbeed53dad7409089e42e24de1a98895cb289614e7d30245d1af900ef4f4588c4ea9b
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^4.3.4":
-  version: 4.4.1
-  resolution: "react-native-safe-area-context@npm:4.4.1"
+"react-native-safe-area-context@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "react-native-safe-area-context@npm:4.5.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: ef7c41ea59a34b114c6481fb130e66ef85e8d5b88acb46279131367761ca9fbf22cd310fe613f49b6c9b56dbd83e044be640f0532eda1d3856bf708e96335a35
+  checksum: 958df1d20492aa89c23d746f88409a3a3bd1b0d397c80310a4b0bbec9888cbbeb7579c9c92dad46841e2e6536491806206228ba009b7c8af970670aef8273a30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

It looks like CI has had a 100% cache miss the past few days. Likely due to the recently released Xcode 14.2.

```
Cache directory:    /Users/runner/work/react-native-test-app/react-native-test-app/.ccache
Config file:        /Users/runner/work/react-native-test-app/react-native-test-app/.ccache/ccache.conf
System config file: /usr/local/Cellar/ccache/4.7.4/etc/ccache.conf
Stats updated:      Mon Jan 23 10:38:16 2023
Cacheable calls:      738 /  738 (100.0%)
  Hits:                 0 /  738 ( 0.00%)
    Direct:             0
    Preprocessed:       0
  Misses:             738 /  738 (100.0%)
Successful lookups:
  Direct:               0 /  738 ( 0.00%)
  Preprocessed:         0
Local storage:
  Cache size (GB):   2.29 / 5.00 (45.81%)
  Files:            18853
  Hits:                 0
  Misses:               0
  Reads:              738
  Writes:            1476
```

Full build log: https://github.com/microsoft/react-native-test-app/actions/runs/3982359635/jobs/6832553454.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.