### PR TITLE
chore: make TypeScript happy

### DIFF
--- a/example/test/config.test.js
+++ b/example/test/config.test.js
@@ -17,7 +17,7 @@ const path = require("path");
 const {
   version: cliVersion,
 } = require("@react-native-community/cli/package.json");
-const cliMajorVersion = cliVersion.split(".")[0];
+const cliMajorVersion = Number(cliVersion.split(".")[0]);
 
 /**
  * Test only if given predicate evaluates to `true`.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "generate:code": "node scripts/generate-manifest.mjs",
     "generate:schema": "node scripts/generate-schema.mjs",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | yarn commitlint-lite",
-    "lint:js": "eslint $(git ls-files '*.js' '*.mjs') && tsc",
+    "lint:js": "eslint $(git ls-files '*.js' '*.mjs' '*.ts' '*.tsx') && tsc",
     "lint:kt": "ktlint --code-style=android_studio --relative 'android/app/src/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",
@@ -179,10 +179,7 @@
       "plugin:@rnx-kit/recommended",
       "plugin:jest/recommended",
       "plugin:jest/style"
-    ],
-    "rules": {
-      "@typescript-eslint/ban-ts-comment": "off"
-    }
+    ]
   },
   "jest": {
     "collectCoverage": true,

--- a/scripts/disable-safe-area-context.patch
+++ b/scripts/disable-safe-area-context.patch
@@ -1,5 +1,5 @@
 diff --git a/example/App.tsx b/example/App.tsx
-index 54ed4d1..3c811df 100644
+index a256f50..3343dfa 100644
 --- a/example/App.tsx
 +++ b/example/App.tsx
 @@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
@@ -15,10 +15,10 @@ index 54ed4d1..3c811df 100644
    View,
  } from "react-native";
 -import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
- // @ts-expect-error
+ // @ts-expect-error no type definitions available
  import { version as coreVersion } from "react-native/Libraries/Core/ReactNativeVersion";
  import { Colors, Header } from "react-native/Libraries/NewAppScreen";
-@@ -179,7 +179,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
+@@ -187,7 +187,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
    const [isFabric, setIsFabric] = useIsFabricComponent();
  
    return (
@@ -26,7 +26,7 @@ index 54ed4d1..3c811df 100644
        <SafeAreaView style={styles.body}>
          <StatusBar barStyle={isDarkMode ? "light-content" : "dark-content"} />
          <ScrollView
-@@ -202,7 +201,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
+@@ -210,7 +209,6 @@ function App({ concurrentRoot }: AppProps): React.ReactElement<AppProps> {
            </View>
          </ScrollView>
        </SafeAreaView>

--- a/test/android-test-app/gradle.js
+++ b/test/android-test-app/gradle.js
@@ -53,8 +53,7 @@ async function makeProject(name, platforms, setupFiles = {}) {
       "dir"
     );
   } catch (e) {
-    // @ts-ignore
-    if (e.code !== "EEXIST") {
+    if (e && typeof e === "object" && "code" in e && e.code !== "EEXIST") {
       throw e;
     }
   }

--- a/test/configure/getPlatformPackage.test.js
+++ b/test/configure/getPlatformPackage.test.js
@@ -41,7 +41,7 @@ describe("getPlatformPackage()", () => {
   });
 
   test("throws if target version is invalid", () => {
-    // @ts-ignore intentional use of empty string to elicit an exception
+    // @ts-expect-error intentional use of empty string to elicit an exception
     expect(() => getPlatformPackage("", "version")).toThrow();
   });
 });

--- a/test/configure/reactNativeConfig.test.js
+++ b/test/configure/reactNativeConfig.test.js
@@ -50,7 +50,7 @@ describe("reactNativeConfig()", () => {
   });
 
   test("throws when an unknown platform is specified", () => {
-    // @ts-ignore intentional use of unsupported platform
+    // @ts-expect-error intentional use of unsupported platform
     const params = mockParams({ platforms: ["nextstep"], flatten: true });
     expect(() => reactNativeConfig(params)).toThrow(
       "Unknown platform: nextstep"

--- a/test/mockFiles.js
+++ b/test/mockFiles.js
@@ -11,7 +11,7 @@ const fs = require("fs");
  * @param {Record<string, string>} files
  */
 function mockFiles(files = {}) {
-  // @ts-ignore `__setMockFiles`
+  // @ts-expect-error for mocking purposes only
   fs.__setMockFiles(files);
 }
 

--- a/test/windows-test-app/copy.test.js
+++ b/test/windows-test-app/copy.test.js
@@ -36,7 +36,7 @@ describe("copy", () => {
 
     // Wait until all files have been copied
     const writeDone = waitUntil(() => {
-      // @ts-ignore
+      // @ts-expect-error mock
       const files = Object.keys(fs.__toJSON());
       return files.length === 12;
     });
@@ -44,7 +44,7 @@ describe("copy", () => {
     copy("assets", "assets copy");
     await writeDone;
 
-    // @ts-ignore
+    // @ts-expect-error mock
     const files = Object.keys(fs.__toJSON());
 
     expect(files).toEqual(

--- a/test/windows-test-app/replaceContent.test.js
+++ b/test/windows-test-app/replaceContent.test.js
@@ -5,7 +5,7 @@ describe("replaceContent", () => {
   const { replaceContent } = require("../../windows/test-app");
 
   test("returns same string with no replacements", () => {
-    // @ts-ignore intentional use of `undefined`
+    // @ts-expect-error intentional use of `undefined`
     expect(replaceContent(undefined, {})).toBeUndefined();
     expect(replaceContent("", {})).toBe("");
     expect(replaceContent("content", {})).toBe("content");

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -293,7 +293,7 @@ function generateContentItems(
 ) {
   const uuidv5 = (() => {
     try {
-      // @ts-ignore uuid@3.x
+      // @ts-expect-error export only exists in uuid@3.x and older
       return require("uuid/v5");
     } catch (_) {
       // uuid@7.x and above


### PR DESCRIPTION
### Description

Clean up TypeScript lints and errors.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Remove `react-native-safe-area-context` from `package.json` and apply patch: `git apply scripts/disable-safe-area-context.patch` 

    ```diff
    diff --git a/example/package.json b/example/package.json
    index dc380b4..25409c0 100644
    --- a/example/package.json
    +++ b/example/package.json
    @@ -34,7 +34,6 @@
         "react": "18.2.0",
         "react-native": "^0.71.6",
         "react-native-macos": "^0.71.0",
    -    "react-native-safe-area-context": "^4.5.1",
         "react-native-test-app": "workspace:.",
         "react-native-windows": "^0.71.4",
         "webdriverio": "^8.11.2"
    ```

2. Enable New Architecture:

    ```diff
    diff --git a/example/android/gradle.properties b/example/android/gradle.properties
    index a951019..f5ed9b7 100644
    --- a/example/android/gradle.properties
    +++ b/example/android/gradle.properties
    @@ -36,7 +36,7 @@ android.enableJetifier=true

     # Enable new architecture, i.e. Fabric + TurboModule - implies USE_FABRIC=1.
     # Note that this is incompatible with web debugging.
    -#newArchEnabled=true
    +newArchEnabled=true

     # Uncomment the line below if building react-native from source
     #ANDROID_NDK_VERSION=23.1.7779620
    ```

3. Make sure Hermes version is displayed and Fabric is detected:

    ```sh
    cd example
    yarn android

    # In a separate terminal
    yarn start
    ```

    ![Screenshot_1692953941](https://github.com/microsoft/react-native-test-app/assets/4123478/3cae37fb-72ca-4172-89dd-147965bf9dbe)