### PR TITLE
fix: inifite loop when passing certain paths to `findFile`

### DIFF
--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -26,16 +26,18 @@ const BUILD_PROPS = [
  * @returns {string | undefined}
  */
 function findFile(file, startDir = process.cwd()) {
-  let candidate = path.join(startDir, file);
+  let currentDir = startDir;
+  let candidate = path.join(currentDir, file);
   while (!fs.existsSync(candidate)) {
-    const cwd = path.dirname(candidate);
-    const parent = path.dirname(cwd);
-    if (parent === cwd) {
+    const nextDir = path.dirname(currentDir);
+    if (nextDir === currentDir) {
       return undefined;
     }
 
-    candidate = path.join(parent, file);
+    currentDir = nextDir;
+    candidate = path.join(currentDir, file);
   }
+
   return candidate;
 }
 


### PR DESCRIPTION
### Description

`findFile` assumes the first parameter is always a filename. If a path is passed, the root directory is never reached and thus not terminate the loop.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/react-native-test-app/issues/1428.