### PR TITLE
fix: fix `-h` and `-v` flags not working as intended

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -68,6 +68,9 @@ const { parseArgs } = require("../scripts/parseargs");
  */
 const cliPlatformIOS = "@react-native-community/cli-platform-ios";
 
+/** @type {{ encoding: "utf-8" }} */
+const utf8 = { encoding: "utf-8" };
+
 /**
  * Prints an error message to the console.
  * @param {string} message
@@ -421,9 +424,7 @@ function reactNativeConfig({ name, testAppPath, platforms, flatten }) {
   }
 
   const config = path.join(testAppPath, "example", "react-native.config.js");
-  return fs
-    .readFileSync(config, { encoding: "utf-8" })
-    .replace(/Example/g, name);
+  return fs.readFileSync(config, utf8).replace(/Example/g, name);
 }
 
 /**
@@ -530,9 +531,7 @@ const getConfig = (() => {
                     source: path.join(templateDir, "index.js"),
                   },
                   "package.json": fs
-                    .readFileSync(path.join(templateDir, "package.json"), {
-                      encoding: "utf-8",
-                    })
+                    .readFileSync(path.join(templateDir, "package.json"), utf8)
                     .replace(/HelloWorld/g, name),
                 }),
           },

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -33,8 +33,9 @@ function findNearest(
 
 /**
  * Reads and parses JSON file at specified path.
+ * @template [T = Record<string, unknown>]
  * @param {import("node:fs").PathLike} path
- * @returns {Record<string, unknown>}
+ * @returns {T}
  */
 function readJSONFile(path, fs = require("fs")) {
   return JSON.parse(fs.readFileSync(path, { encoding: "utf-8" }));

--- a/scripts/parseargs.js
+++ b/scripts/parseargs.js
@@ -137,7 +137,7 @@ function parseArgs(description, options, callback) {
 
   const args = require("minimist")(
     process.argv.slice(2),
-    minimistOptions(options)
+    minimistOptions(mergedOptions)
   );
 
   if (args["help"]) {

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -8,6 +8,7 @@ const path = require("path");
 const {
   findNearest,
   getPackageVersion,
+  readJSONFile,
   requireTransitive,
 } = require("../scripts/helpers");
 const { parseArgs } = require("../scripts/parseargs");
@@ -24,6 +25,20 @@ const { parseArgs } = require("../scripts/parseargs");
  *   assetItemFilters: string;
  *   assetFilters: string;
  * }} Assets;
+ *
+ * @typedef {string[] | { windows?: string[] }} Resources;
+ *
+ * @typedef {{
+ *   name?: string;
+ *   singleApp?: string;
+ *   resources?: Resources;
+ *   windows?: {
+ *     appxManifest?: string;
+ *     certificateKeyFile?: string;
+ *     certificatePassword?: string;
+ *     certificateThumbprint?: string;
+ *   };
+ * }} AppManifest
  */
 
 const templateView = {
@@ -250,11 +265,7 @@ function nuGetPackage(id, version) {
 }
 
 /**
- * @param {{
- *   certificateKeyFile?: string;
- *   certificateThumbprint?: string;
- *   certificatePassword?: string;
- * }} certificate
+ * @param {Required<AppManifest>["windows"]} certificate
  * @param {string} projectPath
  * @returns {string}
  */
@@ -525,8 +536,9 @@ function getBundleResources(manifestFilePath, fs = require("fs")) {
 
   if (manifestFilePath) {
     try {
-      const content = fs.readFileSync(manifestFilePath, textFileReadOptions);
-      const { name, singleApp, resources, windows } = JSON.parse(content);
+      /** @type {AppManifest} */
+      const manifest = readJSONFile(manifestFilePath, fs);
+      const { name, singleApp, resources, windows } = manifest;
       const projectPath = path.dirname(manifestFilePath);
       return {
         appName: name || defaultName,

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -657,8 +657,8 @@ function generateSolution(
     projDir
   );
 
-  fs.mkdirSync(projectFilesDestPath, { recursive: true });
-  fs.mkdirSync(destPath, { recursive: true });
+  fs.mkdirSync(projectFilesDestPath, mkdirRecursiveOptions);
+  fs.mkdirSync(destPath, mkdirRecursiveOptions);
 
   require("../scripts/validate-manifest").validate("file", destPath);
 


### PR DESCRIPTION
### Description

The short forms of `--help` and `--version` (`-h` and `-v` respectively) have been broken since #1367.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Both of these should print the help message:

```
yarn configure-test-app --help
yarn configure-test-app -h
```

These should print the version number:

```
yarn configure-test-app --version
yarn configure-test-app -v
```