### PR TITLE
chore: use `metro` to determine version of `metro-react-native-babel-preset`

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -185,8 +185,7 @@ async function resolveCommonDependencies({ dependencies, peerDependencies }) {
       // Metro bumps and publishes all packages together, meaning we can use
       // `metro-react-native-babel-transformer` to determine the version of
       // `metro-react-native-babel-preset` that should be used.
-      const metroBabelTransformer = "metro-react-native-babel-transformer";
-      const version = dependencies?.[metroBabelTransformer];
+      const version = dependencies?.["metro-react-native-babel-transformer"];
       if (version) {
         return version;
       }
@@ -196,7 +195,7 @@ async function resolveCommonDependencies({ dependencies, peerDependencies }) {
       // `@react-native-community/cli-plugin-metro` instead.
       const cliPluginMetro = "@react-native-community/cli-plugin-metro";
       const metroPluginInfo = await fetchPackageInfo(cliPluginMetro);
-      return metroPluginInfo.dependencies?.[metroBabelTransformer];
+      return metroPluginInfo.dependencies?.["metro"];
     })(),
     react: peerDependencies?.["react"],
   };


### PR DESCRIPTION
### Description

Use `metro` to determine version of `metro-react-native-babel-preset`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`metro-react-native-babel-preset` should not be `undefined`:

```
% npm run set-react-version -- 0.72

> react-native-test-app@0.0.1-dev set-react-version
> node scripts/set-react-version.mjs 0.72

{
  '@react-native-community/cli': '11.0.0-alpha.2',
  '@react-native-community/cli-platform-android': '11.0.0-alpha.2',
  '@react-native-community/cli-platform-ios': '11.0.0-alpha.2',
  'hermes-engine': undefined,
  'metro-react-native-babel-preset': '0.76.0',
  react: '18.2.0',
  'react-native': '0.72.0-rc.0',
  'react-native-macos': undefined,
  'react-native-windows': undefined
}
