### PR TITLE
chore: update Renovate config for 0.71

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,11 +4,7 @@
   "packageRules": [
     {
       "matchPackagePrefixes": ["@react-native-community/cli"],
-      "allowedVersions": "^7.0.0"
-    },
-    {
-      "matchPackageNames": ["hermes-engine"],
-      "allowedVersions": "~0.11.0"
+      "allowedVersions": "^10.0.0"
     },
     {
       "groupName": "Android",
@@ -33,7 +29,7 @@
     {
       "groupName": "Metro",
       "matchSourceUrlPrefixes": ["https://github.com/facebook/metro"],
-      "allowedVersions": "^0.67.0"
+      "allowedVersions": "^0.73.0"
     },
     {
       "groupName": "Moshi",
@@ -46,12 +42,11 @@
     },
     {
       "matchPackageNames": [
-        "@types/react-native",
         "react-native",
         "react-native-macos",
         "react-native-windows"
       ],
-      "allowedVersions": "^0.68.0"
+      "allowedVersions": "^0.71.0"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,6 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@types/jest": "^29.0.0",
-    "@types/react-native": "^0.68.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "^0.73.9",
     "mkdirp": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3000,44 +3000,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.5
-  resolution: "@types/prop-types@npm:15.7.5"
-  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
-  languageName: node
-  linkType: hard
-
-"@types/react-native@npm:^0.68.0":
-  version: 0.68.12
-  resolution: "@types/react-native@npm:0.68.12"
-  dependencies:
-    "@types/react": ^17
-  checksum: 9a438b302fd839f183b2989bb77a963c2ba97aff23fe335cca827d033c3a5db65fcee65eb3fd75238a7cb7d854d9c03b43cd948883ad60977fdf9a45b9e84414
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17":
-  version: 17.0.48
-  resolution: "@types/react@npm:17.0.48"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: b683fa33f751ced0b8c8715df9f40de15513c1d7ce66064a75cdfb8805cc913b0b214a2e7022ef0b724bd62a1e8651d040cd265dd0452bde03cca9b8e495742d
-  languageName: node
-  linkType: hard
-
 "@types/retry@npm:^0.12.0":
   version: 0.12.1
   resolution: "@types/retry@npm:0.12.1"
   checksum: 5f46b2556053655f78262bb33040dc58417c900457cc63ff37d6c35349814471453ef511af0cec76a540c601296cd2b22f64bab1ab649c0dacc0223765ba876c
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.16.2
-  resolution: "@types/scheduler@npm:0.16.2"
-  checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
   languageName: node
   linkType: hard
 
@@ -4730,13 +4696,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "csstype@npm:3.1.0"
-  checksum: 644e986cefab86525f0b674a06889cfdbb1f117e5b7d1ce0fc55b0423ecc58807a1ea42ecc75c4f18999d14fc42d1d255f84662a45003a52bb5840e977eb2ffd
-  languageName: node
-  linkType: hard
-
 "dateformat@npm:^3.0.0":
   version: 3.0.3
   resolution: "dateformat@npm:3.0.3"
@@ -5515,7 +5474,6 @@ __metadata:
     "@babel/core": ^7.1.6
     "@babel/preset-env": ^7.1.6
     "@types/jest": ^29.0.0
-    "@types/react-native": ^0.68.0
     jest: ^29.2.1
     metro-react-native-babel-preset: ^0.73.9
     mkdirp: ^1.0.0


### PR DESCRIPTION
### Description

Update Renovate config for 0.71

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a