### PR TITLE
fix(ios): resolve `cli-platform-ios` via `react-native`

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -38,8 +38,9 @@ def apply_config_plugins(project_root)
   raise 'Failed to apply config plugins' unless result
 end
 
-def autolink_script_path
-  package_path = resolve_module('@react-native-community/cli-platform-ios')
+def autolink_script_path(project_root, target_platform)
+  react_native = react_native_path(project_root, target_platform)
+  package_path = resolve_module('@react-native-community/cli-platform-ios', react_native)
   File.join(package_path, 'native_modules')
 end
 
@@ -397,7 +398,7 @@ def use_test_app_internal!(target_platform, options)
 
   install! 'cocoapods', :deterministic_uuids => false if project_target[:use_turbomodule]
 
-  require_relative(autolink_script_path)
+  require_relative(autolink_script_path(project_root, target_platform))
 
   begin
     platform :ios, platforms[:ios] if target_platform == :ios

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
   "peerDependencies": {
     "@expo/config-plugins": ">=5.0",
     "@react-native-community/cli": ">=5.0",
-    "@react-native-community/cli-platform-ios": ">=5.0",
     "mustache": "^4.0.0",
     "react": "~17.0.1 || ~18.0.0 || ~18.1.0 || ~18.2.0",
     "react-native": "^0.0.0-0 || 0.64 - 0.72 || 1000.0.0",
@@ -103,9 +102,6 @@
       "optional": true
     },
     "@react-native-community/cli": {
-      "optional": true
-    },
-    "@react-native-community/cli-platform-ios": {
       "optional": true
     },
     "mustache": {
@@ -124,7 +120,6 @@
     "@expo/config-plugins": "^7.0.0",
     "@microsoft/eslint-plugin-sdl": "^0.2.0",
     "@react-native-community/cli": "^11.3.6",
-    "@react-native-community/cli-platform-ios": "^11.3.6",
     "@rnx-kit/eslint-plugin": "^0.5.0",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^4.0.5",

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -45,14 +45,8 @@ describe("getPackageVersion", () => {
   test("returns version number for specified package", () => {
     const rnPath = path.join(nodeModulesPath, "react-native");
     expect(getPackageVersion("react-native", rnPath)).toBe("1000.0.0");
-
-    const rnCliPath = path.join(
-      nodeModulesPath,
-      "@react-native-community",
-      "cli-platform-ios"
-    );
     expect(
-      getPackageVersion("@react-native-community/cli-platform-ios", rnCliPath)
+      getPackageVersion("@react-native-community/cli-platform-ios", rnPath)
     ).toBe("4.10.1");
   });
 });

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -35,10 +35,10 @@ class TestTestApp < Minitest::Test
   end
 
   def test_autolink_script_path
-    cli = fixture_path('test_app', 'node_modules', '@react-native-community', 'cli-platform-ios')
+    react_native_dir = fixture_path('test_app', 'node_modules', 'react-native')
 
-    stub :resolve_module, cli do
-      assert(require(autolink_script_path))
+    stub :react_native_path, react_native_dir do
+      assert(require(autolink_script_path(fixture_path('test_app'), :ios)))
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12161,7 +12161,6 @@ fsevents@^2.3.2:
     "@expo/config-plugins": ^7.0.0
     "@microsoft/eslint-plugin-sdl": ^0.2.0
     "@react-native-community/cli": ^11.3.6
-    "@react-native-community/cli-platform-ios": ^11.3.6
     "@rnx-kit/eslint-plugin": ^0.5.0
     "@rnx-kit/react-native-host": ^0.2.8
     "@types/jest": ^29.0.0
@@ -12195,7 +12194,6 @@ fsevents@^2.3.2:
   peerDependencies:
     "@expo/config-plugins": ">=5.0"
     "@react-native-community/cli": ">=5.0"
-    "@react-native-community/cli-platform-ios": ">=5.0"
     mustache: ^4.0.0
     react: ~17.0.1 || ~18.0.0 || ~18.1.0 || ~18.2.0
     react-native: ^0.0.0-0 || 0.64 - 0.72 || 1000.0.0
@@ -12205,8 +12203,6 @@ fsevents@^2.3.2:
     "@expo/config-plugins":
       optional: true
     "@react-native-community/cli":
-      optional: true
-    "@react-native-community/cli-platform-ios":
       optional: true
     mustache:
       optional: true


### PR DESCRIPTION
### Description

Resolving `cli-platform-ios` via `react-native` so we no longer rely on hoisting.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a