### PR TITLE
chore: allow prereleases when building nightlies

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -123,12 +123,12 @@ function inferReactNativeVersion({ name, version, dependencies }) {
   }
 
   const v = {
-    7: "^0.68",
-    8: "^0.69",
-    9: "^0.70",
-    10: "^0.71",
-    11: "^0.72",
-    12: "^0.73",
+    7: "^0.68.0-0",
+    8: "^0.69.0-0",
+    9: "^0.70.0-0",
+    10: "^0.71.0-0",
+    11: "^0.72.0-0",
+    12: "^0.73.0-0",
   }[m[1]];
   if (!v) {
     throw new Error(`Unsupported '${cliPackage}' version: ${cliVersion}`);


### PR DESCRIPTION
### Description

`react-native-macos` nightlies are failing because it cannot find `react-native@npm:^0.73`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version canary-macos
yarn
```

The command will still fail, but it will at least resolve `react-native`.

#### Before

```
➤ YN0001: │ Error: react-native@npm:^0.73: No candidates found
```

#### After

```
➤ YN0001: │ Error: @react-native-mac/virtualized-lists@npm:^0.73.0: No candidates found
```