### PR TITLE
fix(android): handle `DevServerHelper` constructor signature change

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -301,52 +301,36 @@ android {
     }
 
     sourceSets {
-        if (project.ext.react.enableCamera) {
-            main.java.srcDirs += "src/camera/java"
-        } else {
-            main.java.srcDirs += "src/no-camera/java"
-        }
+        main.java.srcDirs += [
+            project.ext.react.enableCamera ? "src/camera/java" : "src/no-camera/java",
+
+            // TODO: Remove this block when we drop support for 0.67
+            project.ext.react.enableFabric ? "src/fabric/java" : "src/no-fabric/java",
+
+            // TODO: Remove this block when we drop support for 0.65
+            enableNewArchitecture ? "src/turbomodule/java" : "src/no-turbomodule/java",
+
+            // TODO: Remove this block when we drop support for 0.67
+            // https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4
+            reactNativeVersion > 0 && reactNativeVersion < 6800
+                ? "src/reactinstanceeventlistener-pre-0.68/java"
+                : "src/reactinstanceeventlistener-0.68/java",
+
+            // TODO: Remove this block when we drop support for 0.72
+            // https://github.com/facebook/react-native/commit/e5dd9cdc6688e63e75a7e0bebf380be1a9a5fe2b
+            reactNativeVersion > 0 && reactNativeVersion < 7200
+                ? "src/reactactivitydelegate-pre-0.72/java"
+                : "src/reactactivitydelegate-0.72/java",
+
+            // TODO: Remove this block when we drop support for 0.73
+            // https://github.com/facebook/react-native/commit/da358d0ec7a492edb804b9cdce70e7516ee518ae
+            reactNativeVersion > 0 && reactNativeVersion < 7300
+                ? "src/devserverhelper-pre-0.73/java"
+                : "src/devserverhelper-0.73/java",
+        ]
 
         if (project.ext.react.enableFlipper) {
             debug.java.srcDirs += "src/flipper/java"
-        }
-
-        // TODO: Remove this block when we drop support for 0.67
-        if (project.ext.react.enableFabric) {
-            main.java.srcDirs += "src/fabric/java"
-        } else {
-            main.java.srcDirs += "src/no-fabric/java"
-        }
-
-        // TODO: Remove this block when we drop support for 0.65
-        if (enableNewArchitecture) {
-            main.java.srcDirs += "src/turbomodule/java"
-        } else {
-            main.java.srcDirs += "src/no-turbomodule/java"
-        }
-
-        // TODO: Remove this block when we drop support for 0.67
-        // https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4
-        if (reactNativeVersion > 0 && reactNativeVersion < 6800) {
-            main.java.srcDirs += "src/reactinstanceeventlistener-pre-0.68/java"
-        } else {
-            main.java.srcDirs += "src/reactinstanceeventlistener-0.68/java"
-        }
-
-        // TODO: Remove this block when we drop support for 0.72
-        // https://github.com/facebook/react-native/commit/e5dd9cdc6688e63e75a7e0bebf380be1a9a5fe2b
-        if (reactNativeVersion > 0 && reactNativeVersion < 7200) {
-            main.java.srcDirs += "src/reactactivitydelegate-pre-0.72/java"
-        } else {
-            main.java.srcDirs += "src/reactactivitydelegate-0.72/java"
-        }
-
-        // TODO: Remove this block when we drop support for 0.73
-        // https://github.com/facebook/react-native/commit/da358d0ec7a492edb804b9cdce70e7516ee518ae
-        if (reactNativeVersion > 0 && reactNativeVersion < 7300) {
-            main.java.srcDirs += "src/devserverhelper-pre-0.73/java"
-        } else {
-            main.java.srcDirs += "src/devserverhelper-0.73/java"
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -340,6 +340,14 @@ android {
         } else {
             main.java.srcDirs += "src/reactactivitydelegate-0.72/java"
         }
+
+        // TODO: Remove this block when we drop support for 0.73
+        // https://github.com/facebook/react-native/commit/da358d0ec7a492edb804b9cdce70e7516ee518ae
+        if (reactNativeVersion > 0 && reactNativeVersion < 7300) {
+            main.java.srcDirs += "src/devserverhelper-pre-0.73/java"
+        } else {
+            main.java.srcDirs += "src/devserverhelper-0.73/java"
+        }
     }
 
     splits {

--- a/android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -1,0 +1,16 @@
+package com.microsoft.reacttestapp.react
+
+import android.content.Context
+import com.facebook.react.devsupport.DevServerHelper
+import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+
+fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper {
+    return DevServerHelper(
+        developerSettings,
+        context.packageName,
+        { BundleStatus() },
+        PackagerConnectionSettings(context)
+    )
+}

--- a/android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -1,0 +1,18 @@
+package com.microsoft.reacttestapp.react
+
+import android.content.Context
+import com.facebook.react.devsupport.DevInternalSettings
+import com.facebook.react.devsupport.DevServerHelper
+import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings
+
+fun createDevServerHelper(
+    context: Context,
+    @Suppress("UNUSED_PARAMETER") developerSettings: DeveloperSettings
+): DevServerHelper {
+    return DevServerHelper(
+        DevInternalSettings(context) {},
+        context.packageName,
+        { BundleStatus() }
+    )
+}

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -12,9 +12,6 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.devsupport.DevInternalSettings
-import com.facebook.react.devsupport.DevServerHelper
-import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.modules.systeminfo.ReactNativeVersion
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
@@ -212,13 +209,12 @@ class TestAppReactNativeHost(
         val latch = CountDownLatch(1)
         var packagerIsRunning = false
 
-        DevServerHelper(
-            DevInternalSettings(context) {},
-            context.packageName
-        ) { BundleStatus() }.isPackagerRunning {
+        val devSettings = reactInstanceManager.devSupportManager.devSettings
+        createDevServerHelper(context, devSettings).isPackagerRunning {
             packagerIsRunning = it
             latch.countDown()
         }
+
         latch.await()
         return packagerIsRunning
     }

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -31,6 +31,8 @@ describe("npm pack", () => {
       "android/app/lint.xml",
       "android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt",
       "android/app/src/camera/java/com/microsoft/reacttestapp/camera/QRCodeScannerFragment.kt",
+      "android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
+      "android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
       "android/app/src/fabric/java/com/microsoft/reacttestapp/fabric/FabricJSIModulePackage.kt",
       "android/app/src/flipper/java/com/microsoft/reacttestapp/ReactNativeFlipper.kt",
       "android/app/src/main/AndroidManifest.xml",


### PR DESCRIPTION
### Description

The signature of the `DevServerHelper` constructor recently changed.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
# cherry-pick https://github.com/microsoft/react-native-test-app/pull/1388
npm run set-react-version nightly
yarn

# manually apply https://github.com/facebook/react-native/pull/37332
cd example
yarn android
```

#### Screenshots

| 0.71 | nightly |
| :-: | :-: |
| ![Screenshot_1683633374](https://github.com/microsoft/react-native-test-app/assets/4123478/55af1d62-a611-4455-bada-5a75363c7ca6) | ![Screenshot_1683633107](https://github.com/microsoft/react-native-test-app/assets/4123478/3787a073-858b-468f-ba46-2222703cc5e6) |
