### PR TITLE
fix(ios): support multiwindow on iPad

### DIFF
--- a/ios/ReactTestApp/Info.plist
+++ b/ios/ReactTestApp/Info.plist
@@ -57,7 +57,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

Update the [UIApplicationSupportsMultipleScenes](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationscenemanifest/uiapplicationsupportsmultiplescenes?language=objc) from false to true in the plist so that the test app can support multiple windows on iPad.

Consideration of multiwindow scenarios came up in this [PR](https://github.com/microsoft/fluentui-react-native/pull/2614) in FURN. I was able turn on the multiwindow setting locally for the FURN test app, but thought we could turn it on for the test app in general.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

Tested by making this change locally in the FURN test app (fluentui-react-native/node_modules/react-native-test-app/ios/ReactTestApp/Info.plist)

Before:

https://user-images.githubusercontent.com/78454019/218600063-afe3bc24-5260-4455-89ab-9dc653708a71.mov


After:

https://user-images.githubusercontent.com/78454019/218600061-23e27b22-00d4-458b-a8a9-0327942bcd2c.mov


Note: I also tried to test directly in the react-native-test-app repo - I thought that after making this change, when I followed the [steps](https://github.com/microsoft/react-native-test-app/wiki/Quick-Start) to generate a test app, that test app would have UIApplicationSupportsMultipleScenes set to true, but every time the setting is still false. If there is something I'm missing please let me know. 

