### PR TITLE
chore(windows): `autolink` should only default to true on Windows

### DIFF
--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -3,47 +3,43 @@ on:
   workflow_dispatch:
     inputs:
       architecture:
-        description: "Supported architectures are `arm64`, `x64`"
+        description: Supported architectures are `arm64`, `x64`
         required: true
-        default: "x64"
+        default: x64
       deviceType:
-        description: "Supported device types are `device`, `emulator`, `simulator`"
+        description: Supported device types are `device`, `emulator`, `simulator`
         required: true
-        default: "simulator"
+        default: simulator
       distribution:
-        description: "Distribution config string, e.g. `local` or `firebase:<appId>`"
+        description: Distribution config string, e.g. `local` or `firebase:<appId>`
         required: true
-        default: "local"
+        default: local
       packageManager:
-        description: "Binary name of the package manager used in the current repo"
+        description: Binary name of the package manager used in the current repo
         required: true
-        default: "yarn"
+        default: yarn
       platform:
-        description: "Supported platforms are `android`, `ios`, `macos`, `windows`"
+        description: Supported platforms are `android`, `ios`, `macos`, `windows`
         required: true
       projectRoot:
-        description: "Root of the project"
+        description: Root of the project
         required: true
       scheme:
-        description: "The workspace scheme to build (iOS and macOS only)"
-        default: "ReactTestApp"
+        description: The workspace scheme to build (iOS and macOS only)
+        default: ReactTestApp
 jobs:
   build-android:
-    name: "Build Android"
+    name: Build Android
     if: ${{ github.event.inputs.platform == 'android' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3.10.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
-          distribution: temurin
-          java-version: 11
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version: 18
+          platform: android
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
@@ -60,7 +56,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-ios:
-    name: "Build iOS"
+    name: Build iOS
     if: ${{ github.event.inputs.platform == 'ios' }}
     runs-on: macos-12
     env:
@@ -71,10 +67,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
-          node-version: 18
+          platform: ios
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -117,16 +115,18 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-macos:
-    name: "Build macOS"
+    name: Build macOS
     if: ${{ github.event.inputs.platform == 'macos' }}
     runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
-          node-version: 18
+          platform: macos
+          project-root: ${{ github.event.inputs.projectRoot }}
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Pods
@@ -149,18 +149,17 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   build-windows:
-    name: "Build Windows"
+    name: Build Windows
     if: ${{ github.event.inputs.platform == 'windows' }}
     runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.3
-      - name: Set up Node 18
-        uses: actions/setup-node@v3.6.0
+      - name: Set up toolchain
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.11
         with:
-          node-version: 18
+          platform: windows
+          cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Install Windows test app
@@ -192,9 +191,9 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   distribute:
-    name: "Distribute build"
+    name: Distribute build
     needs: [build-android, build-ios]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ github.event.inputs.distribution != 'local' && !cancelled() && !failure() }} # `success()` excludes skipped jobs
     steps:
       - name: Download build artifact

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -903,7 +903,7 @@ if (require.main === module) {
       autolink: {
         type: "boolean",
         description: "Run autolink after generating the solution",
-        default: true,
+        default: require("os").platform() === "win32",
       },
       "use-hermes": {
         type: "boolean",


### PR DESCRIPTION
### Description

`autolink` should only default to true on Windows because it relies on system access.

Context: `install-windows-test-app` can be run on macOS for debugging purposes.

Totally unrelated: Also update `rnx-build.yml`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

On macOS, `autolink` should now default to `false`:

```diff
 % yarn install-windows-test-app --help
 test-app.js [options]
 
 Generate a Visual Studio solution for React Test App
 
 Options:
       --help               Show help                                   [boolean]
       --version            Show version number                         [boolean]
   -p, --project-directory  Directory where solution will be created
                                                    [string] [default: "windows"]
       --autolink           Run autolink after generating the solution
+                                                      [boolean] [default: false]
       --use-hermes         Use Hermes JavaScript engine (experimental) [boolean]
       --use-nuget          Use NuGet packages (experimental)
                                                       [boolean] [default: false]
```