### PR TITLE
test: fix `react-native config` test failing on nightly

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -108,11 +108,11 @@ describe("react-native config", () => {
           android: expect.anything(),
         }),
         project: expect.objectContaining({
-          android: {
+          android: expect.objectContaining({
             sourceDir: expect.stringContaining(sourceDir),
             appName: fs.existsSync("android/app") ? "app" : "",
             packageName: "com.microsoft.reacttestapp",
-          },
+          }),
         }),
       });
     }


### PR DESCRIPTION
### Description

Fix `react-native config` test failing on nightly.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
yarn jest
```