### PR TITLE
chore(macos): remove workaround for missing `FlipperConfiguration`

### DIFF
--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -12,12 +12,6 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
-  # TODO: Remove this block when react-native-macos catches up to core.
-  unless defined?(FlipperConfiguration)
-    require_relative('use_react_native-0.68')
-    return include_react_native!(options)
-  end
-
   if target_platform == :ios && flipper_versions
     Pod::UI.warn(
       'use_flipper is deprecated from 0.70; use the flipper_configuration ' \


### PR DESCRIPTION
### Description

Removes workaround for when react-native-macos was in-between 0.69 and 0.70.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a