### PR TITLE
fix(init): find latest version supported by all platforms

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -22,14 +22,6 @@ function memo(fn) {
 }
 
 /**
- * @param {string} v
- */
-function minorVersion(v) {
-  const [major, minor] = v.split("-")[0].split(".").map(Number);
-  return major * 100 + minor;
-}
-
-/**
  * Invokes `npm`.
  * @param {...string} args
  */
@@ -82,6 +74,7 @@ const getInstalledVersion = memo(() => {
 });
 
 /**
+ * Returns the npm package name for the specified platform.
  * @param {string} platform
  * @returns {string}
  */
@@ -130,7 +123,8 @@ function getVersion(platforms) {
       return result;
     }
 
-    const v = minorVersion(npm("view", pkgName, "version"));
+    const [major, minor] = npm("view", pkgName, "version").split(".");
+    const v = Number(major) * 100 + Number(minor);
     return v < result ? v : result;
   }, Number.MAX_VALUE);
 


### PR DESCRIPTION
### Description

When no version is specified, `init` uses the latest minor published by `react-native`. This doesn't always work because some platforms may be lagging behind.

Resolves #1528.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
mkdir temp
cd temp
GIT_IGNORE_FILE=.gitignore /path/to/react-native-test-app/scripts/init.js
```

If macOS is included, we should pick 0.71:
![image](https://github.com/microsoft/react-native-test-app/assets/4123478/f1febf25-9f0b-44c8-9403-e01192abf5c0)

Otherwise, we should pick 0.72:
![image](https://github.com/microsoft/react-native-test-app/assets/4123478/b289437d-74d9-4251-aff4-60bb4cadc160)