### PR TITLE
fix: add Flipper deprecation warning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -418,6 +418,8 @@ dependencies {
     }
 
     if (project.ext.react.enableFlipper) {
+        logger.warn("\nFlipper is deprecated and is removed from react-native in 0.74")
+        logger.warn("\nFlipper will be removed from react-native-test-app in 3.0")
         def flipperVersion = project.ext.react.enableFlipper
         debugImplementation("com.facebook.flipper:flipper:${flipperVersion}") {
             exclude(group: "com.facebook.fbjni")

--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/CyclomaticComplexity
+
 require 'open3'
 
 def include_react_native!(options)
@@ -6,6 +8,11 @@ def include_react_native!(options)
   )
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
+
+  if target_platform == :ios && flipper_versions
+    Pod::UI.warn('Flipper is deprecated and is removed from react-native in 0.74')
+    Pod::UI.warn('Flipper will be removed from react-native-test-app in 3.0')
+  end
 
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
   use_react_native!(options)
@@ -30,3 +37,5 @@ def include_react_native!(options)
     end
   }
 end
+
+# rubocop:enable Metrics/CyclomaticComplexity

--- a/ios/use_react_native-0.68.rb
+++ b/ios/use_react_native-0.68.rb
@@ -10,6 +10,11 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
+  if target_platform == :ios && flipper_versions
+    Pod::UI.warn('Flipper is deprecated and is removed from react-native in 0.74')
+    Pod::UI.warn('Flipper will be removed from react-native-test-app in 3.0')
+  end
+
   use_new_architecture!(options)
   use_flipper!(flipper_versions) if target_platform == :ios && flipper_versions
   use_react_native!(options)

--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -12,26 +12,38 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
-  if target_platform == :ios && flipper_versions
-    Pod::UI.warn(
-      'use_flipper is deprecated from 0.70; use the flipper_configuration ' \
-      'option in the use_test_app! function instead if you don\'t need to ' \
-      'support older versions of react-native.'
-    )
-    options[:flipper_configuration] = FlipperConfiguration.enabled(['Debug'], flipper_versions)
+  if target_platform == :ios && (flipper_versions || options.key?(:flipper_configuration))
+    Pod::UI.warn('Flipper is deprecated and is removed from react-native in 0.74')
+    Pod::UI.warn('Flipper will be removed from react-native-test-app in 3.0')
+    if flipper_versions && defined?(FlipperConfiguration)
+      options[:flipper_configuration] = FlipperConfiguration.enabled(['Debug'], flipper_versions)
+    end
   end
 
   use_new_architecture!(options)
-  use_react_native!(
-    path: react_native,
-    fabric_enabled: options[:fabric_enabled] == true,
-    new_arch_enabled: options[:new_arch_enabled] == true,
-    production: options.key?(:production) ? options[:production] : ENV['PRODUCTION'] == '1',
-    hermes_enabled: options[:hermes_enabled] == true,
-    flipper_configuration: options[:flipper_configuration] || FlipperConfiguration.disabled,
-    app_path: options[:app_path] || '..',
-    config_file_dir: options[:config_file_dir] || ''
-  )
+  if defined?(FlipperConfiguration)
+    # TODO: Remove this branch in 3.0
+    use_react_native!(
+      path: react_native,
+      fabric_enabled: options[:fabric_enabled] == true,
+      new_arch_enabled: options[:new_arch_enabled] == true,
+      production: options.key?(:production) ? options[:production] : ENV['PRODUCTION'] == '1',
+      hermes_enabled: options[:hermes_enabled] == true,
+      flipper_configuration: options[:flipper_configuration] || FlipperConfiguration.disabled,
+      app_path: options[:app_path] || '..',
+      config_file_dir: options[:config_file_dir] || ''
+    )
+  else
+    use_react_native!(
+      path: react_native,
+      fabric_enabled: options[:fabric_enabled] == true,
+      new_arch_enabled: options[:new_arch_enabled] == true,
+      production: options.key?(:production) ? options[:production] : ENV['PRODUCTION'] == '1',
+      hermes_enabled: options[:hermes_enabled] == true,
+      app_path: options[:app_path] || '..',
+      config_file_dir: options[:config_file_dir] || ''
+    )
+  end
 
   # If we're using react-native@main, we'll also need to prepare
   # `react-native-codegen`.


### PR DESCRIPTION
### Description

Flipper has been removed upstream. We will also be removing it from 3.0.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Verify that there are no warnings when running:

```
cd example/android
./gradlew clean  # No Flipper warnings here
cd ..
pod install --project-directory=ios  # No Flipper warnings here
```

Enable Flipper:

```diff
diff --git a/example/android/gradle.properties b/example/android/gradle.properties
index a951019..feed9af 100644
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -29,7 +29,7 @@ android.enableJetifier=true

 # Version of Flipper to use with React Native. Default value is whatever React
 # Native defaults to. To disable Flipper, set it to `false`.
-#FLIPPER_VERSION=0.182.0
+FLIPPER_VERSION=0.182.0

 # Enable Fabric at runtime.
 #USE_FABRIC=1
diff --git a/example/ios/Podfile b/example/ios/Podfile
index 245fc9a..be8485f 100644
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -2,7 +2,7 @@ require_relative '../node_modules/react-native-test-app/test_app'

 workspace 'Example.xcworkspace'

-use_flipper! false unless ENV['ENABLE_FLIPPER']
+use_flipper!

 options = {
   :fabric_enabled => false,
```

With Flipper enabled, we should see warnings:

```
cd android
./gradlew clean  # Flipper deprecation warning
cd ..
pod install --project-directory=ios  # Flipper deprecation warning
```

Finally, verify that `react-native@nightly` builds: https://github.com/microsoft/react-native-test-app/actions/runs/6556025689/job/17805367241