### PR TITLE
fix(android): fix Fabric cannot be enabled on 0.72

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -311,26 +311,34 @@ android {
             debug.java.srcDirs += "src/flipper/java"
         }
 
-        // TODO: Remove this block when we drop support for 0.67.
+        // TODO: Remove this block when we drop support for 0.67
         if (project.ext.react.enableFabric) {
             main.java.srcDirs += "src/fabric/java"
         } else {
             main.java.srcDirs += "src/no-fabric/java"
         }
 
-        // TODO: Remove this block when we drop support for 0.65.
+        // TODO: Remove this block when we drop support for 0.65
         if (enableNewArchitecture) {
             main.java.srcDirs += "src/turbomodule/java"
         } else {
             main.java.srcDirs += "src/no-turbomodule/java"
         }
 
-        // TODO: Remove this block when we drop support for 0.67.
+        // TODO: Remove this block when we drop support for 0.67
         // https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4
         if (reactNativeVersion > 0 && reactNativeVersion < 6800) {
             main.java.srcDirs += "src/reactinstanceeventlistener-pre-0.68/java"
         } else {
             main.java.srcDirs += "src/reactinstanceeventlistener-0.68/java"
+        }
+
+        // TODO: Remove this block when we drop support for 0.72
+        // https://github.com/facebook/react-native/commit/e5dd9cdc6688e63e75a7e0bebf380be1a9a5fe2b
+        if (reactNativeVersion > 0 && reactNativeVersion < 7200) {
+            main.java.srcDirs += "src/reactactivitydelegate-pre-0.72/java"
+        } else {
+            main.java.srcDirs += "src/reactactivitydelegate-0.72/java"
         }
     }
 

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -7,30 +7,14 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
 import com.microsoft.reacttestapp.BuildConfig
 
 class ComponentActivity : ReactActivity() {
 
-    private inner class ComponentActivityDelegate(
-        activity: ReactActivity,
-        mainComponentName: String?
-    ) : ReactActivityDelegate(activity, mainComponentName) {
-        override fun getLaunchOptions(): Bundle? {
-            return intent.extras?.getBundle(COMPONENT_INITIAL_PROPERTIES)
-        }
-
-        override fun createRootView(): ReactRootView {
-            val rootView = super.createRootView()
-            rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
-            return rootView
-        }
-    }
-
     companion object {
         private const val COMPONENT_NAME = "extra:componentName"
         private const val COMPONENT_DISPLAY_NAME = "extra:componentDisplayName"
-        private const val COMPONENT_INITIAL_PROPERTIES = "extra:componentInitialProperties"
+        const val COMPONENT_INITIAL_PROPERTIES = "extra:componentInitialProperties"
 
         fun newIntent(activity: Activity, component: ComponentViewModel): Intent {
             return Intent(activity, ComponentActivity::class.java).apply {
@@ -43,6 +27,8 @@ class ComponentActivity : ReactActivity() {
             }
         }
     }
+
+    // ReactActivity overrides
 
     override fun createReactActivityDelegate(): ReactActivityDelegate {
         return ComponentActivityDelegate(this, mainComponentName)
@@ -74,13 +60,7 @@ class ComponentActivity : ReactActivity() {
         } ?: loadApp(componentName)
     }
 
-    private fun findClass(name: String): Class<*>? {
-        return try {
-            Class.forName(name)
-        } catch (e: ClassNotFoundException) {
-            null
-        }
-    }
+    // Activity overrides
 
     override fun getSystemService(name: String): Any? {
         if (name == "service:reactNativeHostService") {
@@ -98,5 +78,15 @@ class ComponentActivity : ReactActivity() {
         }
 
         return super.onOptionsItemSelected(item)
+    }
+
+    // Private
+
+    private fun findClass(name: String): Class<*>? {
+        return try {
+            Class.forName(name)
+        } catch (e: ClassNotFoundException) {
+            null
+        }
     }
 }

--- a/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -1,0 +1,30 @@
+package com.microsoft.reacttestapp.component
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+import com.microsoft.reacttestapp.BuildConfig
+
+class ComponentActivityDelegate(
+    activity: ReactActivity,
+    mainComponentName: String?
+) : ReactActivityDelegate(activity, mainComponentName) {
+    override fun getLaunchOptions(): Bundle? {
+        return plainActivity.intent.extras?.getBundle(
+            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+        )
+    }
+
+    override fun createRootView(): ReactRootView {
+        val rootView = super.createRootView()
+        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        return rootView
+    }
+
+    override fun createRootView(bundle: Bundle?): ReactRootView {
+        val rootView = super.createRootView(bundle)
+        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        return rootView
+    }
+}

--- a/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -1,0 +1,24 @@
+package com.microsoft.reacttestapp.component
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+import com.microsoft.reacttestapp.BuildConfig
+
+class ComponentActivityDelegate(
+    activity: ReactActivity,
+    mainComponentName: String?
+) : ReactActivityDelegate(activity, mainComponentName) {
+    override fun getLaunchOptions(): Bundle? {
+        return plainActivity.intent.extras?.getBundle(
+            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+        )
+    }
+
+    override fun createRootView(): ReactRootView {
+        val rootView = super.createRootView()
+        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        return rootView
+    }
+}

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -82,6 +82,8 @@ describe("npm pack", () => {
       "android/app/src/no-fabric/java/com/microsoft/reacttestapp/fabric/FabricJSIModulePackage.kt",
       "android/app/src/no-turbomodule/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt",
       "android/app/src/no-turbomodule/java/com/microsoft/reacttestapp/fabric/ComponentsRegistry.kt",
+      "android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
+      "android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactinstanceeventlistener-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt",
       "android/app/src/reactinstanceeventlistener-pre-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt",
       "android/app/src/turbomodule/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt",


### PR DESCRIPTION
### Description

Fix Fabric cannot be enabled on 0.72

Prerequisite for #1359.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.72
yarn
cd example

# Set `newArchEnabled=true` in /example/gradle.properties

yarn android
```