### PR TITLE
fix(ios): no implicit conversion of Pathname into String

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -206,7 +206,7 @@ def use_react_native!(project_root, target_platform, options)
   require_relative(react_native_pods(version))
 
   include_react_native!(**options,
-                        app_path: find_file('package.json', project_root).parent,
+                        app_path: find_file('package.json', project_root).parent.to_s,
                         path: react_native.relative_path_from(project_root).to_s,
                         rta_flipper_versions: flipper_versions,
                         rta_project_root: project_root,


### PR DESCRIPTION
### Description

`use_react_native!` expects strings.

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/4350507991/jobs/7601274289

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

`pod install` should succeed:

```
npm run set-react-version -- nightly
yarn
cd example
pod install --project-directory=ios
```