### PR TITLE
chore: align `@react-native/*` packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,6 +42,12 @@
     },
     {
       "matchPackageNames": [
+        "@react-native/assets-registry",
+        "@react-native/codegen",
+        "@react-native/gradle-plugin",
+        "@react-native/js-polyfills",
+        "@react-native/normalize-colors",
+        "@react-native/virtualized-lists",
         "react-native",
         "react-native-macos",
         "react-native-windows"


### PR DESCRIPTION
### Description

Tell Renovate to not bump `@react-native/*` packages.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a