### PR TITLE
refactor: simplify `writeAllFiles()`

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -901,38 +901,19 @@ function updatePackageManifest(path, { dependencies, scripts }) {
 function writeAllFiles(files, destination) {
   const options = { recursive: true, mode: 0o755 };
   return Promise.all(
-    Object.keys(files).map((filename) => {
+    Object.keys(files).map(async (filename) => {
       const content = files[filename];
       if (!content) {
-        return Promise.resolve();
+        return;
       }
 
       const file = path.join(destination, filename);
-      /** @type {Promise<void>} */
-      const p = new Promise((resolve, reject) =>
-        fs.mkdir(path.dirname(file), options, (error) => {
-          // Calling `fs.mkdir()` when `path` is a directory that exists results
-          // in an error only when `recursive` is false.
-          if (error) {
-            reject(error);
-          } else {
-            /** @type {(error: Error | null) => void} */
-            const callback = (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            };
-            if (typeof content === "string") {
-              fs.writeFile(file, content, callback);
-            } else {
-              fs.copyFile(content.source, file, callback);
-            }
-          }
-        })
-      );
-      return p;
+      await fsp.mkdir(path.dirname(file), options);
+      if (typeof content === "string") {
+        await fsp.writeFile(file, content);
+      } else {
+        await fsp.copyFile(content.source, file);
+      }
     })
   );
 }

--- a/test/__mocks__/fs/promises.js
+++ b/test/__mocks__/fs/promises.js
@@ -4,6 +4,9 @@ const fs = jest.createMockFromModule("fs/promises");
 
 const { vol } = require("memfs");
 
+fs.copyFile = (...args) => vol.promises.copyFile(...args);
+fs.mkdir = (...args) => vol.promises.mkdir(...args);
 fs.rm = (...args) => vol.promises.rm(...args);
+fs.writeFile = (...args) => vol.promises.writeFile(...args);
 
 module.exports = fs;

--- a/test/configure/writeAllFiles.test.js
+++ b/test/configure/writeAllFiles.test.js
@@ -2,6 +2,7 @@
 "use strict";
 
 jest.mock("fs");
+jest.mock("fs/promises");
 
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
### Description

Simplify `writeAllFiles()`. Hopefully this also fixes race conditions (?) when running tests on CI:

```
  ● test-app-util › getSigningConfigs() fails if `storeFile` is missing

    ENOENT: no such file or directory, copyfile '/Users/runner/work/react-native-test-app/react-native-test-app/example/.gitignore' -> '.android-test-TestAppUtilTest/.gitignore'



  ● test-app-util › getSigningConfigs() skips empty `signingConfigs` config

    ENOENT: no such file or directory, copyfile '/Users/runner/work/react-native-test-app/react-native-test-app/example/.gitignore' -> '.android-test-TestAppUtilTest/.gitignore'



  ● test-app-util › getSigningConfigs() returns debug signing config

    ENOENT: no such file or directory, copyfile '/Users/runner/work/react-native-test-app/react-native-test-app/example/.gitignore' -> '.android-test-TestAppUtilTest/.gitignore'



  ● test-app-util › getSigningConfigs() returns release signing config

    ENOENT: no such file or directory, copyfile '/Users/runner/work/react-native-test-app/react-native-test-app/example/.gitignore' -> '.android-test-TestAppUtilTest/.gitignore'
```

Full build log: https://github.com/microsoft/react-native-test-app/actions/runs/5854960083/job/15872741382

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Existing tests should pass.