### PR TITLE
fix(android): fix crash on startup with release builds

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -206,6 +206,15 @@ class TestAppReactNativeHost(
     }
 
     private fun isPackagerRunning(context: Context): Boolean {
+        if (!hasInstance()) {
+            // Return early otherwise we will get in an initialization loop.
+            // `source` may be initialized by calling this function. Without
+            // this check, the `getReactInstanceManager()` call below will
+            // instantiate `ReactInstanceManager`, which in turn will try to
+            // access `source`.
+            return BuildConfig.DEBUG
+        }
+
         val latch = CountDownLatch(1)
         var packagerIsRunning = false
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "generate:schema": "node scripts/generate-schema.mjs",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | yarn commitlint-lite",
     "lint:js": "eslint $(git ls-files '*.js' '*.mjs' ':!:.yarn') && tsc",
-    "lint:kt": "ktlint --android --relative 'android/app/src/**/*.kt'",
+    "lint:kt": "ktlint --code-style=android_studio --relative 'android/app/src/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",
     "prepack": "node scripts/pack.mjs pre",


### PR DESCRIPTION
### Description

The crash happens because `source` is initialized with `isPackagerRunning`, which initializes `ReactInstanceManager`, which in turn tries to access `source`.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Add dummy signing configs:

```diff
diff --git a/android/app/build.gradle b/android/app/build.gradle
index bb94321..7d32e80 100644
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -303,6 +303,19 @@ android {
         buildType.signingConfig = signingConfigs[name]
     }

+    signingConfigs {
+        debug {}
+    }
+
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            signingConfig signingConfigs.debug
+        }
+    }
+
     sourceSets {
         main.java.srcDirs += [
             project.ext.react.enableCamera ? "src/camera/java" : "src/no-camera/java",
```

Then build:

```
cd example
yarn build:android
yarn android --mode release
```

Make sure the no dev server is running.