### PR TITLE
fix(macos): fix build break introduced in 2.5.13

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -332,7 +332,7 @@ PODS:
     - React-jsi (= 0.71.26)
     - React-logger (= 0.71.26)
     - React-perflogger (= 0.71.26)
-  - ReactNativeHost (0.2.7):
+  - ReactNativeHost (0.2.8):
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -499,7 +499,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: e6217ee1a90f98aab19888fa9326966250619030
   React-runtimeexecutor: 332a0a638d7fed64b7e94475f802e7549132e06b
   ReactCommon: 4d2b2c80862b5d12183dee271d5ced9082949354
-  ReactNativeHost: 5dd0021c01ade845f1171f4e6f6814f214ddfadb
+  ReactNativeHost: 5caf8c9381f26c453fabbe8c3b87f6a013a3c459
   ReactTestApp-DevSupport: 5fd0815a03f06e26b120ac7b8a7ff29824fa700b
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -69,16 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBAction
     func onRememberLastComponentSelected(_ menuItem: NSMenuItem) {
-        switch menuItem.state {
-        case .mixed, .on:
-            Session.shouldRememberLastComponent = false
-            menuItem.state = .off
-        case .off:
-            Session.shouldRememberLastComponent = true
-            menuItem.state = .on
-        default:
-            assertionFailure()
-        }
+        onRememberLastComponentSelectedInternal(menuItem)
     }
 
     // MARK: Private
@@ -204,6 +195,19 @@ extension AppDelegate {
         rememberLastComponentMenuItem.isEnabled = components.count > 1
     }
 
+    private func onRememberLastComponentSelectedInternal(_ menuItem: NSMenuItem) {
+        switch menuItem.state {
+        case .mixed, .on:
+            Session.shouldRememberLastComponent = false
+            menuItem.state = .off
+        case .off:
+            Session.shouldRememberLastComponent = true
+            menuItem.state = .on
+        default:
+            assertionFailure()
+        }
+    }
+
     private func present(_ component: Component) {
         guard let window = mainWindow,
               let host = reactInstance.host
@@ -300,13 +304,11 @@ extension AppDelegate {
         window.contentViewController?.view = rootView
 
         #if DEBUG
-        if Session.shouldRememberLastComponent {
-            rememberLastComponentMenuItem.state = .on
-        }
-
         showReactMenu()
         #endif // DEBUG
     }
+
+    private func onRememberLastComponentSelectedInternal(_: NSMenuItem) {}
 }
 
 #endif // ENABLE_SINGLE_APP_MODE


### PR DESCRIPTION
### Description

Fix build break introduced in #1522

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

Enable single app mode:

```diff
diff --git a/example/app.json b/example/app.json
index ef69fa7..8e4ddc7 100644
--- a/example/app.json
+++ b/example/app.json
@@ -2,10 +2,12 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
   "name": "Example",
   "displayName": "Example",
+  "singleApp": "example-app",
   "components": [
     {
       "appKey": "Example",
-      "displayName": "App"
+      "displayName": "App",
+      "slug": "example-app"
     },
     {
       "appKey": "Example",
```

Build and run:

```
pod install --project-directory=macos
yarn macos
```

In a separate terminal, start the dev server:

```
yarn start
```