### PR TITLE
fix(android): call `super.createReactInstanceManager()`

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -12,9 +12,6 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.bridge.ReactMarker
-import com.facebook.react.bridge.ReactMarkerConstants
-import com.facebook.react.common.LifecycleState
 import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
@@ -152,20 +149,7 @@ class TestAppReactNativeHost(
     }
 
     override fun createReactInstanceManager(): ReactInstanceManager {
-        ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_START)
-        val reactInstanceManager = ReactInstanceManager.builder()
-            .setApplication(application)
-            .setJavaScriptExecutorFactory(javaScriptExecutorFactory)
-            .setBundleAssetName(bundleAssetName)
-            .setJSMainModulePath(jsMainModuleName)
-            .addPackages(packages)
-            .setUseDeveloperSupport(useDeveloperSupport)
-            .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
-            .setRedBoxHandler(redBoxHandler)
-            .setJSIModulesPackage(jsiModulePackage)
-            .build()
-        ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_END)
-
+        val reactInstanceManager = super.createReactInstanceManager()
         addCustomDevOptions(reactInstanceManager.devSupportManager)
 
         synchronized(reactInstanceEventListeners) {
@@ -193,8 +177,9 @@ class TestAppReactNativeHost(
 
     override fun getJSMainModuleName() = "index"
 
-    override fun getBundleAssetName() =
-        if (source == BundleSource.Disk) reactBundleNameProvider.bundleName else null
+    // We may not always need a JS bundle, but `ReactNativeHost.createReactInstanceManager`
+    // asserts it so we need to return something.
+    override fun getBundleAssetName() = reactBundleNameProvider.bundleName ?: "main.android.bundle"
 
     override fun getUseDeveloperSupport() = source == BundleSource.Server
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -177,8 +177,9 @@ class TestAppReactNativeHost(
 
     override fun getJSMainModuleName() = "index"
 
-    // We may not always need a JS bundle, but `ReactNativeHost.createReactInstanceManager`
-    // asserts it so we need to return something.
+    // We may not always have (or need) a JS bundle, but
+    // `ReactNativeHost.createReactInstanceManager` asserts it so we need to
+    // return something.
     override fun getBundleAssetName() = reactBundleNameProvider.bundleName ?: "main.android.bundle"
 
     override fun getUseDeveloperSupport() = source == BundleSource.Server


### PR DESCRIPTION
### Description

Our custom override has been working fine up until now, but seems to be causing crashes on 0.72.

Prerequisite for #1359.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Make sure the Android app still builds/boots:

```
cd example
yarn android
```

| 0.64 | 0.71 |
| :-: | :-: |
| ![Screenshot_1679662771](https://user-images.githubusercontent.com/4123478/227527778-25f647c3-e084-48b6-b406-be55097e00c3.png) | ![Screenshot_1679665590](https://user-images.githubusercontent.com/4123478/227538200-bd63b17f-ccb3-42a4-a2bc-f2d5890c46a2.png) |