### PR TITLE
chore: npm 9 broke `npm pack`

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -29,7 +29,8 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v3.6.0
       with:
-        node-version: 18
+        # `npm pack` is broken in npm 9.x: https://github.com/npm/npm-packlist/issues/152
+        node-version: 16
         cache: yarn
     - name: Set up JDK
       uses: actions/setup-java@v3.9.0


### PR DESCRIPTION
### Description

Latest version looks fine, so we won't need to re-publish anything.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Download the latest version:

```
npm pack react-native-test-app
```

Then manually make sure that Gradle wrappers are included, and that the example JS code and tests are excluded.