### PR TITLE
fix(android): fix multiple Kotlin Gradle plugin loads warning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
     id("com.android.application")
     id("com.google.devtools.ksp").version("${kspVersion}")
-    id("org.jetbrains.kotlin.android").version("${kotlinVersion}")
+    id("org.jetbrains.kotlin.android")
 }
 
 def reactNativePath = file(findNodeModulesPath("react-native", rootDir))

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -54,7 +54,7 @@ ext {
         : "7.3.1"
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")
         ? rootProject.properties["KOTLIN_VERSION"]
-        : "1.7.10"
+        : "1.7.22"
     kspVersion = getKspVersion(kotlinVersion)
 
     /**
@@ -86,7 +86,10 @@ ext {
     ]
 
     getReactNativeDependencies = {
-        def dependencies = ["com.android.tools.build:gradle:${androidPluginVersion}"]
+        def dependencies = [
+          "com.android.tools.build:gradle:${androidPluginVersion}",
+          "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}",
+        ]
 
         if (autodetectReactNativeVersion || enableNewArchitecture) {
             dependencies << "com.facebook.react:react-native-gradle-plugin"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -39,7 +39,7 @@ android.enableJetifier=true
 #newArchEnabled=true
 
 # Uncomment the line below if building react-native from source
-#ANDROID_NDK_VERSION=21.4.7075529
+#ANDROID_NDK_VERSION=23.1.7779620
 
 # Version of Kotlin to build against.
 #KOTLIN_VERSION=1.7.22

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -42,4 +42,4 @@ android.enableJetifier=true
 #ANDROID_NDK_VERSION=21.4.7075529
 
 # Version of Kotlin to build against.
-#KOTLIN_VERSION=1.7.10
+#KOTLIN_VERSION=1.7.22


### PR DESCRIPTION
### Description

Building the example app currently outputs the following warning:

```
% ./gradlew assembleDebug
Configuration on demand is an incubating feature.

The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
The Kotlin plugin was loaded in the following projects: ':app', ':react-native-safe-area-context'
```

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

There should be no warning when running `./gradlew assembleDebug`.