### PR TITLE
chore: fix `link-project.js` breaking Renovate

### DIFF
--- a/.yarn/plugins/link-project.js
+++ b/.yarn/plugins/link-project.js
@@ -2,7 +2,13 @@ module.exports = {
   name: "plugin-link-project",
   factory: (_require) => ({
     hooks: {
-      afterAllInstalled(project, _options) {
+      afterAllInstalled(project, options) {
+        // This mode is typically used by tools like Renovate or Dependabot to
+        // keep a lockfile up-to-date without incurring the full install cost.
+        if (options.mode === "update-lockfile") {
+          return;
+        }
+
         // As of 3.3.0, Yarn avoids creating circular symlinks. We need to
         // manually create a symlink to the main project after install.
         if (project.configuration.values.get("nodeLinker") !== "node-modules") {


### PR DESCRIPTION
### Description

For an example, see https://github.com/microsoft/react-native-test-app/pull/1290

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
yarn clean
yarn install --mode update-lockfile
```