### PR TITLE
fix(android): fix compatibility with 0.73/nightlies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,8 +10,6 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-checkEnvironment()
-
 def reactNativePath = file(findNodeModulesPath("react-native", rootDir))
 
 if (autodetectReactNativeVersion || enableNewArchitecture) {
@@ -112,10 +110,13 @@ android {
 
     kotlinOptions {
         allWarningsAsErrors = true
-        if (reactNativeVersion > 0 && reactNativeVersion < 6900) {
-            jvmTarget = JavaVersion.VERSION_1_8
-        } else {
-            jvmTarget = JavaVersion.VERSION_11
+        if (reactNativeVersion > 0) {
+            if (reactNativeVersion < 6900) {
+                jvmTarget = JavaVersion.VERSION_1_8
+            } else if (reactNativeVersion < 7300) {
+                jvmTarget = JavaVersion.VERSION_11
+            }
+            // else let `@react-native/gradle-plugin` handle this
         }
     }
 

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,10 +1,24 @@
 /**
+ * Get the recommended Kotlin version for the specified React Native version.
+ */
+static String getDefaultKotlinVersion(int reactNativeVersion) {
+    // Kotlin version can be found in the template:
+    // https://github.com/facebook/react-native/blob/main/packages/react-native/template/android/build.gradle
+    if (reactNativeVersion == 0 || reactNativeVersion >= 7300) {
+        return "1.8.0"
+    } else {
+        return "1.7.21"
+    }
+}
+
+/**
  * Find the latest version of KSP that supports the specified Kotlin version.
  */
 static String getKspVersion(String kotlinVersion) {
     return [
         // Run `scripts/update-ksp-versions.mjs` to update this list
         // update-ksp-versions start
+        "1.8.22-1.0.11",
         "1.8.21-1.0.11",
         "1.8.20-1.0.11",
         "1.8.10-1.0.9",
@@ -56,7 +70,7 @@ ext {
         : "7.3.1"
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")
         ? rootProject.properties["KOTLIN_VERSION"]
-        : "1.7.22"
+        : getDefaultKotlinVersion(reactNativeVersion)
     kspVersion = getKspVersion(kotlinVersion)
 
     /**

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -6,29 +6,41 @@ import java.security.MessageDigest
 
 ext.manifest = null
 
-ext.checkEnvironment = {
+ext.checkEnvironment = { rootDir ->
+    def warnGradle = { gradleVersion, gradleVersionRange, reactNativeVersion ->
+        def message = [
+            "\n",
+            "Latest Gradle {} is recommended for React Native {}.\n",
+            "> Run the following command in the 'android' folder to install a supported version:\n",
+            "   > ./gradlew wrapper --gradle-version={}\n",
+            "> If the command above fails, you can manually modify 'gradle/wrapper/gradle-wrapper.properties'.",
+        ].join("")
+        logger.warn(message, gradleVersionRange, reactNativeVersion, gradleVersion)
+    }
+
+    // Gradle version can be found in the template:
+    // https://github.com/facebook/react-native/blob/main/packages/react-native/template/android/gradle/wrapper/gradle-wrapper.properties
     def (major, minor, patch) = gradle.gradleVersion.findAll(/\d+/)
     def gradleVersion = (major as int) * 10000 + (minor as int) * 100 + (patch as int)
-    if (reactNativeVersion > 0 && reactNativeVersion < 7200) {
-        if (gradleVersion < 70501 || gradleVersion >= 80000) {
-            logger.warn([
-                "Latest Gradle 7.x is required for current React Native version. ",
-                "Run the following command in the 'android' folder to install a supported version: ",
-                "./gradlew wrapper --gradle-version=7.6.1",
-            ].join(""))
+
+    def reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
+    if (reactNativeVersion == 0 || reactNativeVersion >= 7300) {
+        if (gradleVersion < 80100) {
+            warnGradle("8.1.1", "8.1.x", "0.73 and newer")
         }
-    } else {
+    } else if (reactNativeVersion >= 7200) {
         // Gradle 7.5+ seems to be working with 0.72 so we will only recommend a
         // newer version if it's older.
         if (gradleVersion < 70501) {
+            warnGradle("8.0.2", "8.0.x", "0.72")
             logger.warn([
-                "Latest Gradle 8.0.x is recommended for React Native 0.72 and higher. ",
-                "Run the following command in the 'android' folder to install a supported version: ",
-                "./gradlew wrapper --gradle-version=8.0.2",
-                "\n\n",
-                "If you still need to work with older versions of React Native, ",
-                "Gradle 7.5.1+ should still work."
+                "> If you still need to work with older versions of React Native, ",
+                "Gradle 7.5.1+ should still work.",
             ].join(""))
+        }
+    } else {
+        if (gradleVersion < 70501 || gradleVersion >= 80000) {
+            warnGradle("7.6.1", "7.x", "0.71 and older")
         }
     }
 }

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -1,5 +1,16 @@
+diff --git a/example/android/gradle/wrapper/gradle-wrapper.properties b/example/android/gradle/wrapper/gradle-wrapper.properties
+index 774fae8..fae0804 100644
+--- a/example/android/gradle/wrapper/gradle-wrapper.properties
++++ b/example/android/gradle/wrapper/gradle-wrapper.properties
+@@ -1,5 +1,5 @@
+ distributionBase=GRADLE_USER_HOME
+ distributionPath=wrapper/dists
+-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+ zipStoreBase=GRADLE_USER_HOME
+ zipStorePath=wrapper/dists
 diff --git a/example/package.json b/example/package.json
-index 9c2e1aa..94fb85e 100644
+index e2e6f42..6878533 100644
 --- a/example/package.json
 +++ b/example/package.json
 @@ -32,7 +32,6 @@

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -359,6 +359,19 @@ getProfile(version)
         manifest["devDependencies"][packageName] = version;
       }
 
+      // Reset resolutions so we don't get old packages
+      const resolutions = manifest["resolutions"];
+      if (resolutions) {
+        for (const pkg of Object.keys(resolutions)) {
+          if (
+            pkg.startsWith("@react-native-community/cli") ||
+            pkg.startsWith("metro")
+          ) {
+            resolutions[pkg] = undefined;
+          }
+        }
+      }
+
       const tmpFile = `${manifestPath}.tmp`;
       fs.writeFileSync(
         tmpFile,

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -26,6 +26,7 @@ private static void patchArgumentTypeMismatchError(String testAppDir, File rootD
 def testAppDir = buildscript.sourceFile.getParent()
 apply(from: "${testAppDir}/android/test-app-util.gradle")
 
+checkEnvironment(rootDir)
 patchArgumentTypeMismatchError(testAppDir, rootDir)
 
 if (findNodeModulesPath("@expo/config-plugins", rootDir)) {


### PR DESCRIPTION
### Description

Starting with 0.73, we need the following:

- Let `@react-native/gradle-plugin` set JVM target
- Gradle 8.1
- Kotlin 1.8

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
git apply scripts/disable-safe-area-context.patch
git apply scripts/android-nightly.patch
npm run set-react-version -- nightly
yarn
cd example/android
./gradlew assembleDebug
```