### PR TITLE
fix: fix `@expo/config-plugins` no longer working

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('test/test_*.rb').each { |file| require_relative file }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.2.5",
+    "@rnx-kit/react-native-host": "^0.2.6",
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
     "cliui": "^8.0.0",

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -7,15 +7,15 @@ const { withMod } = require("@expo/config-plugins");
  */
 
 /**
- * Provides the `BridgeDelegate` file for modification.
+ * Provides the `ReactNativeHost` file for modification.
  * @param {ExportedConfig} config Exported config
  * @param {Mod} action Method to run on the mod when the config is compiled
  * @returns {ExportedConfig} Modified config
  */
-function withBridgeDelegate(config, action) {
+function withReactNativeHost(config, action) {
   return withMod(config, {
     platform: "ios",
-    mod: "bridgeDelegate",
+    mod: "reactNativeHost",
     action,
   });
 }
@@ -34,5 +34,5 @@ function withSceneDelegate(config, action) {
   });
 }
 
-exports.withBridgeDelegate = withBridgeDelegate;
+exports.withReactNativeHost = withReactNativeHost;
 exports.withSceneDelegate = withSceneDelegate;

--- a/scripts/config-plugins/plugins/withIosBaseMods.mjs
+++ b/scripts/config-plugins/plugins/withIosBaseMods.mjs
@@ -1,8 +1,15 @@
 // @ts-check
+import { createRequire } from "module";
+import * as path from "path";
 import { BaseMods } from "../ExpoConfigPlugins.mjs";
 import { makeFilePathModifier, makeNullProvider } from "../provider.mjs";
 
 const modifyFilePath = makeFilePathModifier("node_modules/.generated/ios");
+
+const require = createRequire(import.meta.url);
+const modifyReactNativeHostFilePath = makeFilePathModifier(
+  path.dirname(require.resolve("@rnx-kit/react-native-host/package.json"))
+);
 
 const nullProvider = makeNullProvider();
 
@@ -30,13 +37,15 @@ const defaultProviders = {
 };
 
 // `react-native-test-app` files
-defaultProviders["bridgeDelegate"] = modifyFilePath(
-  expoProviders.appDelegate,
-  "ReactTestApp/BridgeDelegate.mm"
-);
 defaultProviders["sceneDelegate"] = modifyFilePath(
   expoProviders.appDelegate,
   "ReactTestApp/SceneDelegate.swift"
+);
+
+// `@rnx-kit/react-native-host` files
+defaultProviders["reactNativeHost"] = modifyReactNativeHostFilePath(
+  expoProviders.appDelegate,
+  "cocoa/ReactNativeHost.mm"
 );
 
 export function getIosModFileProviders() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,12 +2677,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "@rnx-kit/react-native-host@npm:0.2.5"
+"@rnx-kit/react-native-host@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@rnx-kit/react-native-host@npm:0.2.6"
   peerDependencies:
     react-native: ">=0.64"
-  checksum: 2a2cfb1cb227697d42640af3e71bd141e8ec33cd9e91345c7696ddf06709d525521604ec084babe916ac4afe1918a579938315d26e5183e973e75eb539ea9b78
+  checksum: cc160c9cd90d90afbd1e5ed477dcfad609fa8d3bdd1ae115eea0b10632f02df117be1bd6d36c20cab78edf54daf0de0d85d699a9343c2c2ce93641b0bc864058
   languageName: node
   linkType: hard
 
@@ -9880,7 +9880,7 @@ fsevents@^2.3.2:
     "@react-native-community/cli-platform-ios": ^10.2.1
     "@rnx-kit/commitlint-lite": ^1.0.0
     "@rnx-kit/eslint-plugin": ^0.4.0
-    "@rnx-kit/react-native-host": ^0.2.5
+    "@rnx-kit/react-native-host": ^0.2.6
     "@types/jest": ^29.0.0
     "@types/mustache": ^4.0.0
     "@types/node": ^16.0.0


### PR DESCRIPTION
### Description

After refactoring to use `@rnx-kit/react-native-host` in 2.4.0, config plugins stopped working because RNTA no longer owns the host.

Blocked by:
- [x] https://github.com/microsoft/react-native-test-app/pull/1430
- [x] https://github.com/microsoft/rnx-kit/pull/2420

Resolves https://github.com/microsoft/react-native-test-app/issues/1428.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/react-native-test-app/issues/1428.