### PR TITLE
feat: add post_install option to use_test_app

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -430,6 +430,7 @@ def use_test_app_internal!(target_platform, options)
 
   post_install do |installer|
     react_native_post_install&.call(installer)
+    options[:post_install]&.call(installer)
 
     test_dependencies = {}
     %w[ReactTestAppTests ReactTestAppUITests].each do |target|


### PR DESCRIPTION
Some libraries like @rnmapbox/maps requires `post_install` hooks to cocoa pods. Add post_install option to `use_test_app!`

```jsx
use_test_app!(post_install: ->(installer) { $RNMapboxMaps.post_install(installer) })
```