### PR TITLE
fix(android): fix `versionCode` not being set

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -121,8 +121,8 @@ android {
         applicationId project.ext.react.applicationId
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
-        versionCode getVersionCode()
-        versionName getVersionName()
+        versionCode project.ext.getVersionCode()
+        versionName project.ext.getVersionName()
 
         def (appManifest, checksum) = validateManifest(rootDir)
         buildConfigField "String", "ReactTestApp_appManifest", "\"${appManifest}\""


### PR DESCRIPTION
### Description

`getVersionCode` was being shadowed by the current scope.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Clone https://github.com/ayush547/fluentui-react-native/commit/8bca9b6a963679ca8ae14ed8c7a0e4eae77e2328
2. Run `./gradlew bundleRelease` under `/apps/fluent-tester/android`