### PR TITLE
fix(scripts, init): make the init script more resilient to template changes

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -430,9 +430,16 @@ const getConfig = (() => {
             ...(!init
               ? undefined
               : {
-                  "App.js": {
-                    source: path.join(templateDir, "App.js"),
-                  },
+                  // starting with RN 0.71, App.js is no longer in the template
+                  ...(fs.existsSync(path.join(templateDir, "App.tsx"))
+                    ? {
+                        "App.tsx": {
+                          source: path.join(templateDir, "App.tsx"),
+                        },
+                      }
+                    : {
+                        "App.js": { source: path.join(templateDir, "App.js") },
+                      }),
                   "app.json": serialize({
                     name,
                     displayName: name,


### PR DESCRIPTION
### Description

While playing around with the [init command](https://github.com/microsoft/react-native-test-app/pull/1167) for RNTA, I noticed that we failed on 0.71 because we changed `App.js` to `App.tsx`, and the code wasn't updated to match that.

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

Checkout the branch, run `GIT_IGNORE_FILE=".gitignore" node react-native-test-app/scripts/init.js --version 0.71` from outside the repo folder - it will succeed with the `App.tsx` file 👍

(we need to add that env variable because of [this workaround](https://github.com/microsoft/react-native-test-app/pull/1231))

see here:
<img width="333" alt="Screenshot 2023-02-16 at 14 16 26" src="https://user-images.githubusercontent.com/16104054/219390649-93e0299b-464f-4eac-a848-c36f6b894126.png">

