### PR TITLE
refactor(ios): reduce direct usage of `RCTBridge`

### DIFF
--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -52,16 +52,21 @@ final class ContentViewController: UITableViewController {
     // MARK: - UIResponder overrides
 
     override public func motionEnded(_: UIEvent.EventSubtype, with event: UIEvent?) {
-        guard event?.subtype == .motionShake,
-              let bridge = reactInstance.host?.bridge,
-              let settings = bridge.module(for: RCTDevSettings.self) as? RCTDevSettings,
-              settings.isShakeToShowDevMenuEnabled,
-              let devMenu = bridge.module(for: RCTDevMenu.self) as? RCTDevMenu
-        else {
+        guard event?.subtype == .motionShake, let host = reactInstance.host else {
             return
         }
 
-        devMenu.show()
+        host.using(module: RCTDevSettings.self) { settings in
+            let settings = settings as? RCTDevSettings
+            guard settings?.isShakeToShowDevMenuEnabled == true else {
+                return
+            }
+
+            host.using(module: RCTDevMenu.self) { devMenu in
+                let devMenu = devMenu as? RCTDevMenu
+                devMenu?.show()
+            }
+        }
     }
 
     // MARK: - UIViewController overrides
@@ -194,14 +199,13 @@ final class ContentViewController: UITableViewController {
 
     private func navigate(to component: Component) {
         guard let host = reactInstance.host,
-              let bridge = host.bridge,
               let navigationController = navigationController
         else {
             return
         }
 
         let viewController: UIViewController = {
-            if let viewController = RTAViewControllerFromString(component.appKey, bridge) {
+            if let viewController = RTAViewControllerFromString(component.appKey, host) {
                 return viewController
             }
 

--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -198,9 +198,7 @@ final class ContentViewController: UITableViewController {
     // MARK: - Private
 
     private func navigate(to component: Component) {
-        guard let host = reactInstance.host,
-              let navigationController = navigationController
-        else {
+        guard let host = reactInstance.host, let navigationController else {
             return
         }
 

--- a/ios/ReactTestApp/Manifest+Decoder.swift
+++ b/ios/ReactTestApp/Manifest+Decoder.swift
@@ -65,14 +65,14 @@ private struct DynamicCodingKey: CodingKey {
     }
 
     func toHashable() -> AnyHashable {
-        guard let intValue = intValue else {
+        guard let intValue else {
             return stringValue
         }
         return intValue
     }
 }
 
-extension Array where Element == Any {
+extension [Any] {
     static func decode(from decoder: Decoder) throws -> Array? {
         guard var container = try? decoder.unkeyedContainer() else {
             return nil
@@ -100,7 +100,7 @@ extension Array where Element == Any {
     }
 }
 
-extension Dictionary where Key == AnyHashable, Value == Any {
+extension [AnyHashable: Any] {
     static func decode(from decoder: Decoder) throws -> Dictionary? {
         guard let container = try? decoder.container(keyedBy: DynamicCodingKey.self) else {
             return nil

--- a/ios/ReactTestApp/QRCodeScannerViewController.swift
+++ b/ios/ReactTestApp/QRCodeScannerViewController.swift
@@ -105,7 +105,7 @@ final class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutp
 
             feedback.notificationOccurred(.success)
 
-            guard let presentingViewController = presentingViewController else {
+            guard let presentingViewController else {
                 assertionFailure()
                 return
             }

--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -1,4 +1,8 @@
+// Disable clang-format because it gets confused when there's a "+" in the
+// filename.
+// clang-format off
 #import "React+Compatibility.h"
+// clang-format on
 
 #include <TargetConditionals.h>
 

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -94,7 +94,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
 
         NotificationCenter.default.post(
             name: .ReactTestAppDidInitializeReactNative,
-            object: reactNativeHost.bridge
+            object: reactNativeHost
         )
 
         onDidInitialize()

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -119,7 +119,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
     // MARK: - RCTBridgeDelegate details
 
     func sourceURL(for _: RCTBridge!) -> URL? {
-        if let remoteBundleURL = remoteBundleURL {
+        if let remoteBundleURL {
             return remoteBundleURL
         }
 
@@ -144,7 +144,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
         let extensions = [".macos", ".native", ""]
         #endif
 
-        guard let bundleRoot = bundleRoot else {
+        guard let bundleRoot else {
             return extensions.reduce(into: []) { files, ext in
                 files.append("index" + ext)
                 files.append("main" + ext)

--- a/ios/ReactTestApp/SceneDelegate.swift
+++ b/ios/ReactTestApp/SceneDelegate.swift
@@ -146,18 +146,18 @@ extension UIScene.OpenURLOptions {
     func dictionary() -> [UIApplication.OpenURLOptionsKey: Any] {
         var options: [UIApplication.OpenURLOptionsKey: Any] = [:]
 
-        if let sourceApplication = sourceApplication {
+        if let sourceApplication {
             options[.sourceApplication] = sourceApplication
         }
 
-        if let annotation = annotation {
+        if let annotation {
             options[.annotation] = annotation
         }
 
         options[.openInPlace] = openInPlace
 
         if #available(iOS 14.5, *) {
-            if let eventAttribution = eventAttribution {
+            if let eventAttribution {
                 options[.eventAttribution] = eventAttribution
             }
         }

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.h
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.h
@@ -7,10 +7,10 @@
 #define RTAViewController NSViewController
 #endif
 
-@class RCTBridge;
+@class ReactNativeHost;
 
 NS_ASSUME_NONNULL_BEGIN
 
-RTAViewController *_Nullable RTAViewControllerFromString(NSString *name, RCTBridge *bridge);
+RTAViewController *_Nullable RTAViewControllerFromString(NSString *name, ReactNativeHost *host);
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.m
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.m
@@ -1,13 +1,15 @@
 #import "UIViewController+ReactTestApp.h"
 
+#import <ReactNativeHost/ReactNativeHost.h>
+
 @protocol RTAViewController <NSObject>
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 @end
 
-RTAViewController *RTAViewControllerFromString(NSString *name, RCTBridge *bridge)
+RTAViewController *RTAViewControllerFromString(NSString *name, ReactNativeHost *host)
 {
     Class viewController = NSClassFromString(name);
     return [viewController instancesRespondToSelector:@selector(initWithBridge:)]
-               ? [[viewController alloc] initWithBridge:bridge]
+               ? [[viewController alloc] initWithBridge:host.bridge]
                : nil;
 }

--- a/ios/ReactTestApp/UIViewController+ReactTestApp.m
+++ b/ios/ReactTestApp/UIViewController+ReactTestApp.m
@@ -1,4 +1,8 @@
+// Disable clang-format because it gets confused when there's a "+" in the
+// filename.
+// clang-format off
 #import "UIViewController+ReactTestApp.h"
+// clang-format on
 
 #import <ReactNativeHost/ReactNativeHost.h>
 

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -206,8 +206,7 @@ extension AppDelegate {
 
     private func present(_ component: Component) {
         guard let window = mainWindow,
-              let host = reactInstance.host,
-              let bridge = host.bridge
+              let host = reactInstance.host
         else {
             return
         }
@@ -215,7 +214,7 @@ extension AppDelegate {
         let title = component.displayName ?? component.appKey
 
         let viewController: NSViewController = {
-            if let viewController = RTAViewControllerFromString(component.appKey, bridge) {
+            if let viewController = RTAViewControllerFromString(component.appKey, host) {
                 return viewController
             }
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "clean": "git clean -dfqx --exclude=.yarn/cache",
     "format:c": "clang-format -i $(git ls-files '*.cpp' '*.h' '*.m' '*.mm')",
     "format:js": "prettier --write $(git ls-files '*.js' '*.yml' 'test/**/*.json')",
-    "format:swift": "swiftformat --swiftversion 5.5 --ifdef no-indent --stripunusedargs closure-only ios macos",
+    "format:swift": "swiftformat --swiftversion 5.7 --ifdef no-indent --stripunusedargs closure-only ios macos",
     "generate:code": "node scripts/generate-manifest.mjs",
     "generate:schema": "node scripts/generate-schema.mjs",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | yarn commitlint-lite",


### PR DESCRIPTION
### Description

Reduce direct usage of `RCTBridge` in preparation for its eventual (?) removal.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
cd example
pod install --project-directory=ios
yarn ios

# In a separate terminal, start the dev server
yarn start
```

Once the app launches, navigate back to the Home screen if necessary and press `^⌘Z` to shake the device. The devmenu should open.