### PR TITLE
ci: nightlies require Xcode 14.3+

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -69,6 +69,7 @@ runs:
       if: ${{ inputs.xcode-developer-dir != '' }}
       run: |
         sudo xcode-select --switch ${{ inputs.xcode-developer-dir }}
+      shell: bash
     - name: Cache /.ccache
       if: ${{ steps.setup-ccache.outputs.cache-key }}
       uses: actions/cache@v3

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -10,6 +10,8 @@ inputs:
   cache-npm-dependencies:
     description: Caches npm dependencies (supports npm, yarn, pnpm v6.10+)
     default: yarn
+  xcode-developer-dir:
+    description: Set the path for the active Xcode developer directory
 runs:
   using: composite
   steps:
@@ -63,6 +65,10 @@ runs:
       with:
         node-version: 18
         cache: ${{ inputs.cache-npm-dependencies }}
+    - name: Set up Xcode
+      if: ${{ inputs.xcode-developer-dir != '' }}
+      run: |
+        sudo xcode-select --switch ${{ inputs.xcode-developer-dir }}
     - name: Cache /.ccache
       if: ${{ steps.setup-ccache.outputs.cache-key }}
       uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,9 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: example
+      - name: Select Xcode version
+        run: |
+          xcode-select --switch $DEVELOPER_DIR
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -191,6 +194,9 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
+      - name: Select Xcode version
+        run: |
+          xcode-select --switch $DEVELOPER_DIR
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -308,6 +314,9 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: example
+      - name: Select Xcode version
+        run: |
+          xcode-select --switch $DEVELOPER_DIR
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -369,6 +378,9 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
+      - name: Select Xcode version
+        run: |
+          xcode-select --switch $DEVELOPER_DIR
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ on:
     # Nightly builds against react-native@nightly at 4:00, Monday through Friday
     - cron: 0 4 * * 1-5
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   VisualStudioVersion: "17.0"
+  XCODE_DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
 concurrency:
   # Ensure single build of a pull request. `trunk` should not be affected.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
@@ -144,9 +144,7 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: example
-      - name: Select Xcode version
-        run: |
-          xcode-select --switch $DEVELOPER_DIR
+          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -194,9 +192,7 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
-      - name: Select Xcode version
-        run: |
-          xcode-select --switch $DEVELOPER_DIR
+          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -314,9 +310,7 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: example
-      - name: Select Xcode version
-        run: |
-          xcode-select --switch $DEVELOPER_DIR
+          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -378,9 +372,7 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
-      - name: Select Xcode version
-        run: |
-          xcode-select --switch $DEVELOPER_DIR
+          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     # Nightly builds against react-native@nightly at 4:00, Monday through Friday
     - cron: 0 4 * * 1-5
 env:
+  DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   VisualStudioVersion: "17.0"
 concurrency:
@@ -133,7 +134,7 @@ jobs:
     timeout-minutes: 60
   ios:
     name: "iOS"
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -179,7 +180,7 @@ jobs:
     strategy:
       matrix:
         template: [all, ios]
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
@@ -297,7 +298,7 @@ jobs:
     timeout-minutes: 60
   macos:
     name: "macOS"
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -357,7 +358,7 @@ jobs:
     strategy:
       matrix:
         template: [all, macos]
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -eox pipefail
 
 workspace=$1
 action=$2

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -9,9 +9,8 @@ platform=$(grep -o '\w\+/ReactTestApp.xcodeproj' "$workspace/contents.xcworkspac
 
 if [[ $platform == ios/* ]]; then
   if [[ $action == 'test' || $action == 'test-without-building' ]]; then
-    device_name=${1:-'iPhone 14'}
-    device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
-    re='\(([-0-9A-Fa-f]+)\)'
+    device=$(xcrun simctl list devices iPhone available)
+    re='iPhone [0-9]+ \(([-0-9A-Fa-f]+)\)'
     [[ $device =~ $re ]] || exit 1
     shift || true
     destination="-destination \"platform=iOS Simulator,id=${BASH_REMATCH[1]}\""

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -9,7 +9,7 @@ platform=$(grep -o '\w\+/ReactTestApp.xcodeproj' "$workspace/contents.xcworkspac
 
 if [[ $platform == ios/* ]]; then
   if [[ $action == 'test' || $action == 'test-without-building' ]]; then
-    device_name=${1:-'iPhone 13'}
+    device_name=${1:-'iPhone 14'}
     device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
     re='\(([-0-9A-Fa-f]+)\)'
     [[ $device =~ $re ]] || exit 1


### PR DESCRIPTION
### Description

Upstream started using `JSGlobalContextSetInspectable` which is [only available in iOS 16.4](https://developer.apple.com/documentation/javascriptcore/4111149-jsglobalcontextsetinspectable). The SDK for this version is only available in Xcode 14.3+, which only `macos-13` agents [have installed](https://github.com/actions/runner-images/blob/macOS-12/20230612.1/images/macos/macos-13-Readme.md#xcode).

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a