### PR TITLE
fix(android): bump target API level to 33

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -50,7 +50,7 @@ class ComponentActivity : ReactActivity() {
         findClass(componentName)?.let {
             @Suppress("UNCHECKED_CAST")
             val fragmentClass = it as Class<Fragment>
-            val fragment = fragmentClass.newInstance()
+            val fragment = fragmentClass.getDeclaredConstructor().newInstance()
 
             if (savedInstanceState == null) {
                 supportFragmentManager.beginTransaction()

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -35,6 +35,8 @@ static String getKspVersion(String kotlinVersion) {
     return [
         // Run `scripts/update-ksp-versions.mjs` to update this list
         // update-ksp-versions start
+        "1.9.10-1.0.13",
+        "1.9.0-1.0.13",
         "1.8.22-1.0.11",
         "1.8.21-1.0.11",
         "1.8.20-1.0.11",
@@ -66,9 +68,9 @@ static int toVersionNumber(String version) {
 ext {
     apply(from: "${buildscript.sourceFile.getParent()}/test-app-util.gradle")
 
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     minSdkVersion = 23
-    targetSdkVersion = 29
+    targetSdkVersion = 33
 
     reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
     autodetectReactNativeVersion = reactNativeVersion == 0 || reactNativeVersion >= 7100

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: ["module:metro-react-native-babel-preset"],
+  presets: (() => {
+    try {
+      return [require.resolve("@react-native/babel-preset")];
+    } catch (_) {
+      return ["module:metro-react-native-babel-preset"];
+    }
+  })(),
 };

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -321,11 +321,13 @@ async function getProfile(v) {
     default: {
       const coreOnly = process.argv.includes("--core-only");
       const [
-        { version: rnMetroConfig },
+        { version: rnBabelPresetVersion },
+        { version: rnMetroConfigVersion },
         reactNative,
         { version: rnmVersion },
         { version: rnwVersion },
       ] = await Promise.all([
+        fetchPackageInfo(`@react-native/babel-preset@^${v}.0-0`),
         fetchPackageInfo(`@react-native/metro-config@^${v}.0-0`),
         fetchPackageInfo(`react-native@^${v}.0-0`),
         coreOnly
@@ -338,7 +340,8 @@ async function getProfile(v) {
       const commonDeps = await resolveCommonDependencies(reactNative);
       return {
         ...commonDeps,
-        "@react-native/metro-config": rnMetroConfig,
+        "@react-native/babel-preset": rnBabelPresetVersion,
+        "@react-native/metro-config": rnMetroConfigVersion,
         "react-native": reactNative.version,
         "react-native-macos": rnmVersion,
         "react-native-windows": rnwVersion,

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -128,6 +128,7 @@ function inferReactNativeVersion({ name, version, dependencies }) {
     9: "^0.70",
     10: "^0.71",
     11: "^0.72",
+    12: "^0.73",
   }[m[1]];
   if (!v) {
     throw new Error(`Unsupported '${cliPackage}' version: ${cliVersion}`);
@@ -318,6 +319,7 @@ async function getProfile(v) {
     }
 
     default: {
+      const coreOnly = process.argv.includes("--core-only");
       const [
         { version: rnMetroConfig },
         reactNative,
@@ -326,8 +328,12 @@ async function getProfile(v) {
       ] = await Promise.all([
         fetchPackageInfo(`@react-native/metro-config@^${v}.0-0`),
         fetchPackageInfo(`react-native@^${v}.0-0`),
-        fetchPackageInfo(`react-native-macos@^${v}.0-0`),
-        fetchPackageInfo(`react-native-windows@^${v}.0-0`),
+        coreOnly
+          ? Promise.resolve({ version: undefined })
+          : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
+        coreOnly
+          ? Promise.resolve({ version: undefined })
+          : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
       ]);
       const commonDeps = await resolveCommonDependencies(reactNative);
       return {

--- a/scripts/test-matrix.sh
+++ b/scripts/test-matrix.sh
@@ -23,7 +23,7 @@ function pod_install {
 function prepare {
   terminate_dev_server
   git checkout .
-  npm run set-react-version ${VERSION}
+  npm run set-react-version ${VERSION} -- --core-only
   git clean -dfqx --exclude='.yarn/cache' --exclude='example/*.png'
   ${PACKAGE_MANAGER} install
   pushd example 1> /dev/null


### PR DESCRIPTION
### Description

- Addressed `Class.newInstance()` deprecation
- Updated list of KSP (Kotlin Symbol Processing) versions
- Bumped Android SDK Platform to 34
- Added flag for ignoring out-of-tree platforms in `set-react-version` script

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
cd example
yarn android

# In a new terminal
yarn start
```