### PR TITLE
chore: ktlint required changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           yarn test:js --ci
         shell: bash
       - name: ktlint
-        if: ${{ matrix.platform == 'macos' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.platform == 'macos' }}
         run: |
           brew install ktlint
           echo "::add-matcher::.github/ktlint.json"

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -26,7 +26,8 @@ import java.util.concurrent.CountDownLatch
 
 sealed class BundleSource {
     enum class Action {
-        RESTART, RELOAD
+        RESTART,
+        RELOAD
     }
 
     abstract fun moveTo(to: BundleSource): Action


### PR DESCRIPTION
### Description

We got a ktlint bump in-between a PR merging and being built on `trunk` and broke the pipeline.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

ktlint will no longer be run when building on `trunk`.