### PR TITLE
fix(macos): fix build failing when New Arch is enabled on 0.71

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('test/test_*.rb').each { |file| require_relative file }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.2.6",
+    "@rnx-kit/react-native-host": "^0.2.7",
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
     "cliui": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,12 +2822,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "@rnx-kit/react-native-host@npm:0.2.6"
+"@rnx-kit/react-native-host@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "@rnx-kit/react-native-host@npm:0.2.7"
   peerDependencies:
     react-native: ">=0.64"
-  checksum: cc160c9cd90d90afbd1e5ed477dcfad609fa8d3bdd1ae115eea0b10632f02df117be1bd6d36c20cab78edf54daf0de0d85d699a9343c2c2ce93641b0bc864058
+  checksum: 67570885718da085f33512defbd56878f9b745ea5bd16a1c5854054d0d85874ad1fdd5f17909960301709d17fa7e35dcccfb428c817c92bcfa486fb80ac010de
   languageName: node
   linkType: hard
 
@@ -10024,7 +10024,7 @@ fsevents@^2.3.2:
     "@react-native-community/cli-platform-ios": ^10.2.1
     "@rnx-kit/commitlint-lite": ^1.0.0
     "@rnx-kit/eslint-plugin": ^0.4.0
-    "@rnx-kit/react-native-host": ^0.2.6
+    "@rnx-kit/react-native-host": ^0.2.7
     "@types/jest": ^29.0.0
     "@types/mustache": ^4.0.0
     "@types/node": ^18.0.0


### PR DESCRIPTION
### Description

Fix build failing when New Arch is enabled on 0.71.

For details, see https://github.com/microsoft/rnx-kit/pull/2461.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

Enable New Arch:

```diff
diff --git a/example/macos/Podfile b/example/macos/Podfile
index 2266ea3..7750a75 100644
--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -2,7 +2,13 @@ require_relative '../node_modules/react-native-test-app/macos/test_app'

 workspace 'Example.xcworkspace'

-use_test_app! :hermes_enabled => false do |target|
+options = {
+  :fabric_enabled => true,
+  :hermes_enabled => false,
+  :turbomodule_enabled => true,
+}
+
+use_test_app! options do |target|
   target.tests do
     pod 'Example-Tests', :path => '..'
   end
```

Build:

```
cd example
pod install --project-directory=macos
yarn macos
```