### PR TITLE
chore: move `clean` script into a plugin

### DIFF
--- a/.yarn/plugins/clean.cjs
+++ b/.yarn/plugins/clean.cjs
@@ -1,0 +1,38 @@
+// @ts-check
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+/** @type {{ name: string; factory: (require: NodeRequire) => unknown; }} */
+module.exports = {
+  name: "plugin-clean",
+  factory: (require) => {
+    // @ts-expect-error Yarn internal package
+    const { BaseCommand } = require("@yarnpkg/cli");
+
+    class CleanCommand extends BaseCommand {
+      static paths = [["clean"]];
+
+      async execute() {
+        const projectRoot = path.dirname(path.dirname(__dirname));
+
+        // Remove the symlink first. On Windows, `git clean` resolves/traverses
+        // the symlink, causing an infinite loop.
+        const symlink = path.join(
+          projectRoot,
+          "example",
+          "node_modules",
+          "react-native-test-app"
+        );
+        fs.rmSync(symlink, { force: true, maxRetries: 3, recursive: true });
+
+        spawnSync("git", ["clean", "-dfqx", "--exclude=.yarn/cache"], {
+          cwd: projectRoot,
+          stdio: "inherit",
+        });
+      }
+    }
+
+    return { commands: [CleanCommand] };
+  },
+};

--- a/.yarn/plugins/link-project.cjs
+++ b/.yarn/plugins/link-project.cjs
@@ -1,7 +1,17 @@
+// @ts-check
+/**
+ * @typedef {{ values: Map<string, unknown>; }} Configuration
+ * @typedef {{ cwd: string; }} Workspace
+ * @typedef {{ configuration: Configuration; cwd: string; workspaces: Workspace[]; }} Project
+ * @typedef {{ mode?: "skip-build" | "update-lockfile"; }} InstallOptions
+ *
+ * @type {{ name: string; factory: (require: NodeRequire) => unknown; }}
+ */
 module.exports = {
   name: "plugin-link-project",
   factory: (_require) => ({
     hooks: {
+      /** @type {(project: Project, options: InstallOptions) => void} */
       afterAllInstalled(project, options) {
         // This mode is typically used by tools like Renovate or Dependabot to
         // keep a lockfile up-to-date without incurring the full install cost.
@@ -19,6 +29,10 @@ module.exports = {
         const os = require("node:os");
         const path = require("node:path");
 
+        /**
+         * @param {string} p
+         * @returns {string}
+         */
         function normalize(p) {
           // On Windows, paths are prefixed with `/`
           return p.replace(/^[/\\]([^/\\]+:[/\\])/, "$1");

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -50,5 +50,6 @@ packageExtensions:
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-compat.cjs
     spec: "@yarnpkg/plugin-compat"
-  - path: .yarn/plugins/link-project.js
+  - path: .yarn/plugins/clean.cjs
+  - path: .yarn/plugins/link-project.cjs
 yarnPath: .yarn/releases/yarn-3.6.1.cjs

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -36,6 +36,7 @@ type FeatureProps =
 
 function getHermesVersion(): string | undefined {
   return (
+    "HermesInternal" in global &&
     HermesInternal &&
     "getRuntimeProperties" in HermesInternal &&
     typeof HermesInternal.getRuntimeProperties === "function" &&
@@ -50,7 +51,7 @@ function getReactNativeVersion(): string {
 }
 
 function isBridgeless() {
-  return RN$Bridgeless === true;
+  return "RN$Bridgeless" in global && RN$Bridgeless === true;
 }
 
 function isFabricInstance<T>(

--- a/package.json
+++ b/package.json
@@ -60,14 +60,13 @@
     "url": "https://github.com/microsoft/react-native-test-app.git"
   },
   "scripts": {
-    "clean": "git clean -dfqx --exclude=.yarn/cache",
     "format:c": "clang-format -i $(git ls-files '*.cpp' '*.h' '*.m' '*.mm')",
-    "format:js": "prettier --write $(git ls-files '*.js' '*.yml' 'test/**/*.json')",
+    "format:js": "prettier --write $(git ls-files '*.[cm]js' '*.[jt]s' '*.tsx' '*.yml' 'test/**/*.json' ':!:.yarn/releases')",
     "format:swift": "swiftformat --swiftversion 5.7 --ifdef no-indent --stripunusedargs closure-only ios macos",
     "generate:code": "node scripts/generate-manifest.mjs",
     "generate:schema": "node scripts/generate-schema.mjs",
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | yarn commitlint-lite",
-    "lint:js": "eslint $(git ls-files '*.js' '*.mjs' '*.ts' '*.tsx') && tsc",
+    "lint:js": "eslint $(git ls-files '*.[cm]js' '*.[jt]s' '*.tsx') && tsc",
     "lint:kt": "ktlint --code-style=android_studio --relative 'android/app/src/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -331,7 +331,7 @@ async function getProfile(v) {
   }
 }
 
-if (!await checkEnvironment()) {
+if (!(await checkEnvironment())) {
   process.exit(1);
 }
 


### PR DESCRIPTION
### Description

On Windows, we need to delete symlinks first to prevent `git clean` from resolving/traversing them in an infinite loop.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a