### PR TITLE
chore: update Renovate config for 0.72

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchPackagePrefixes": ["@react-native-community/cli"],
-      "allowedVersions": "^10.0.0"
+      "allowedVersions": "^11.0.0"
     },
     {
       "groupName": "Android",
@@ -29,7 +29,7 @@
     {
       "groupName": "Metro",
       "matchSourceUrlPrefixes": ["https://github.com/facebook/metro"],
-      "allowedVersions": "^0.73.0"
+      "allowedVersions": "^0.76.0"
     },
     {
       "groupName": "Moshi",
@@ -46,7 +46,7 @@
         "react-native-macos",
         "react-native-windows"
       ],
-      "allowedVersions": "^0.71.0"
+      "allowedVersions": "^0.72.0"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
### Description

Update Renovate config for 0.72

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a