### PR TITLE
Fix compiling SceneDelegate with Xcode 14.3

### DIFF
--- a/ios/ReactTestApp/SceneDelegate.swift
+++ b/ios/ReactTestApp/SceneDelegate.swift
@@ -54,7 +54,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             object: [
                 "scene": scene,
                 "URLContexts": URLContexts,
-            ]
+            ] as [String: Any]
         )
 
         // scene(_:openURLContexts:)


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

When compiling the `react-native-test-app` with `react-native` 0.71.6 and Xcode 14.3 for iOS, I started to get the following error:
```
❌  /some-path/fixture/node_modules/.generated/ios/ReactTestApp/SceneDelegate.swift:54:21: heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional

            object: [
                    ^
```

The fix in this PR just adds `as [String: Any]` as the error message suggests.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

Try `react-native-test-app` with `react-native` 0.71.6 and Xcode 14.3