### PR TITLE
fix: replace yargs with minimist to reduce footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,11 +80,12 @@
   "dependencies": {
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
+    "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",
+    "minimist": "^1.2.8",
     "prompts": "^2.4.0",
     "semver": "^7.3.5",
-    "uuid": "^8.3.2",
-    "yargs": "^16.0.0"
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@expo/config-plugins": ">=5.0",

--- a/scripts/parseargs.js
+++ b/scripts/parseargs.js
@@ -1,0 +1,152 @@
+// @ts-check
+"use strict";
+
+/**
+ * @typedef {{
+ *    description: string;
+ *    type: "string" | "boolean";
+ *    multiple?: boolean;
+ *    short?: string;
+ *    default?: string | boolean | string[];
+ * }} Option;
+ *
+ * @typedef {{ [key: string]: Option }} Options;
+ */
+/**
+ * @template {Option} O
+ * @typedef {O extends { type: "boolean" }
+ *             ? boolean
+ *             : O extends { type: "string", multiple: true }
+ *               ? string[]
+ *               : string
+ * } InferredOptionType<O>;
+ */
+/**
+ * @template {Options} O
+ * @typedef {{ [key in keyof O]: InferredOptionType<O[key]> }} InferredOptionTypes<O>;
+ */
+/**
+ * @template {Options} O
+ * @typedef {InferredOptionTypes<O> & { _: string[] }} Args;
+ */
+/**
+ * @typedef {{
+ *   string: string[];
+ *   boolean: string[];
+ *   alias: Record<string, string>;
+ *   default: Record<string, string | boolean | string[]>;
+ * }} MinimistOptions;
+ */
+
+/**
+ * Generates help message.
+ * @param {string} description
+ * @param {Record<string, { short?: string; description: string; }>} options
+ * @returns {string}
+ */
+function formatHelp(description, options) {
+  const flags = Object.entries(options);
+  const indent = "  ";
+  const minWidth =
+    Math.max(...flags.map(([flag]) => flag.length)) + indent.length * 2;
+
+  const ui = require("cliui")();
+  for (const [flag, config] of flags) {
+    ui.div(
+      { text: "", width: 2 },
+      { text: config.short ? `-${config.short},` : "", width: 4 },
+      { text: `--${flag}`, width: minWidth + 2 },
+      { text: config.description }
+    );
+  }
+
+  const script = require("path").basename(process.argv[1]);
+  return [
+    `usage: ${script} [options]`,
+    "",
+    description,
+    "",
+    "Options:",
+    ui.toString(),
+    "",
+  ].join("\n");
+}
+
+/**
+ * Converts options to the format required by minimist.
+ * @param {Options} options
+ * @returns {MinimistOptions}
+ */
+function minimistOptions(options) {
+  /** @type {MinimistOptions} */
+  const minimist = {
+    string: [],
+    boolean: [],
+    alias: {},
+    default: {},
+  };
+
+  for (const [flag, option] of Object.entries(options)) {
+    if (option.type === "boolean") {
+      minimist.boolean.push(flag);
+    } else {
+      minimist.string.push(flag);
+    }
+
+    if (option.short) {
+      minimist.alias[option.short] = flag;
+    }
+
+    if (option.default) {
+      minimist.default[flag] = option.default;
+    }
+  }
+
+  return minimist;
+}
+
+/**
+ * Parses command line arguments.
+ *
+ * Note: In the future, we can replace minimist with `util.parseArgs`.
+ *
+ * @see {@link https://nodejs.org/api/util.html#utilparseargsconfig}
+ *
+ * @template {Options} O
+ * @param {string} description
+ * @param {O} options
+ * @param {(args: Args<O>) => void} callback
+ */
+function parseArgs(description, options, callback) {
+  const mergedOptions = {
+    help: {
+      description: "Show this help message",
+      type: "boolean",
+      short: "h",
+      default: false,
+    },
+    version: {
+      description: "Show version number",
+      type: "boolean",
+      short: "v",
+      default: false,
+    },
+    ...options,
+  };
+
+  const args = require("minimist")(
+    process.argv.slice(2),
+    minimistOptions(options)
+  );
+
+  if (args["help"]) {
+    console.log(formatHelp(description, mergedOptions));
+  } else if (args["version"]) {
+    const { name, version } = require("../package.json");
+    console.log(`${name} ${version}`);
+  } else {
+    callback(/** @type {Args<O>} */ (args));
+  }
+}
+
+exports.parseArgs = parseArgs;

--- a/scripts/parseargs.js
+++ b/scripts/parseargs.js
@@ -50,6 +50,7 @@ function formatHelp(description, options) {
   const minWidth =
     Math.max(...flags.map(([flag]) => flag.length)) + indent.length * 2;
 
+  // @ts-expect-error This expression is not callable
   const ui = require("cliui")();
   for (const [flag, config] of flags) {
     ui.div(

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -181,6 +181,7 @@ describe("npm pack", () => {
       "scripts/helpers.js",
       "scripts/init.js",
       "scripts/link.js",
+      "scripts/parseargs.js",
       "scripts/patch-cli-platform-android.js",
       "scripts/validate-manifest.js",
       "test-app.gradle",

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { findNearest, getPackageVersion } = require("../scripts/helpers");
+const { parseArgs } = require("../scripts/parseargs");
 
 /**
  * @typedef {{
@@ -890,28 +891,29 @@ exports.toProjectEntry = toProjectEntry;
 if (require.main === module) {
   require("../scripts/link")(module);
 
-  require("yargs").usage(
-    "$0 [options]",
+  parseArgs(
     "Generate a Visual Studio solution for React Test App",
     {
       "project-directory": {
-        alias: "p",
+        description:
+          "Directory where solution will be created (default: “windows”)",
         type: "string",
-        description: "Directory where solution will be created",
+        short: "p",
         default: "windows",
       },
       autolink: {
+        description: `Run autolink after generating the solution (this is the default on Windows)`,
         type: "boolean",
-        description: "Run autolink after generating the solution",
         default: require("os").platform() === "win32",
       },
       "use-hermes": {
-        type: "boolean",
         description: "Use Hermes JavaScript engine (experimental)",
+        type: "boolean",
+        default: false,
       },
       "use-nuget": {
-        type: "boolean",
         description: "Use NuGet packages (experimental)",
+        type: "boolean",
         default: false,
       },
     },
@@ -931,5 +933,5 @@ if (require.main === module) {
         process.exitCode = 1;
       }
     }
-  ).argv;
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,6 +4303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cliui@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
+  languageName: node
+  linkType: hard
+
 "clone-deep@npm:^4.0.1":
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
@@ -8851,6 +8862,13 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"minimist@npm:^1.2.8":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
+  languageName: node
+  linkType: hard
+
 "minipass-collect@npm:^1.0.2":
   version: 1.0.2
   resolution: "minipass-collect@npm:1.0.2"
@@ -10162,12 +10180,14 @@ fsevents@^2.3.2:
     "@types/uuid": ^8.3.1
     ajv: ^8.0.0
     chalk: ^4.1.0
+    cliui: ^8.0.0
     eslint: ^8.0.0
     eslint-plugin-jest: ^27.0.0
     fast-xml-parser: ^4.0.0
     jest: ^27.0.0
     js-yaml: ^4.1.0
     memfs: ^3.3.0
+    minimist: ^1.2.8
     prettier: ^2.3.1
     prompts: ^2.4.0
     react: 17.0.2
@@ -10179,7 +10199,6 @@ fsevents@^2.3.2:
     suggestion-bot: ^1.0.0
     typescript: ^5.0.0
     uuid: ^8.3.2
-    yargs: ^16.0.0
   peerDependencies:
     "@expo/config-plugins": ">=5.0"
     "@react-native-community/cli": ">=5.0"
@@ -12713,7 +12732,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.0, yargs@npm:^16.2.0":
+"yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8855,14 +8855,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.6
-  resolution: "minimist@npm:1.2.6"
-  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
-  languageName: node
-  linkType: hard
-
-"minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0


### PR DESCRIPTION
### Description

We don't use everything that yargs has to offer so it brings a bit of a overhead for us. We can replace the bits we need with `minimist` and using `cliui` directly. In the future, we will be able to use [`util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig) and no longer depend on `minimist`.

[![Composition](https://user-images.githubusercontent.com/4123478/229341769-bf4d534a-c6ee-474a-a94f-cbd1f4689bd7.png)](https://bundlephobia.com/package/react-native-test-app@2.3.14)

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows

### Test plan

`scripts/configure.js` and `windows/test-app.js` are the two scripts affected by this change.

- Verify that `--help` is correctly formatted in both big and small terminals
- From the `example` folder, you can run either command to verify that they are getting the arguments passed, for example:
  - `node ../scripts/configure.js` alone should list files that affect all platforms
  - `node ../scripts/configure.js -p android -p ios` should only list Android and iOS files
  - `node ../scripts/configure.js -p windows` should only list Windows files
  - `node ../windows/test-app.js` should generate Visual Studio solution files under `example/windows` (even on a Mac)
  - `node ../windows/test-app.js --autolink` on a Mac will fail because autolinking requires Windows