### PR TITLE
fix(apple): workaround build failure with Xcode 15

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -329,7 +329,7 @@ def make_project!(xcodeproj, project_root, target_platform, options)
       # https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Deprecations
       # Upstream issue: https://github.com/facebook/react-native/issues/37748
       enable_cxx17_removed_unary_binary_function =
-        (rn_version >= 7200 && rn_version < 7207) ||
+        (rn_version >= 7200 && rn_version < 7205) ||
         (rn_version >= 7100 && rn_version < 7114) ||
         (rn_version.positive? && rn_version < 7014)
       target.build_configurations.each do |config|

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "format:c": "clang-format -i $(git ls-files '*.cpp' '*.h' '*.m' '*.mm')",
     "format:js": "prettier --write $(git ls-files '*.[cm]js' '*.[jt]s' '*.tsx' '*.yml' 'test/**/*.json' ':!:.yarn/releases')",
-    "format:swift": "swiftformat --swiftversion 5.7 --ifdef no-indent --stripunusedargs closure-only ios macos",
+    "format:swift": "swiftformat --swiftversion 5.8 --ifdef no-indent --stripunusedargs closure-only ios macos",
     "generate:code": "node scripts/generate-manifest.mjs",
     "generate:docs": "node scripts/generate-manifest-docs.mjs",
     "generate:schema": "node scripts/generate-schema.mjs",


### PR DESCRIPTION
### Description

In Xcode 15, `unary_function` and `binary_function` are no longer provided in C++17 and newer Standard modes. See Xcode release notes: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Deprecations

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Install Xcode 15.
2. Build the iOS app:
    ```
    cd example
    pod install --project-directory=ios
    yarn ios
    ```