### PR TITLE
fix(windows): import transitive deps through `react-native-windows`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,6 @@
   },
   "peerDependencies": {
     "@expo/config-plugins": ">=5.0",
-    "@react-native-community/cli": ">=5.0",
-    "mustache": "^4.0.0",
     "react": "~17.0.1 || ~18.0.0 || ~18.1.0 || ~18.2.0",
     "react-native": "^0.0.0-0 || 0.64 - 0.72 || 1000.0.0",
     "react-native-macos": "^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72",
@@ -99,12 +97,6 @@
   },
   "peerDependenciesMeta": {
     "@expo/config-plugins": {
-      "optional": true
-    },
-    "@react-native-community/cli": {
-      "optional": true
-    },
-    "mustache": {
       "optional": true
     },
     "react-native-macos": {

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -53,6 +53,21 @@ function getPackageVersion(module, startDir = process.cwd()) {
   return version;
 }
 
+/**
+ * @template T
+ * @param {string[]} dependencyChain
+ * @param {string=} startDir
+ * @returns {T}
+ */
+function requireTransitive(dependencyChain, startDir = process.cwd()) {
+  const p = dependencyChain.reduce((curr, next) => {
+    const p = require.resolve(next + "/package.json", { paths: [curr] });
+    return path.dirname(p);
+  }, startDir);
+  return require(p);
+}
+
 exports.findNearest = findNearest;
 exports.getPackageVersion = getPackageVersion;
 exports.readJSONFile = readJSONFile;
+exports.requireTransitive = requireTransitive;

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,7 +1,11 @@
 // @ts-check
 "use strict";
 
-const { findNearest, getPackageVersion } = require("../scripts/helpers");
+const {
+  findNearest,
+  getPackageVersion,
+  requireTransitive,
+} = require("../scripts/helpers");
 
 describe("findNearest", () => {
   const path = require("path");
@@ -48,5 +52,28 @@ describe("getPackageVersion", () => {
     expect(
       getPackageVersion("@react-native-community/cli-platform-ios", rnPath)
     ).toBe("4.10.1");
+  });
+});
+
+describe("requireTransitive", () => {
+  const path = require("path");
+
+  test("imports transitive dependencies", () => {
+    const mustache = requireTransitive([
+      "react-native-windows",
+      "@react-native-windows/cli",
+      "mustache",
+    ]);
+    expect(mustache).toBeDefined();
+    expect(typeof mustache.parse).toBe("function");
+  });
+
+  test("imports transitive dependencies given a start path", () => {
+    const mustache = requireTransitive(
+      ["@react-native-windows/cli", "mustache"],
+      path.dirname(require.resolve("react-native-windows/package.json"))
+    );
+    expect(mustache).toBeDefined();
+    expect(typeof mustache.parse).toBe("function");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12193,18 +12193,12 @@ fsevents@^2.3.2:
     uuid: ^8.3.2
   peerDependencies:
     "@expo/config-plugins": ">=5.0"
-    "@react-native-community/cli": ">=5.0"
-    mustache: ^4.0.0
     react: ~17.0.1 || ~18.0.0 || ~18.1.0 || ~18.2.0
     react-native: ^0.0.0-0 || 0.64 - 0.72 || 1000.0.0
     react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72
     react-native-windows: ^0.0.0-0 || 0.64 - 0.72
   peerDependenciesMeta:
     "@expo/config-plugins":
-      optional: true
-    "@react-native-community/cli":
-      optional: true
-    mustache:
       optional: true
     react-native-macos:
       optional: true


### PR DESCRIPTION
### Description

Import transitive deps through `react-native-windows`. With this, we will have reduced our peer dependencies to the bare minimum.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

CI should pass.