### PR TITLE
chore: eval `wdio.config.js` to get simulator name

### DIFF
--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -10,7 +10,8 @@ scripts_dir=$(cd -P "$(dirname "$0")" && pwd)
 
 function build_and_run {
   if [[ $1 == "ios" ]]; then
-    ${PACKAGE_MANAGER} $1 --simulator 'iPhone 14' --no-packager
+    local simulator=$(TEST_ARGS=ios node -e 'console.log(require("./test/specs/wdio.config")["capabilities"]["appium:deviceName"]);')
+    ${PACKAGE_MANAGER} $1 --simulator "${simulator}" --no-packager
   else
     ${PACKAGE_MANAGER} $1 --no-packager
   fi


### PR DESCRIPTION
### Description

We currently have "iPhone 14" hardcoded in two different places. This reduces it to one. See also https://github.com/microsoft/react-native-test-app/pull/1467#discussion_r1263610486.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Run:

```
scripts/test-matrix.sh 0.72
```

You can cancel the run after the first iOS build successfully launches.