### PR TITLE
fix: load `@react-native/metro-config` if available

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,10 +1,3 @@
-/**
- * Metro configuration for React Native
- * https://github.com/facebook/react-native
- *
- * @format
- */
-
 const path = require("path");
 
 const exclusionList = (() => {
@@ -34,7 +27,7 @@ const blockList = exclusionList([
   /.*\.ProjectImports\.zip/,
 ]);
 
-module.exports = {
+const config = {
   resolver: {
     blacklistRE: blockList,
     blockList,
@@ -48,3 +41,14 @@ module.exports = {
     }),
   },
 };
+
+try {
+  // Starting with react-native 0.72, we are required to provide a full config.
+  const {
+    getDefaultConfig,
+    mergeConfig,
+  } = require("@react-native/metro-config");
+  module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+} catch (_) {
+  module.exports = config;
+}

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -258,6 +258,7 @@ async function getProfile(v) {
       const commonDeps = await resolveCommonDependencies(info);
       return {
         ...commonDeps,
+        "@react-native/metro-config": "latest",
         "react-native": "nightly",
         "react-native-macos": undefined,
         "react-native-windows": undefined,
@@ -265,15 +266,21 @@ async function getProfile(v) {
     }
 
     default: {
-      const [reactNative, { version: rnmVersion }, { version: rnwVersion }] =
-        await Promise.all([
-          fetchPackageInfo(`react-native@^${v}.0-0`),
-          fetchPackageInfo(`react-native-macos@^${v}.0-0`),
-          fetchPackageInfo(`react-native-windows@^${v}.0-0`),
-        ]);
+      const [
+        { version: rnMetroConfig },
+        reactNative,
+        { version: rnmVersion },
+        { version: rnwVersion },
+      ] = await Promise.all([
+        fetchPackageInfo(`@react-native/metro-config@^${v}.0-0`),
+        fetchPackageInfo(`react-native@^${v}.0-0`),
+        fetchPackageInfo(`react-native-macos@^${v}.0-0`),
+        fetchPackageInfo(`react-native-windows@^${v}.0-0`),
+      ]);
       const commonDeps = await resolveCommonDependencies(reactNative);
       return {
         ...commonDeps,
+        "@react-native/metro-config": rnMetroConfig,
         "react-native": reactNative.version,
         "react-native-macos": rnmVersion,
         "react-native-windows": rnwVersion,


### PR DESCRIPTION
### Description

Starting with react-native 0.72, we are required to provide a full config.

Prerequisite for #1359.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

To properly verify this, you'll need to cherry-pick the fix from https://github.com/microsoft/react-native-test-app/pull/1404.

```
npm run set-react-version nightly
yarn
cd example
yarn android

# Open a new terminal
yarn start
```

| Screenshot |
| :-: |
| ![Screenshot_1681992627](https://user-images.githubusercontent.com/4123478/233362411-62197a67-71b7-4ae7-9622-815696d2f145.png) |
