### PR TITLE
chore: use `setup-node` cache + include Yarn version in cache key

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 18
+        cache: yarn
     - name: Set up JDK
       uses: actions/setup-java@v3.9.0
       with:
@@ -53,7 +54,7 @@ runs:
       run: |
         if [[ -f example/${{ inputs.platform }}/Podfile.lock ]]; then
           clang --version > .clang-version
-          echo "cache-key=$(node scripts/shasum.mjs .clang-version example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
+          echo "cache-key=$(node scripts/shasum.mjs .clang-version .yarnrc.yml example/${{ inputs.platform }}/Podfile.lock)" >> $GITHUB_OUTPUT
         else
           echo 'cache-key=false' >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -1,5 +1,5 @@
 name: Yarn
-description: Runs `yarn install` and caches downloaded dependencies
+description: Runs `yarn install`
 inputs:
   immutable:
     description: Abort with an error exit code if the lockfile was to be modified
@@ -7,15 +7,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Generate cache key
-      id: cache-key-generator
-      run: echo "cache-key=$(node scripts/shasum.mjs yarn.lock)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Cache /.yarn/cache
-      uses: actions/cache@v3
-      with:
-        path: .yarn/cache
-        key: yarn-${{ inputs.immutable }}-${{ steps.cache-key-generator.outputs.cache-key }}
     - name: Install npm dependencies
       if: ${{ inputs.immutable == 'true' }}
       run: yarn


### PR DESCRIPTION
### Description

- `actions/setup-node` now supports caching Yarn v2+
- Seems Ccache is affected by the recent bump of Yarn

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.