### PR TITLE
fix(android): fix `versionCode` breaking schema validation

### DIFF
--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -252,7 +252,8 @@ ext.validateManifest = { baseDir ->
     def process = Runtime.runtime.exec(cmd, null, baseDir)
     process.waitFor()
 
-    def inputStream = process.getInputStream()
+    def error = process.exitValue() != 0
+    def inputStream = error ? process.getErrorStream() : process.getInputStream()
     def output = new ByteArrayOutputStream()
     def buffer = new byte[1024]
     def length = inputStream.read(buffer)
@@ -262,6 +263,10 @@ ext.validateManifest = { baseDir ->
     }
 
     def result = output.toString(StandardCharsets.UTF_8.name()).trim()
+    if (error) {
+        throw new GradleException(result);
+    }
+
     def checksum = MessageDigest.getInstance("SHA-256").digest(output.toByteArray())
     return [result, checksum.encodeHex().toString()]
 }

--- a/schema.json
+++ b/schema.json
@@ -237,7 +237,7 @@
         "versionCode": {
           "description": "A positive integer used as an internal version number. Google uses this number\nto determine whether one version is more recent than another. See\n[Version your app](https://developer.android.com/studio/publish/versioning#appversioning)\nfor more on how it is used and how it differs from [`version`](#version).",
           "markdownDescription": "A positive integer used as an internal version number. Google uses this number\nto determine whether one version is more recent than another. See\n[Version your app](https://developer.android.com/studio/publish/versioning#appversioning)\nfor more on how it is used and how it differs from [`version`](#version).\n\nIntroduced in\n[1.4.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.4.0).",
-          "type": "string"
+          "type": "number"
         },
         "icons": {
           "description": "Path to resources folder containing launcher icons for the app.",

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -281,7 +281,7 @@ export async function generateSchema() {
           versionCode: {
             description: extractBrief(await docs["android.versionCode"]),
             markdownDescription: await docs["android.versionCode"],
-            type: "string",
+            type: "number",
           },
           icons: {
             description: extractBrief(await docs["android.icons"]),

--- a/test/android-test-app/test-app-util.test.js
+++ b/test/android-test-app/test-app-util.test.js
@@ -53,23 +53,7 @@ describe("test-app-util", () => {
     removeProject(defaultTestProject);
   });
 
-  test("getAppName() returns `name` if `displayName` is omitted", async () => {
-    const { status, stdout } = await runGradle({
-      "app.json": JSON.stringify({
-        name: "AppName",
-        resources: ["dist/res", "dist/main.android.jsbundle"],
-      }),
-      "build.gradle": [
-        ...buildGradle,
-        'println("getAppName() = " + ext.getAppName())',
-      ],
-    });
-
-    expect(status).toBe(0);
-    expect(stdout).toContain("getAppName() = AppName");
-  });
-
-  test("getAppName() returns `displayName` if set", async () => {
+  test("getAppName() returns `displayName`", async () => {
     const { status, stdout } = await runGradle({
       "app.json": JSON.stringify({
         name: "AppName",


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Verify that `versionCode` set to an integer is valid:

```diff
diff --git a/example/app.json b/example/app.json
index ef69fa7..33b1c3b 100644
--- a/example/app.json
+++ b/example/app.json
@@ -13,6 +13,9 @@
       "presentationStyle": "modal"
     }
   ],
+  "android": {
+    "versionCode": 10
+  },
   "resources": {
     "android": [
       "dist/res",
```

Run:

```
cd example/android
./gradlew assembleDebug
```

Validate that an invalid schema stops Gradle build (e.g. set `presentationStyle` to 0):

```
% ./gradlew assembleDebug
Configuration on demand is an incubating feature.

FAILURE: Build failed with an exception.

* Where:
Script '/~/example/node_modules/react-native-test-app/android/test-app-util.gradle' line: 267

* What went wrong:
A problem occurred evaluating project ':app'.
> /~/example/app.json: error: app.json is not a valid app manifest
  /~/example/app.json: error: /components/1/presentationStyle must be string
  /~/example/app.json: error: /components/1/presentationStyle must be equal to one of the allowed values

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s
```