### PR TITLE
fix(android): fix Android nightly build failure

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/AppRegistry.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/AppRegistry.kt
@@ -13,8 +13,8 @@ class AppRegistry {
         }
 
         fun getAppKeys(context: ReactApplicationContext): Array<String> {
-            val appKeys = AppRegistry().getAppKeys(context.javaScriptContextHolder.get())
-                ?: return arrayOf()
+            val jsContext = context.javaScriptContextHolder?.get() ?: return arrayOf()
+            val appKeys = AppRegistry().getAppKeys(jsContext) ?: return arrayOf()
             return appKeys.filterIsInstance<String>().toTypedArray()
         }
     }


### PR DESCRIPTION
### Description

Upstream recently added `@Nullable` to `javaScriptContextHolder`:

```
e: /~/android/app/src/main/java/com/microsoft/reacttestapp/react/AppRegistry.kt: (16, 83): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type JavaScriptContextHolder?
```

Full build log: https://github.com/microsoft/react-native-test-app/actions/runs/4750360630/jobs/8438470213

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example/android
./gradlew assembleDebug
```