### PR TITLE
chore: include explicit global source in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' do
-  gem 'minitest'
-  gem 'rubocop', require: false
-  gem 'rubocop-minitest'
-  gem 'xcodeproj'
-end
+source 'https://rubygems.org'
+
+gem 'minitest'
+gem 'rubocop', require: false
+gem 'rubocop-minitest'
+gem 'xcodeproj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,4 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.5)
@@ -47,10 +44,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest!
-  rubocop!
-  rubocop-minitest!
-  xcodeproj!
+  minitest
+  rubocop
+  rubocop-minitest
+  xcodeproj
 
 BUNDLED WITH
    2.3.11


### PR DESCRIPTION
### Description

Not using an explicit global source may result in a different lockfile being generated depending on the gems installed locally before bundler is run.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Running the command below should no longer print a big deprecation warning in the console:

```sh
bundle install
```