### PR TITLE
ci: fix Android nightly patch

### DIFF
--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -42,7 +42,7 @@ index a51d4cf..512b9c6 100644
      "react": "17.0.2",
      "react-native": "^0.68.2",
      "react-native-macos": "^0.68.3",
--    "react-native-safe-area-context": "^4.3.4",
+-    "react-native-safe-area-context": "^4.5.0",
      "react-native-test-app": "workspace:.",
      "react-native-windows": "^0.68.8"
    },


### PR DESCRIPTION
### Description

Android nightly builds broke because we bumped `react-native-safe-area-context` without updating the patch.

Full build log: https://github.com/microsoft/react-native-test-app/actions/runs/3992886656/jobs/6849122120

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Apply the patch:

```
git apply scripts/android-nightly.patch
```