### PR TITLE
chore: add `init` to `test-matrix.sh`

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -49,17 +49,21 @@ function inferProjectName() {
  * @returns {import("./scripts/configure").Platform[]}
  */
 function sanitizePlatformChoice(choice) {
-  switch (choice) {
-    case "all":
-      return ["android", "ios", "macos", "windows"];
-    case "android":
-    case "ios":
-    case "macos":
-    case "windows":
-      return [choice];
-    default:
-      throw new Error(`Unknown platform: ${choice}`);
+  const platforms = choice.split(",");
+  for (const platform of choice.split(",")) {
+    switch (platform) {
+      case "all":
+        return ["android", "ios", "macos", "windows"];
+      case "android":
+      case "ios":
+      case "macos":
+      case "windows":
+        continue;
+      default:
+        throw new Error(`Unknown platform: ${platform}`);
+    }
   }
+  return platforms;
 }
 
 /** @type {{ commands: Command<{ destination: string; name: string; platform: string; }>[] }} */

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -8,6 +8,9 @@ const {
 } = require("./scripts/helpers");
 
 /**
+ * @typedef {import("./scripts/configure").Platform} Platform;
+ */
+/**
  * @template Args
  * @typedef {{
  *   name: string,
@@ -46,10 +49,11 @@ function inferProjectName() {
 
 /**
  * @param {string} choice
- * @returns {import("./scripts/configure").Platform[]}
+ * @returns {Platform[]}
  */
 function sanitizePlatformChoice(choice) {
-  const platforms = choice.split(",");
+  /** @type {Set<Platform>} */
+  const platforms = new Set();
   for (const platform of choice.split(",")) {
     switch (platform) {
       case "all":
@@ -58,12 +62,13 @@ function sanitizePlatformChoice(choice) {
       case "ios":
       case "macos":
       case "windows":
+        platforms.add(platform);
         continue;
       default:
         throw new Error(`Unknown platform: ${platform}`);
     }
   }
-  return platforms;
+  return Array.from(platforms);
 }
 
 /** @type {{ commands: Command<{ destination: string; name: string; platform: string; }>[] }} */

--- a/scripts/install-test-template.sh
+++ b/scripts/install-test-template.sh
@@ -35,7 +35,7 @@ done
 npm pack
 
 yarn
-GIT_IGNORE_FILE=".gitignore" npx react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
+GIT_IGNORE_FILE=".gitignore" yarn react-native init-test-app --destination template-example --name TemplateExample --platform "$platform"
 
 pushd template-example 1> /dev/null
 node ../scripts/copy-yarnrc.mjs ../.yarnrc.yml

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
+GIT_IGNORE_FILE=".gitignore"
 PACKAGE_MANAGER=yarn
 VERSION=${1}
 
@@ -59,7 +60,7 @@ echo "│  Build Android  │"
 echo "└─────────────────┘"
 echo
 
-npm run android -- --no-packager
+yarn android --no-packager
 wait_for_user "Android app is ready for testing"
 
 echo
@@ -69,7 +70,7 @@ echo "└─────────────┘"
 echo
 
 pod_install ios
-npm run ios -- --no-packager
+yarn ios --no-packager
 wait_for_user "iOS app is ready for testing"
 
 echo
@@ -80,7 +81,7 @@ echo
 
 sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios -- --no-packager
+yarn ios --no-packager
 wait_for_user "iOS app with Hermes is ready for testing"
 
 echo
@@ -103,7 +104,7 @@ echo
 sed -i '' 's/#newArchEnabled=true/newArchEnabled=true/' android/gradle.properties
 pushd android 1> /dev/null
 popd 1> /dev/null
-npm run android -- --no-packager
+yarn android --no-packager
 wait_for_user "Android app with Fabric is ready for testing"
 
 echo
@@ -114,7 +115,7 @@ echo
 
 sed -i '' 's/:turbomodule_enabled => false/:turbomodule_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios -- --no-packager
+yarn ios --no-packager
 wait_for_user "iOS app with Fabric is ready for testing"
 
 echo
@@ -125,7 +126,15 @@ echo
 
 sed -i '' 's/:hermes_enabled => false/:hermes_enabled => true/' ios/Podfile
 pod_install ios
-npm run ios -- --no-packager
+yarn ios --no-packager
 wait_for_user "iOS app with Fabric + Hermes is ready for testing"
 
 popd 1> /dev/null
+
+echo
+echo "┌─────────────────────┐"
+echo "│  Initialize new app │"
+echo "└─────────────────────┘"
+echo
+
+yarn react-native init-test-app --destination template-example --name TemplateExample --platform android,ios


### PR DESCRIPTION
### Description

Add `init` to `test-matrix.sh` and make it part of testing new react-native versions.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

> Note: This may require you to keep a local copy of `react-native.config.js` since we'll be rolling back to an earlier commit to ensure that we catch name changes in core template.

1. Rollback to 89a0c58: `git reset --hard 89a0c58`
2. Install dependencies: `yarn`
3. Manually run `init-test-app`:
    ```
    % GIT_IGNORE_FILE=".gitignore" yarn react-native init-test-app --destination template-example --name TemplateExample --platform android,ios
    /~/example/node_modules/flow-parser/flow_parser.js:807
    throw a}function
    ^

    [Error: ENOENT: no such file or directory, copyfile '../node_modules/react-native/template/App.js' -> 'template-example/App.js'] {
      errno: -2,
      code: 'ENOENT',
      syscall: 'copyfile',
      path: '../node_modules/react-native/template/App.js',
      dest: 'template-example/App.js'
    }
    ```
4. Reset to origin: `git pull`
5. Repeat steps 2-3