### PR TITLE
fix(android): fix signing configs not being used

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -289,27 +289,15 @@ android {
         pickFirst "lib/x86/libc++_shared.so"
     }
 
-    def signingDebug = project.ext.signingConfigs["debug"]
-    def signingRelease = project.ext.signingConfigs["release"]
-    if (signingDebug || signingRelease) {
-        signingConfigs {
-            if (signingDebug) {
-                debug {
-                    keyAlias signingDebug["keyAlias"]
-                    keyPassword signingDebug["keyPassword"]
-                    storeFile signingDebug["storeFile"]
-                    storePassword signingDebug["storePassword"]
-                }
-            }
-            if (signingRelease) {
-                release {
-                    keyAlias signingRelease["keyAlias"]
-                    keyPassword signingRelease["keyPassword"]
-                    storeFile signingRelease["storeFile"]
-                    storePassword signingRelease["storePassword"]
-                }
-            }
+    project.ext.signingConfigs.each { name, config ->
+        signingConfigs.register(name) {
+            keyAlias config["keyAlias"]
+                keyPassword config["keyPassword"]
+                storeFile config["storeFile"]
+                storePassword config["storePassword"]
         }
+
+        buildTypes[name].signingConfig = signingConfigs[name]
     }
 
     sourceSets {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -290,14 +290,14 @@ android {
     }
 
     project.ext.signingConfigs.each { name, config ->
-        signingConfigs.register(name) {
-            keyAlias config["keyAlias"]
-                keyPassword config["keyPassword"]
-                storeFile config["storeFile"]
-                storePassword config["storePassword"]
-        }
+        def signingConfig = signingConfigs.findByName(name) ?: signingConfigs.create(name)
+        signingConfig.keyAlias = config["keyAlias"]
+        signingConfig.keyPassword = config["keyPassword"]
+        signingConfig.storeFile = config["storeFile"]
+        signingConfig.storePassword = config["storePassword"]
 
-        buildTypes[name].signingConfig = signingConfigs[name]
+        def buildType = buildTypes.findByName(name) ?: buildTypes.create(name)
+        buildType.signingConfig = signingConfigs[name]
     }
 
     sourceSets {


### PR DESCRIPTION
### Description

We also need to add the signing config to the appropriate build type.

Reference: https://developer.android.com/studio/build/gradle-tips#sign-your-app

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Clone https://github.com/ayush547/fluentui-react-native/commit/8bca9b6a963679ca8ae14ed8c7a0e4eae77e2328
2. Run `./gradlew assembleRelease` under `/apps/fluent-tester/android`