### PR TITLE
ci: default Xcode version on `macos-13` is 14.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   VisualStudioVersion: "17.0"
-  XCODE_DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
 concurrency:
   # Ensure single build of a pull request. `trunk` should not be affected.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.run_id }}
@@ -148,7 +147,6 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: example
-          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -196,7 +194,6 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
-          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -313,7 +310,6 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: example
-          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -375,7 +371,6 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
-          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:


### PR DESCRIPTION
### Description

Builds are failing because of changes in the `macos-13` agents:

```
xcode-select: error: invalid developer directory '/Applications/Xcode_14.3.1.app/Contents/Developer'
```

Full build logs: https://github.com/microsoft/react-native-test-app/actions/runs/6243810173/job/16949777573

See also https://github.com/actions/runner-images/blob/macos-13/20230903.1/images/macos/macos-13-Readme.md#xcode

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a