### PR TITLE
fix: update Reanimated config plugin to support 3.3

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -456,6 +456,16 @@ def use_test_app_internal!(target_platform, options)
           config.build_settings['WARNING_CFLAGS'] ||= ['$(inherited)']
           config.build_settings['WARNING_CFLAGS'] << '-Wno-nullability-completeness'
         end
+      when 'RNReanimated'
+        # Reanimated tries to automatically install itself by swizzling a method
+        # in `RCTAppDelegate`. We don't use it since it doesn't exist on older
+        # versions of React Native. Redirect users to the config plugin instead.
+        # See https://github.com/microsoft/react-native-test-app/issues/1195 and
+        # https://github.com/software-mansion/react-native-reanimated/commit/a8206f383e51251e144cb9fd5293e15d06896df0.
+        target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'DONT_AUTOINSTALL_REANIMATED'
+        end
       else
         # Ensure `ENABLE_TESTING_SEARCH_PATHS` is always set otherwise Xcode may
         # fail to properly import XCTest

--- a/plugins/reanimated.js
+++ b/plugins/reanimated.js
@@ -53,13 +53,13 @@ function installerFor(version, indent = "    ") {
     "",
     "#if __has_include(<reacthermes/HermesExecutorFactory.h>)",
     "#import <reacthermes/HermesExecutorFactory.h>",
-    "using ExecutorFactory = HermesExecutorFactory;",
+    "using ExecutorFactory = facebook::react::HermesExecutorFactory;",
     "#elif __has_include(<React/HermesExecutorFactory.h>)",
     "#import <React/HermesExecutorFactory.h>",
-    "using ExecutorFactory = HermesExecutorFactory;",
+    "using ExecutorFactory = facebook::react::HermesExecutorFactory;",
     "#else",
     "#import <React/JSCExecutorFactory.h>",
-    "using ExecutorFactory = JSCExecutorFactory;",
+    "using ExecutorFactory = facebook::react::JSCExecutorFactory;",
     "#endif",
     "",
     "#pragma clang diagnostic pop",
@@ -76,6 +76,7 @@ function installerFor(version, indent = "    ") {
     // As of React Native 0.72, we need to call `REAInitializer` instead. See
     // https://github.com/software-mansion/react-native-reanimated/commit/a8206f383e51251e144cb9fd5293e15d06896df0.
     const installer = [
+      `${indent}reanimated::REAInitializer(bridge);`,
       `${indent}return std::make_unique<ExecutorFactory>(`,
       `${indent}${indent}facebook::react::RCTJSIExecutorRuntimeInstaller([](facebook::jsi::Runtime &) {}));`,
     ].join("\n");

--- a/plugins/reanimated.js
+++ b/plugins/reanimated.js
@@ -3,6 +3,7 @@ const { createRunOncePlugin } = require("@expo/config-plugins");
 const {
   mergeContents,
 } = require("@expo/config-plugins/build/utils/generateCode");
+const fs = require("fs");
 const { withReactNativeHost } = require("./index");
 
 /**
@@ -30,9 +31,69 @@ function addContents(tag, src, newSrc, anchor) {
   }).contents;
 }
 
-function rnMinorVersion() {
-  const { version } = require("react-native/package.json");
-  return version.split(".")[1];
+/**
+ * Returns the code that initializes Reanimated.
+ * @param {number} version
+ * @param {string} indent
+ * @returns {[string, string]}
+ */
+function installerFor(version, indent = "    ") {
+  const minorVersion = Math.trunc(version / 100) % 100;
+  const header = [
+    "#if !USE_TURBOMODULE",
+    "#pragma clang diagnostic push",
+    '#pragma clang diagnostic ignored "-Wnullability-completeness"',
+    "",
+    `#define REACT_NATIVE_MINOR_VERSION ${minorVersion}`,
+    "#import <RNReanimated/REAInitializer.h>",
+    "",
+    "#if __has_include(<React/RCTJSIExecutorRuntimeInstaller.h>)",
+    "#import <React/RCTJSIExecutorRuntimeInstaller.h>",
+    "#endif",
+    "",
+    "#if __has_include(<reacthermes/HermesExecutorFactory.h>)",
+    "#import <reacthermes/HermesExecutorFactory.h>",
+    "using ExecutorFactory = HermesExecutorFactory;",
+    "#elif __has_include(<React/HermesExecutorFactory.h>)",
+    "#import <React/HermesExecutorFactory.h>",
+    "using ExecutorFactory = HermesExecutorFactory;",
+    "#else",
+    "#import <React/JSCExecutorFactory.h>",
+    "using ExecutorFactory = JSCExecutorFactory;",
+    "#endif",
+    "",
+    "#pragma clang diagnostic pop",
+    "#endif  // !USE_TURBOMODULE",
+  ].join("\n");
+
+  if (version > 0 && version < 7200) {
+    const installer = [
+      `${indent}const auto installer = reanimated::REAJSIExecutorRuntimeInstaller(bridge, nullptr);`,
+      `${indent}return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(installer));`,
+    ].join("\n");
+    return [header, installer];
+  } else {
+    // As of React Native 0.72, we need to call `REAInitializer` instead. See
+    // https://github.com/software-mansion/react-native-reanimated/commit/a8206f383e51251e144cb9fd5293e15d06896df0.
+    const installer = [
+      `${indent}return std::make_unique<ExecutorFactory>(`,
+      `${indent}${indent}facebook::react::RCTJSIExecutorRuntimeInstaller([](facebook::jsi::Runtime &) {}));`,
+    ].join("\n");
+    return [header, installer];
+  }
+}
+
+/**
+ * Returns the version number of the specified package.
+ * @param {string} pkg
+ * @returns {number} The version number
+ */
+function versionOf(pkg) {
+  const manifestPath = require.resolve(pkg + "/package.json");
+  const manifest = fs.readFileSync(manifestPath, { encoding: "utf-8" });
+  const { version } = JSON.parse(manifest);
+  const [major, minor, patch] = version.split("-")[0].split(".").map(Number);
+  return major * 10000 + minor * 100 + patch;
 }
 
 /**
@@ -51,46 +112,24 @@ function withReanimatedExecutor(config) {
       );
     }
 
+    const [header, installer] = installerFor(versionOf("react-native"));
+
     // Add Reanimated headers
     config.modResults.contents = addContents(
       "header",
       config.modResults.contents,
-      [
-        "#if !USE_TURBOMODULE",
-        "#pragma clang diagnostic push",
-        '#pragma clang diagnostic ignored "-Wnullability-completeness"',
-        "",
-        `#define REACT_NATIVE_MINOR_VERSION ${rnMinorVersion()}`,
-        "#import <RNReanimated/REAInitializer.h>",
-        "",
-        "#if __has_include(<reacthermes/HermesExecutorFactory.h>)",
-        "#import <reacthermes/HermesExecutorFactory.h>",
-        "using ExecutorFactory = HermesExecutorFactory;",
-        "#elif __has_include(<React/HermesExecutorFactory.h>)",
-        "#import <React/HermesExecutorFactory.h>",
-        "using ExecutorFactory = HermesExecutorFactory;",
-        "#else",
-        "#import <React/JSCExecutorFactory.h>",
-        "using ExecutorFactory = JSCExecutorFactory;",
-        "#endif",
-        "",
-        "#pragma clang diagnostic pop",
-        "#endif  // !USE_TURBOMODULE",
-      ].join("\n"),
+      header,
       /#import "ReactNativeHost\.h"/
     );
 
     // Install Reanimated's JSI executor runtime
-    const indent = "    ";
     config.modResults.contents = addContents(
-      "executor",
+      "installer",
       config.modResults.contents,
-      [
-        `${indent}const auto installer = reanimated::REAJSIExecutorRuntimeInstaller(bridge, nullptr);`,
-        `${indent}return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(installer));`,
-      ].join("\n"),
+      installer,
       /\/\/ jsExecutorFactoryForBridge: \(USE_TURBOMODULE=0\)/
     );
+
     return config;
   });
 }


### PR DESCRIPTION
### Description

Resolves #1456.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Apply the following patch:

```diff
diff --git a/example/App.js b/example/App.js
index c9cd14d..b3bce70 100644
--- a/example/App.js
+++ b/example/App.js
@@ -10,6 +10,7 @@ import {
   useColorScheme,
   View,
 } from "react-native";
+import Animated from "react-native-reanimated";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 // @ts-expect-error
 import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
@@ -179,6 +180,16 @@ const App = ({ concurrentRoot }) => {
         >
           <Header />
           <DevMenu />
+          <Animated.View
+            style={[
+              {
+                width: 100,
+                height: 80,
+                backgroundColor: "orange",
+                margin: 30,
+              },
+            ]}
+          />
           <View style={styles.group}>
             <Feature value={getReactNativeVersion()}>React Native</Feature>
             <Separator />
diff --git a/example/app.json b/example/app.json
index ef69fa7..c492b30 100644
--- a/example/app.json
+++ b/example/app.json
@@ -13,6 +13,9 @@
       "presentationStyle": "modal"
     }
   ],
+  "plugins": [
+    "react-native-test-app/plugins/reanimated.js"
+  ],
   "resources": {
     "android": [
       "dist/res",
diff --git a/example/babel.config.js b/example/babel.config.js
index 5ae49c3..8a4543d 100644
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ["module:metro-react-native-babel-preset"],
+  plugins: ["react-native-reanimated/plugin"],
 };
diff --git a/example/package.json b/example/package.json
index e2e6f42..824a173 100644
--- a/example/package.json
+++ b/example/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
+    "@expo/config-plugins": "^6.0.0",
     "@types/jest": "^29.0.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "^0.73.9",
@@ -32,6 +33,7 @@
     "react": "18.2.0",
     "react-native": "^0.71.6",
     "react-native-macos": "^0.71.0",
+    "react-native-reanimated": "^3.3.0",
     "react-native-safe-area-context": "^4.5.1",
     "react-native-test-app": "workspace:.",
     "react-native-windows": "^0.71.4"
```

Make sure it works with both 0.71 and 0.72.

### Screenshots

| 0.71 | 0.72 | Reference |
| :--: | :--: | :--: |
| ![image](https://github.com/microsoft/react-native-test-app/assets/4123478/3e4e0bf2-7965-403c-a5a9-00ed08f036ff) | ![image](https://github.com/microsoft/react-native-test-app/assets/4123478/4a6fc23d-580d-40da-8500-d3e1a1220e5d) | ![image](https://github.com/microsoft/react-native-test-app/assets/4123478/2a9474a9-3fc5-4413-8ea4-ba11dc215867) |