### PR TITLE
fix: autorecalculate the key view loop on the macOS window

### DIFF
--- a/macos/ReactTestApp/Base.lproj/Main.storyboard
+++ b/macos/ReactTestApp/Base.lproj/Main.storyboard
@@ -453,7 +453,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" identifier="MainWindow" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="MainWindow" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" identifier="MainWindow" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="MainWindow" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>


### PR DESCRIPTION
### Description

Without this, keyboard accessibility doesn't work in any macOS test app 🤷🏾

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

Tested in FluentUI React Native. I can now Tab across the controls without hacks.
