### PR TITLE
fix: bump `react-native-safe-area-context` to fix for xcode 14.3

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -236,7 +236,7 @@ PODS:
   - React-jsinspector (0.71.6)
   - React-logger (0.71.6):
     - glog
-  - react-native-safe-area-context (4.5.0):
+  - react-native-safe-area-context (4.5.1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -471,7 +471,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: fbbbda979d16e09825cced680f799108bec2ab58
   React-jsinspector: d5ce2ef3eb8fd30c28389d0bc577918c70821bd6
   React-logger: 9332c3e7b4ef007a0211c0a9868253aac3e1da82
-  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
+  react-native-safe-area-context: f5549f36508b1b7497434baa0cd97d7e470920d4
   React-perflogger: 43392072a5b867a504e2b4857606f8fc5a403d7f
   React-RCTActionSheet: c7b67c125bebeda9fb19fc7b200d85cb9d6899c4
   React-RCTAnimation: c2de79906f607986633a7114bee44854e4c7e2f5

--- a/example/package.json
+++ b/example/package.json
@@ -32,7 +32,7 @@
     "react": "18.2.0",
     "react-native": "^0.71.6",
     "react-native-macos": "^0.71.0",
-    "react-native-safe-area-context": "^4.5.0",
+    "react-native-safe-area-context": "^4.5.1",
     "react-native-test-app": "workspace:.",
     "react-native-windows": "^0.71.4"
   },

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -20,7 +20,7 @@ index c9cd14d..f63758d 100644
  import { Colors, Header } from "react-native/Libraries/NewAppScreen";
 @@ -169,7 +169,6 @@ const App = ({ concurrentRoot }) => {
    );
-
+ 
    return (
 -    <SafeAreaProvider>
        <SafeAreaView style={styles.body}>
@@ -33,7 +33,7 @@ index c9cd14d..f63758d 100644
 -    </SafeAreaProvider>
    );
  };
-
+ 
 diff --git a/example/package.json b/example/package.json
 index 9c2e1aa..94fb85e 100644
 --- a/example/package.json

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -20,7 +20,7 @@ index c9cd14d..f63758d 100644
  import { Colors, Header } from "react-native/Libraries/NewAppScreen";
 @@ -169,7 +169,6 @@ const App = ({ concurrentRoot }) => {
    );
- 
+
    return (
 -    <SafeAreaProvider>
        <SafeAreaView style={styles.body}>
@@ -33,7 +33,7 @@ index c9cd14d..f63758d 100644
 -    </SafeAreaProvider>
    );
  };
- 
+
 diff --git a/example/package.json b/example/package.json
 index 9c2e1aa..94fb85e 100644
 --- a/example/package.json
@@ -42,7 +42,7 @@ index 9c2e1aa..94fb85e 100644
      "react": "18.2.0",
      "react-native": "^0.71.6",
      "react-native-macos": "^0.71.0",
--    "react-native-safe-area-context": "^4.5.0",
+-    "react-native-safe-area-context": "^4.5.1",
      "react-native-test-app": "workspace:.",
      "react-native-windows": "^0.71.4"
    },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,7 +5455,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.71.6
     react-native-macos: ^0.71.0
-    react-native-safe-area-context: ^4.5.0
+    react-native-safe-area-context: ^4.5.1
     react-native-test-app: "workspace:."
     react-native-windows: ^0.71.4
   peerDependencies:
@@ -9847,13 +9847,13 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "react-native-safe-area-context@npm:4.5.0"
+"react-native-safe-area-context@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "react-native-safe-area-context@npm:4.5.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 958df1d20492aa89c23d746f88409a3a3bd1b0d397c80310a4b0bbec9888cbbeb7579c9c92dad46841e2e6536491806206228ba009b7c8af970670aef8273a30
+  checksum: 5eb4e8d57f0fd072cbef74c7a31685149590706a3b0a05d7598fdbf6aa69707d09e9fb44494d2aa93c5f4ec9b669da10476b5e858f6b92d1d4290c3f94e43c4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

While testing https://github.com/microsoft/react-native-test-app/pull/1363 I noticed that we needed this bump https://github.com/th3rdwave/react-native-safe-area-context/releases/tag/v4.5.1 or iOS won't build.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Run 
```
cd example
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=ios
yarn ios
```

without this bump, it will fail with the "value 12.0" error.