### PR TITLE
chore: forbid `process.exit()`

### DIFF
--- a/.github/eslint.config.js
+++ b/.github/eslint.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  extends: ["plugin:@microsoft/sdl/required", "plugin:@rnx-kit/recommended"],
-  ignorePatterns: ["!.yarn"],
-};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+const { FlatCompat } = require("@eslint/eslintrc");
+const js = require("@eslint/js");
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+module.exports = [
+  ...compat.extends(
+    "plugin:@microsoft/sdl/required",
+    "plugin:@rnx-kit/recommended"
+  ),
+  {
+    ignores: ["!.yarn"],
+    plugins: {
+      local: require("./scripts/eslint/plugin"),
+    },
+    rules: {
+      "local/no-process-exit": "error",
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
+    "@eslint/eslintrc": "^2.1.2",
+    "@eslint/js": "^8.0.0",
     "@expo/config-plugins": "^7.0.0",
     "@microsoft/eslint-plugin-sdl": "^0.2.0",
     "@react-native-community/cli": "^11.3.6",
@@ -158,9 +160,6 @@
   "workspaces": [
     "example"
   ],
-  "eslintConfig": {
-    "extends": "./.github/eslint.config.js"
-  },
   "prettier": "./.github/prettierrc.json",
   "release": {
     "extends": "./.github/semantic-release.json"

--- a/scripts/eslint/no-process-exit.js
+++ b/scripts/eslint/no-process-exit.js
@@ -1,0 +1,58 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+/**
+ * @author Nicholas C. Zakas
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Toru Nagashima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "disallow the use of `process.exit()`",
+      category: "Possible Errors",
+      recommended: false,
+      url: "https://github.com/eslint-community/eslint-plugin-n/blob/16.2.0/docs/rules/no-process-exit.md",
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noProcessExit: "Don't use process.exit(); throw an error instead.",
+    },
+  },
+
+  create(context) {
+    return {
+      "CallExpression > MemberExpression.callee[object.name = 'process'][property.name = 'exit']"(
+        node
+      ) {
+        context.report({
+          node: node.parent,
+          messageId: "noProcessExit",
+        });
+      },
+    };
+  },
+};

--- a/scripts/eslint/plugin.js
+++ b/scripts/eslint/plugin.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "no-process-exit": require("./no-process-exit"),
+  },
+};

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -352,6 +352,7 @@ async function getProfile(v) {
 }
 
 if (!(await checkEnvironment())) {
+  // eslint-disable-next-line local/no-process-exit
   process.exit(1);
 }
 
@@ -361,6 +362,7 @@ if (!isValidVersion(version)) {
   console.log(
     `Usage: ${script} [<version number> | ${VALID_TAGS.join(" | ")}]`
   );
+  // eslint-disable-next-line local/no-process-exit
   process.exit(1);
 }
 

--- a/test/validate-manifest.test.mjs
+++ b/test/validate-manifest.test.mjs
@@ -16,12 +16,6 @@ describe("validate-manifest", () => {
   /** @type {typeof validateManifestActual} */
   const validateManifest = (p) => validateManifestActual(p, fs);
 
-  /*
-  jest.spyOn(global.process, "exit").mockImplementation((code) => {
-    throw new Error(code?.toString() ?? "0");
-  });
-  */
-
   afterEach(() => {
     fs.__setMockFiles();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,7 +1881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.51.0":
+"@eslint/js@npm:8.51.0, @eslint/js@npm:^8.0.0":
   version: 8.51.0
   resolution: "@eslint/js@npm:8.51.0"
   checksum: 0228bf1e1e0414843e56d9ff362a2a72d579c078f93174666f29315690e9e30a8633ad72c923297f7fd7182381b5a476805ff04dac8debe638953eb1ded3ac73
@@ -11139,6 +11139,8 @@ fsevents@^2.3.2:
   dependencies:
     "@babel/core": ^7.1.6
     "@babel/preset-env": ^7.1.6
+    "@eslint/eslintrc": ^2.1.2
+    "@eslint/js": ^8.0.0
     "@expo/config-plugins": ^7.0.0
     "@microsoft/eslint-plugin-sdl": ^0.2.0
     "@react-native-community/cli": ^11.3.6


### PR DESCRIPTION
### Description

Also migrated to ESLint's [flat config format](https://eslint.org/docs/latest/use/configure/migration-guide) because that's the only way (?) to use local custom rules.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.