### PR TITLE
chore: bump eslint-plugin-react to 7.32.2

### DIFF
--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.12
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.16
         with:
           platform: android
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.12
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.16
         with:
           platform: ios
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.12
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.16
         with:
           platform: macos
           project-root: ${{ github.event.inputs.projectRoot }}
@@ -156,7 +156,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.12
+        uses: microsoft/react-native-test-app/.github/actions/setup-toolchain@2.3.16
         with:
           platform: windows
           cache-npm-dependencies: ${{ github.event.inputs.packageManager }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,8 +5269,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react@npm:^7.26.0":
-  version: 7.32.1
-  resolution: "eslint-plugin-react@npm:7.32.1"
+  version: 7.32.2
+  resolution: "eslint-plugin-react@npm:7.32.2"
   dependencies:
     array-includes: ^3.1.6
     array.prototype.flatmap: ^1.3.1
@@ -5289,7 +5289,7 @@ __metadata:
     string.prototype.matchall: ^4.0.8
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: e20eab61161a3db6211c2bd1eb9be3e407fd14e72c06c5f39a078b6ac37427b2af6056ee70e3954249bca0a04088ae797a0c8ba909fb8802e29712de2a41262d
+  checksum: 2232b3b8945aa50b7773919c15cd96892acf35d2f82503667a79e2f55def90f728ed4f0e496f0f157acbe1bd4397c5615b676ae7428fe84488a544ca53feb944
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Renovate fails to bump `eslint-plugin-react` for some reason so here's a manual bump.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a