### PR TITLE
fix: further simplify project config

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -1,25 +1,18 @@
 const project = (() => {
-  const fs = require("fs");
-  const path = require("path");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require("react-native-test-app");
-    const iosProject = iosProjectPath("ios");
-    return {
+    const { configureProjects } = require("react-native-test-app");
+    return configureProjects({
       android: {
         sourceDir: "android",
-        manifestPath: androidManifestPath(path.join(__dirname, "android")),
       },
-      windows: fs.existsSync("windows/Example.sln") && {
+      ios: {
+        sourceDir: "ios",
+      },
+      windows: {
         sourceDir: "windows",
-        solutionFile: "Example.sln",
-        project: windowsProjectPath(path.join(__dirname, "windows")),
+        solutionFile: "windows/Example.sln",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }

--- a/scripts/install-test-template.sh
+++ b/scripts/install-test-template.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 install=true
 platforms=(all android ios macos windows)
 version=$(node -e 'console.log(require("./package.json").version)')
+tarball=react-native-test-app-$version.$(git rev-parse --short HEAD).tgz
 
 function print_usage {
   echo "usage: $(basename "$0") [-u] <$(IFS=\|; echo "${platforms[*]}")>"
@@ -33,6 +34,7 @@ done
 
 # Use tarballs to ensure that published packages are consumable
 npm pack
+mv react-native-test-app-$version.tgz $tarball
 
 yarn
 GIT_IGNORE_FILE=".gitignore" yarn react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
@@ -40,7 +42,7 @@ GIT_IGNORE_FILE=".gitignore" yarn react-native init-test-app --destination templ
 pushd template-example 1> /dev/null
 node ../scripts/copy-yarnrc.mjs ../.yarnrc.yml
 
-script="s/\"react-native-test-app\": \".*\"/\"react-native-test-app\": \"..\/react-native-test-app-$version.tgz\"/"
+script="s/\"react-native-test-app\": \".*\"/\"react-native-test-app\": \"..\/$tarball\"/"
 if sed --version &> /dev/null; then
   sed -i'' "$script" package.json
 else

--- a/test/configure/__snapshots__/gatherConfig.test.js.snap
+++ b/test/configure/__snapshots__/gatherConfig.test.js.snap
@@ -26,15 +26,12 @@ use_test_app!
     },
     "react-native.config.js": "const project = (() => {
   try {
-    const { iosProjectPath } = require(\\"react-native-test-app\\");
-    const project = iosProjectPath(\\".\\");
-    return project
-      ? {
-          ios: {
-            project,
-          },
-        }
-      : undefined;
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
+      ios: {
+        sourceDir: \\".\\",
+      },
+    });
   } catch (_) {
     return undefined;
   }
@@ -139,27 +136,20 @@ use_test_app!
       "source": "example/metro.config.js",
     },
     "react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }
@@ -212,27 +202,20 @@ Object {
       "source": "example/metro.config.js",
     },
     "common/react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }
@@ -246,27 +229,20 @@ module.exports = {
       "source": "example/metro.config.js",
     },
     "react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }
@@ -309,27 +285,20 @@ use_test_app!
       "source": "example/metro.config.js",
     },
     "react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }
@@ -443,27 +412,20 @@ use_test_app!
       "source": "example/metro.config.js",
     },
     "react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }
@@ -584,27 +546,20 @@ use_test_app!
       "source": "example/metro.config.js",
     },
     "react-native.config.js": "const project = (() => {
-  const fs = require(\\"fs\\");
-  const path = require(\\"path\\");
   try {
-    const {
-      androidManifestPath,
-      iosProjectPath,
-      windowsProjectPath,
-    } = require(\\"react-native-test-app\\");
-    const iosProject = iosProjectPath(\\"ios\\");
-    return {
+    const { configureProjects } = require(\\"react-native-test-app\\");
+    return configureProjects({
       android: {
         sourceDir: \\"android\\",
-        manifestPath: androidManifestPath(path.join(__dirname, \\"android\\")),
       },
-      windows: fs.existsSync(\\"windows/Test.sln\\") && {
+      ios: {
+        sourceDir: \\"ios\\",
+      },
+      windows: {
         sourceDir: \\"windows\\",
-        solutionFile: \\"Test.sln\\",
-        project: windowsProjectPath(path.join(__dirname, \\"windows\\")),
+        solutionFile: \\"windows/Test.sln\\",
       },
-      ...(iosProject ? { ios: { project: iosProject } } : undefined),
-    };
+    });
   } catch (_) {
     return undefined;
   }

--- a/test/configure/reactNativeConfig.test.js
+++ b/test/configure/reactNativeConfig.test.js
@@ -9,7 +9,7 @@ describe("reactNativeConfig()", () => {
     const genericConfig = reactNativeConfig(mockParams());
     expect(genericConfig).toContain("android: {");
     expect(genericConfig).toContain("ios: {");
-    expect(genericConfig).toContain("windows: fs.exists");
+    expect(genericConfig).toContain("windows: {");
 
     const withFlattenOnly = mockParams({ flatten: true });
     expect(reactNativeConfig(withFlattenOnly)).toEqual(genericConfig);
@@ -23,30 +23,30 @@ describe("reactNativeConfig()", () => {
 
   test("returns Android specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["android"], flatten: true });
-    expect(reactNativeConfig(params)).toContain("androidManifestPath");
-    expect(reactNativeConfig(params)).not.toContain("iosProjectPath");
-    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
+    expect(reactNativeConfig(params)).toContain("android: {");
+    expect(reactNativeConfig(params)).not.toContain("ios: {");
+    expect(reactNativeConfig(params)).not.toContain("windows: {");
   });
 
   test("returns iOS specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["ios"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
-    expect(reactNativeConfig(params)).toContain("iosProjectPath");
-    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("android: {");
+    expect(reactNativeConfig(params)).toContain("ios: {");
+    expect(reactNativeConfig(params)).not.toContain("windows: {");
   });
 
   test("returns macOS specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["macos"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
-    expect(reactNativeConfig(params)).toContain("iosProjectPath");
-    expect(reactNativeConfig(params)).not.toContain("windowsProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("android: {");
+    expect(reactNativeConfig(params)).toContain("ios: {");
+    expect(reactNativeConfig(params)).not.toContain("windows: {");
   });
 
   test("returns Windows specific config for a flatten structure", () => {
     const params = mockParams({ platforms: ["windows"], flatten: true });
-    expect(reactNativeConfig(params)).not.toContain("androidManifestPath");
-    expect(reactNativeConfig(params)).not.toContain("iosProjectPath");
-    expect(reactNativeConfig(params)).toContain("windowsProjectPath");
+    expect(reactNativeConfig(params)).not.toContain("android: {");
+    expect(reactNativeConfig(params)).not.toContain("ios: {");
+    expect(reactNativeConfig(params)).toContain("windows: {");
   });
 
   test("throws when an unknown platform is specified", () => {


### PR DESCRIPTION
### Description

Further simplify `react-native.config.js`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

- 0.68: The output of `node -e "console.dir(require('./react-native.config.js'), {depth: null})"` should not differ before and after this change.
- 0.69+: `yarn react-native config` should not fail

Also tested in AsyncStorage with:

```js
    const { configureProjects } = require("react-native-test-app");
    return configureProjects({
      android: {
        sourceDir: path.join('example', 'android'),
      },
      ios: {
        sourceDir: path.join('example', 'ios'),
      },
      windows: {
        sourceDir: path.join('example', 'windows'),
        solutionFile: path.join('example', 'windows', 'AsyncStorageExample.sln'),
      },
    });
```