### PR TITLE
ci(windows): enable NuGet on template builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -477,8 +477,8 @@ jobs:
       - name: Build bundle and create solution
         run: |
           yarn build:windows
-          if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app }
-          else { yarn install-windows-test-app --project-directory=. }
+          if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app --use-nuget }
+          else { yarn install-windows-test-app --project-directory=. --use-nuget }
         working-directory: template-example
       - name: Build
         run: |


### PR DESCRIPTION
### Description

Windows template builds are now hovering around 30+ minutes. Enabling NuGet to bring the time down.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

| Before | After |
| :-: | :-: |
| <img width="355" alt="image" src="https://github.com/microsoft/react-native-test-app/assets/4123478/b85d06b2-28cd-4d5e-8496-c5e8c6d856cc"> | <img width="350" alt="image" src="https://github.com/microsoft/react-native-test-app/assets/4123478/e8851d29-398d-4a99-9ee3-af0e3ef9b29f"> |
