### PR TITLE
chore: remove unused Yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@rnx-kit/eslint-plugin": "^0.4.0",
     "@types/jest": "^29.0.0",
     "@types/mustache": "^4.0.0",
-    "@types/node": "^16.0.0",
+    "@types/node": "^18.0.0",
     "@types/prompts": "~2.4.0",
     "@types/semver": "^7.3.6",
     "@types/uuid": "^8.3.1",
@@ -159,9 +159,7 @@
   "resolutions": {
     "@expo/config-plugins/glob": "^7.1.6",
     "@microsoft/eslint-plugin-sdl/eslint-plugin-react": "^7.26.0",
-    "@react-native-community/cli-platform-ios": "^10.2.1",
-    "@semantic-release/npm/npm": "link:./example",
-    "core-js-compat/semver": "^7.3.5"
+    "@semantic-release/npm/npm": "link:./example"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,7 +2578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-ios@npm:^10.2.1":
+"@react-native-community/cli-platform-ios@npm:10.2.1, @react-native-community/cli-platform-ios@npm:^10.2.1":
   version: 10.2.1
   resolution: "@react-native-community/cli-platform-ios@npm:10.2.1"
   dependencies:
@@ -3092,10 +3092,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^16.0.0":
-  version: 16.18.34
-  resolution: "@types/node@npm:16.18.34"
-  checksum: 35c0ffe09687578d002ceb7e706d0ba450546aeb3d2716f28691f2af0063bd274dbde0f741d087ea217f2a8db413eb700d22dfb4f08a67986ff801423bd7be8d
+"@types/node@npm:*, @types/node@npm:^18.0.0":
+  version: 18.16.16
+  resolution: "@types/node@npm:18.16.16"
+  checksum: 0efad726dd1e0bef71c392c708fc5d78c5b39c46b0ac5186fee74de4ccb1b2e847b3fa468da67d62812f56569da721b15bf31bdc795e6c69b56c73a45079ed2d
   languageName: node
   linkType: hard
 
@@ -10027,7 +10027,7 @@ fsevents@^2.3.2:
     "@rnx-kit/react-native-host": ^0.2.6
     "@types/jest": ^29.0.0
     "@types/mustache": ^4.0.0
-    "@types/node": ^16.0.0
+    "@types/node": ^18.0.0
     "@types/prompts": ~2.4.0
     "@types/semver": ^7.3.6
     "@types/uuid": ^8.3.1


### PR DESCRIPTION
### Description

Remove unused Yarn resolutions, and bump `@types/node` to v18.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.