### PR TITLE
ci: ccache keeps accumulating cruft, making setup slower

### DIFF
--- a/.ccache/ccache.conf
+++ b/.ccache/ccache.conf
@@ -1,5 +1,6 @@
 depend_mode = true
 direct_mode = true
 hard_link = true
+max_size = 1G
 run_second_cpp = true
 sloppiness = file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,modules,system_headers,time_macros

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -68,5 +68,4 @@ runs:
       uses: actions/cache@v3
       with:
         path: .ccache
-        key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-ccache-${{ steps.setup-ccache.outputs.cache-key }}
-        restore-keys: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-ccache-
+        key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-ccache-${{ steps.setup-ccache.outputs.cache-key }}-1


### PR DESCRIPTION
### Description

Reset ccache and don't reuse older cache.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.