### PR TITLE
fix(windows): fix project generation when `node_modules` doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     ]
   },
   "prettier": {
+    "trailingComma": "es5",
     "endOfLine": "auto"
   },
   "release": {

--- a/test/windows-test-app/generateSolution.test.js
+++ b/test/windows-test-app/generateSolution.test.js
@@ -16,6 +16,8 @@ describe("generateSolution", () => {
     useNuGet: false,
   };
 
+  const testManifest = `{ name: "react-native-test-app", version: "0.0.1-dev" }`;
+
   beforeEach(() => {
     process.chdir(path.dirname(cwd));
   });
@@ -31,14 +33,17 @@ describe("generateSolution", () => {
     );
   });
 
-  test("exits if 'node_modules' folder cannot be found", () => {
+  test("exits if 'package.json' folder cannot be found", () => {
     expect(generateSolution("test", options)).toBe(
-      "Could not find 'node_modules'"
+      "Could not find 'package.json'"
     );
   });
 
   test("exits if 'react-native-windows' folder cannot be found", () => {
-    mockFiles({ [path.resolve("", "node_modules", ".bin")]: "directory" });
+    mockFiles({
+      [path.resolve("", "package.json")]: testManifest,
+      [path.resolve("", "node_modules", ".bin")]: "directory",
+    });
 
     expect(generateSolution("test", options)).toBe(
       "Could not find 'react-native-windows'"
@@ -47,6 +52,7 @@ describe("generateSolution", () => {
 
   test("exits if 'react-native-test-app' folder cannot be found", () => {
     mockFiles({
+      [path.resolve("", "package.json")]: testManifest,
       [path.resolve(
         "",
         "node_modules",

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -586,12 +586,12 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
     return "Missing or invalid destination path";
   }
 
-  const nodeModulesDir = "node_modules";
-
-  const nodeModulesPath = findNearest(nodeModulesDir);
-  if (!nodeModulesPath) {
-    return "Could not find 'node_modules'";
+  const projectManifest = findNearest("package.json");
+  if (!projectManifest) {
+    return "Could not find 'package.json'";
   }
+
+  const nodeModulesDir = "node_modules";
 
   const rnWindowsPath = findNearest(
     path.join(nodeModulesDir, "react-native-windows")
@@ -609,7 +609,8 @@ function generateSolution(destPath, { autolink, useHermes, useNuGet }) {
 
   const projDir = "ReactTestApp";
   const projectFilesDestPath = path.join(
-    nodeModulesPath,
+    path.dirname(projectManifest),
+    nodeModulesDir,
     ".generated",
     "windows",
     projDir


### PR DESCRIPTION
### Description

Fixes Visual Studio project being generated in the wrong directory when `node_modules` doesn't exist in the current package folder.

Resolves #1529

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

For these steps, it's recommended to use [GitHub CLI](https://github.com/cli/cli) (install: `brew install gh`).

```
git clone --filter=blob:none https://github.com/microsoft/fluentui-react-native.git
cd fluentui-react-native
gh pr checkout 2980
yarn
cd apps/fluent-tester

# Observe that project files are generated in the wrong folder
yarn install-windows-test-app
ls node_modules/.generated/windows        # fails
ls ../../node_modules/.generated/windows  # succeeds, but is wrong

# Apply the patch in '../../node_modules/react-native-test-app/windows/test-app.js'
yarn install-windows-test-app
ls node_modules/.generated/windows  # should now succeed
```

On a Windows machine, `yarn install-windows-test-app` will fail on the autolinking step without this patch.