### PR TITLE
ci(android): enable parallel execution

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -3,7 +3,7 @@ description: Executes a Gradle build
 inputs:
   arguments:
     description: Gradle will execute a build with the provided arguments
-    default: --no-daemon clean build check test
+    default: --no-daemon --parallel clean build check test
   project-root:
     description: The path to the root of the project
     required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,14 +253,14 @@ jobs:
       - name: Bundle JavaScript
         # Metro on nightlies currently fails with "SHA-1 for file index.js is
         # not computed" so we'll skip this step for now.
-        if: ${{ github.event_name != 'schedule' || runner.os != 'Windows' }}
+        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
         run: |
           yarn build:android || yarn build:android
         shell: bash
         working-directory: example
       - name: Build
         # Nightlies currently fail on Windows because of wrong path separators.
-        if: ${{ github.event_name != 'schedule' || runner.os != 'Windows' }}
+        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
         uses: ./.github/actions/gradle
         with:
           project-root: example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,14 +253,14 @@ jobs:
       - name: Bundle JavaScript
         # Metro on nightlies currently fails with "SHA-1 for file index.js is
         # not computed" so we'll skip this step for now.
-        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.event_name != 'schedule' || runner.os != 'Windows' }}
         run: |
           yarn build:android || yarn build:android
         shell: bash
         working-directory: example
       - name: Build
         # Nightlies currently fail on Windows because of wrong path separators.
-        if: ${{ github.event_name != 'schedule' || matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.event_name != 'schedule' || runner.os != 'Windows' }}
         uses: ./.github/actions/gradle
         with:
           project-root: example


### PR DESCRIPTION
### Description

Execute Gradle tasks [in parallel](https://docs.gradle.org/current/userguide/performance.html#parallel_execution).

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

| Before | After |
| :-: | :-: |
| ![image](https://github.com/microsoft/react-native-test-app/assets/4123478/6831e4c6-3b71-464d-8266-8e347ce83f26) | ![image](https://github.com/microsoft/react-native-test-app/assets/4123478/2b262422-4e08-49f7-b970-6026e2879486) |
