### PR TITLE
ci(android): update nightly patch

### DIFF
--- a/.github/actions/setup-react-native/action.yml
+++ b/.github/actions/setup-react-native/action.yml
@@ -1,0 +1,17 @@
+name: Setup React Native
+description: Set up a specific version of React Native
+inputs:
+  version:
+    description: The React Native version to set up
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up react-native@${{ inputs.version }}
+      run: |
+        git apply scripts/disable-safe-area-context.patch
+        git apply scripts/android-nightly.patch
+        rm example/ios/Podfile.lock
+        rm example/macos/Podfile.lock
+        npm run set-react-version -- ${{ inputs.version }}
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,6 @@ jobs:
         uses: ./.github/actions/setup-react-native
         with:
           version: canary-windows
-        shell: bash
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,9 +128,13 @@ jobs:
           echo "::add-matcher::.github/swiftlint.json"
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
+      - name: Verify nightly patches
+        run: |
+          git apply scripts/disable-safe-area-context.patch
+          git apply scripts/android-nightly.patch
       - name: Smoke test `set-react-version`
         run: |
-          npm run set-react-version -- 0.66
+          npm run set-react-version -- nightly
     timeout-minutes: 60
   ios:
     name: "iOS"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,13 +128,10 @@ jobs:
           echo "::add-matcher::.github/swiftlint.json"
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
-      - name: Verify nightly patches
-        run: |
-          git apply scripts/disable-safe-area-context.patch
-          git apply scripts/android-nightly.patch
-      - name: Smoke test `set-react-version`
-        run: |
-          npm run set-react-version -- nightly
+      - name: Smoke test `setup-react-native` action
+        uses: ./.github/actions/setup-react-native
+        with:
+          version: nightly
     timeout-minutes: 60
   ios:
     name: "iOS"
@@ -151,9 +148,9 @@ jobs:
           xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
-        run: |
-          npm run set-react-version -- nightly
-          rm example/ios/Podfile.lock
+        uses: ./.github/actions/setup-react-native
+        with:
+          version: nightly
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
@@ -242,11 +239,9 @@ jobs:
           java-version: ${{ github.event_name == 'schedule' && '17' || '11' }}
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
-        run: |
-          git apply scripts/disable-safe-area-context.patch
-          git apply scripts/android-nightly.patch
-          npm run set-react-version -- nightly
-        shell: bash
+        uses: ./.github/actions/setup-react-native
+        with:
+          version: nightly
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
@@ -318,9 +313,9 @@ jobs:
           xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
-        run: |
-          npm run set-react-version -- canary-macos
-          rm example/macos/Podfile.lock
+        uses: ./.github/actions/setup-react-native
+        with:
+          version: canary-macos
       - name: Install npm dependencies
         uses: ./.github/actions/yarn
         with:
@@ -419,8 +414,9 @@ jobs:
           platform: windows
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
-        run: |
-          npm run set-react-version -- canary-windows
+        uses: ./.github/actions/setup-react-native
+        with:
+          version: canary-windows
         shell: bash
       - name: Install npm dependencies
         uses: ./.github/actions/yarn

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -1,11 +1,11 @@
 diff --git a/example/android/gradle/wrapper/gradle-wrapper.properties b/example/android/gradle/wrapper/gradle-wrapper.properties
-index 5083229..37aef8d 100644
+index 4e86b92..37aef8d 100644
 --- a/example/android/gradle/wrapper/gradle-wrapper.properties
 +++ b/example/android/gradle/wrapper/gradle-wrapper.properties
 @@ -1,6 +1,6 @@
  distributionBase=GRADLE_USER_HOME
  distributionPath=wrapper/dists
--distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 +distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
  networkTimeout=10000
  zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

Android nightly failed because Gradle was bumped and we didn't update the patch.

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/5550322401/jobs/10135310028

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a