### PR TITLE
ci(android): use Java 17 for nightly builds

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: yarn
   java-version:
     description: Desired Java version
-    default: '11'
+    default: "11"
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
 runs:
@@ -66,7 +66,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v3.6.0
       with:
-        node-version: 18
+        node-version: "18"
         cache: ${{ inputs.cache-npm-dependencies }}
     - name: Set up Xcode
       if: ${{ inputs.xcode-developer-dir != '' }}

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -10,6 +10,9 @@ inputs:
   cache-npm-dependencies:
     description: Caches npm dependencies (supports npm, yarn, pnpm v6.10+)
     default: yarn
+  java-version:
+    description: Desired Java version
+    default: '11'
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
 runs:
@@ -46,7 +49,7 @@ runs:
       uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
-        java-version: 11
+        java-version: ${{ inputs.java-version }}
     - name: Set up MSBuild
       if: ${{ inputs.platform == 'windows' }}
       uses: microsoft/setup-msbuild@v1.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
     name: "Android"
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -235,8 +235,9 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: android
-          java-version: '17'
+          java-version: ${{ github.event_name == 'schedule' && '17' || '11' }}
       - name: Set up react-native@nightly
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           git apply scripts/disable-safe-area-context.patch
           git apply scripts/android-nightly.patch
@@ -245,7 +246,7 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
-          immutable: false
+          immutable: ${{ github.event_name != 'schedule' }}
       - name: Test `react-native config`
         run: |
           yarn jest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,7 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: android
+          java-version: ${{ github.event_name == 'schedule' && '17' || '11' }}
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
     name: "Android"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -235,9 +235,8 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: android
-          java-version: ${{ github.event_name == 'schedule' && '17' || '11' }}
+          java-version: '17'
       - name: Set up react-native@nightly
-        if: ${{ github.event_name == 'schedule' }}
         run: |
           git apply scripts/disable-safe-area-context.patch
           git apply scripts/android-nightly.patch
@@ -246,7 +245,7 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
-          immutable: ${{ github.event_name != 'schedule' }}
+          immutable: false
       - name: Test `react-native config`
         run: |
           yarn jest


### PR DESCRIPTION
### Description

Nightly builds now require Java 17: https://github.com/microsoft/react-native-test-app/actions/runs/5352698021/jobs/9707865868

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.