### PR TITLE
ci: fix cache key instability

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -35,8 +35,8 @@ runs:
           ccache --zero-stats 1> /dev/null
 
           clang --version > .clang-version
-          input=$(find . -maxdepth 1 -name .clang-version -o -name .yarnrc.yml)
-          echo "cache-key=$(tar -cf - "$podfile_lock" $input | shasum -a 256 | awk '{ print $1 }')" >> $GITHUB_OUTPUT
+          input=$(find . -maxdepth 1 -name .clang-version -o -name .yarnrc.yml | sort)
+          echo "cache-key=$(cat "$podfile_lock" $input | shasum -a 256 | awk '{ print $1 }')" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Set up JDK


### PR DESCRIPTION
### Description

The order in which files are found for generating the final cache key can differ between runs. Also switched to using `cat` instead of `tar`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Put the related lines in a script and execute it:

```sh
#!/bin/sh
podfile_lock="example/ios/Podfile.lock"
input=$(find . -maxdepth 1 -name .clang-version -o -name .yarnrc.yml | sort)
echo "$podfile_lock" $input
cat "$podfile_lock" $input | shasum -a 256 | awk '{ print $1 }'
```

Compare the output with manually invoking the command:
```
cat example/ios/Podfile.lock .clang-version .yarnrc.yml | shasum -a 256
```