### PR TITLE
fix(apple): disable `deterministic_uuids` starting with 0.73

### DIFF
--- a/ios/ReactTestApp/Info.plist
+++ b/ios/ReactTestApp/Info.plist
@@ -43,14 +43,8 @@
 	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>The camera is needed to scan QR codes for JS bundle URLs</string>

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -393,6 +393,7 @@ def make_project!(xcodeproj, project_root, target_platform, options)
       :ios => config.resolve_build_setting('IPHONEOS_DEPLOYMENT_TARGET'),
       :macos => config.resolve_build_setting('MACOSX_DEPLOYMENT_TARGET'),
     },
+    :react_native_version => rn_version,
     :use_fabric => use_fabric,
     :use_turbomodule => use_turbomodule,
     :code_sign_identity => code_sign_identity || '',
@@ -408,7 +409,9 @@ def use_test_app_internal!(target_platform, options)
   project_target = make_project!(xcodeproj, project_root, target_platform, options)
   xcodeproj_dst, platforms = project_target.values_at(:xcodeproj_path, :platforms)
 
-  install! 'cocoapods', :deterministic_uuids => false if project_target[:use_turbomodule]
+  if project_target[:use_turbomodule] || project_target[:react_native_version] >= 7300
+    install! 'cocoapods', :deterministic_uuids => false
+  end
 
   require_relative(autolink_script_path(project_root, target_platform))
 

--- a/macos/ReactTestApp/Info.plist
+++ b/macos/ReactTestApp/Info.plist
@@ -26,14 +26,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2020 Microsoft. All rights reserved.</string>


### PR DESCRIPTION
### Description

Disable `deterministic_uuids` starting with 0.73.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.73
# Manually remove react-native-macos from both `package.json` and `example/package.json`
yarn
cd example
rm ios/Podfile.lock
pod install --project-directory=ios
```