### PR TITLE
chore: update Fabric detector and convert to TypeScript

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@types/jest": "^29.0.0",
+    "@types/react": "~18.2.0",
     "appium": "^2.0.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "^0.73.9",

--- a/scripts/disable-safe-area-context.patch
+++ b/scripts/disable-safe-area-context.patch
@@ -1,9 +1,9 @@
-diff --git a/example/App.js b/example/App.js
-index c9cd14d..f63758d 100644
---- a/example/App.js
-+++ b/example/App.js
-@@ -2,6 +2,7 @@
- import React, { useCallback, useMemo, useState } from "react";
+diff --git a/example/App.tsx b/example/App.tsx
+index edc2259..7168465 100644
+--- a/example/App.tsx
++++ b/example/App.tsx
+@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
+ import type { LayoutChangeEvent, NativeSyntheticEvent } from "react-native";
  import {
    NativeModules,
 +  SafeAreaView,
@@ -18,7 +18,7 @@ index c9cd14d..f63758d 100644
  // @ts-expect-error
  import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
  import { Colors, Header } from "react-native/Libraries/NewAppScreen";
-@@ -169,7 +169,6 @@ const App = ({ concurrentRoot }) => {
+@@ -179,7 +179,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
    );
  
    return (
@@ -26,11 +26,11 @@ index c9cd14d..f63758d 100644
        <SafeAreaView style={styles.body}>
          <StatusBar barStyle={isDarkMode ? "light-content" : "dark-content"} />
          <ScrollView
-@@ -192,7 +191,6 @@ const App = ({ concurrentRoot }) => {
+@@ -202,7 +201,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
            </View>
          </ScrollView>
        </SafeAreaView>
 -    </SafeAreaProvider>
    );
- };
+ }
  

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.5
+  resolution: "@types/prop-types@npm:15.7.5"
+  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
@@ -3659,6 +3666,17 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:~18.2.0":
+  version: 18.2.20
+  resolution: "@types/react@npm:18.2.20"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 30f699c60e5e4bfef273ce64d320651cdd60f5c6a08361c6c7eca8cebcccda1ac953d2ee57c9f321b5ae87f8a62c72b6d35ca42df0e261d337849952daab2141
   languageName: node
   linkType: hard
 
@@ -3675,6 +3693,13 @@ __metadata:
   version: 0.12.1
   resolution: "@types/retry@npm:0.12.1"
   checksum: 5f46b2556053655f78262bb33040dc58417c900457cc63ff37d6c35349814471453ef511af0cec76a540c601296cd2b22f64bab1ab649c0dacc0223765ba876c
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.3
+  resolution: "@types/scheduler@npm:0.16.3"
+  checksum: 2b0aec39c24268e3ce938c5db2f2e77f5c3dd280e05c262d9c2fe7d890929e4632a6b8e94334017b66b45e4f92a5aa42ba3356640c2a1175fa37bef2f5200767
   languageName: node
   linkType: hard
 
@@ -6090,6 +6115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csstype@npm:^3.0.2":
+  version: 3.1.2
+  resolution: "csstype@npm:3.1.2"
+  checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
+  languageName: node
+  linkType: hard
+
 "data-uri-to-buffer@npm:^4.0.0":
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
@@ -7087,6 +7119,7 @@ __metadata:
     "@babel/core": ^7.1.6
     "@babel/preset-env": ^7.1.6
     "@types/jest": ^29.0.0
+    "@types/react": ~18.2.0
     appium: ^2.0.0
     jest: ^29.2.1
     metro-react-native-babel-preset: ^0.73.9


### PR DESCRIPTION
### Description

Update Fabric detector and convert to TypeScript.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
cd example
yarn start

# Pick any platform to test, e.g. Android
yarn android
```

![Screenshot_1692258602](https://github.com/microsoft/react-native-test-app/assets/4123478/450ae144-4880-4de4-8920-493a221a870d)
