### PR TITLE
fix: actually disable Flipper on Android and iOS (both local example app and new generation)

### DIFF
--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -134,6 +134,7 @@ ext.getArchitectures = {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+// TODO: this will not work 0.74 onward.
 ext.getFlipperRecommendedVersion = { baseDir ->
     def reactNativePath = findNodeModulesPath("react-native", baseDir)
     def props = new Properties()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -28,8 +28,9 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of Flipper to use with React Native. Default value is whatever React
-# Native defaults to. To disable Flipper, set it to `false`.
-#FLIPPER_VERSION=0.182.0
+# Native defaults to. To enable Flipper, set the value to `X.Y.Z` (version you want to use).
+# To disable Flipper, set it to `false`.
+FLIPPER_VERSION=false
 
 # Enable Fabric at runtime.
 #USE_FABRIC=1

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -2,7 +2,7 @@ require_relative '../node_modules/react-native-test-app/test_app'
 
 workspace 'Example.xcworkspace'
 
-use_flipper! false unless ENV['ENABLE_FLIPPER']
+use_flipper! false unless ENV['USE_FLIPPER'] == '1'
 
 options = {
   :fabric_enabled => false,

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -643,7 +643,7 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              "use_flipper! false unless ENV['USE_FLIPPER']",
+              "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
               "",
               `workspace '${name}.xcworkspace'`,
               "",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -643,7 +643,7 @@ const getConfig = (() => {
             Podfile: join(
               `require_relative '${testAppRelPath}/test_app'`,
               "",
-              "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+              "use_flipper! false unless ENV['USE_FLIPPER']",
               "",
               `workspace '${name}.xcworkspace'`,
               "",

--- a/test/android-test-app/test-app-util.test.mjs
+++ b/test/android-test-app/test-app-util.test.mjs
@@ -141,6 +141,11 @@ describe("test-app-util.gradle", () => {
         ...buildGradle,
         'println("getFlipperVersion() = " + ext.getFlipperVersion(rootDir))',
       ],
+      "gradle.properties": [
+        "android.useAndroidX=true",
+        "android.enableJetifier=true",
+        "#FLIPPER_VERSION=0.0.0-test",
+      ],
     });
 
     equal(status, 0);

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -113,7 +113,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false unless ENV['USE_FLIPPER']",
+          "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -298,7 +298,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false unless ENV['USE_FLIPPER']",
+          "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -426,7 +426,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false unless ENV['USE_FLIPPER']",
+          "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -495,7 +495,7 @@ describe("gatherConfig()", () => {
         Podfile: join(
           "require_relative '../test_app'",
           "",
-          "use_flipper! false unless ENV['USE_FLIPPER']",
+          "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -612,7 +612,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false unless ENV['USE_FLIPPER']",
+          "use_flipper! false unless ENV['USE_FLIPPER'] == '1'",
           "",
           "workspace 'Test.xcworkspace'",
           "",

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -113,7 +113,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+          "use_flipper! false unless ENV['USE_FLIPPER']",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -298,7 +298,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+          "use_flipper! false unless ENV['USE_FLIPPER']",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -426,7 +426,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+          "use_flipper! false unless ENV['USE_FLIPPER']",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -495,7 +495,7 @@ describe("gatherConfig()", () => {
         Podfile: join(
           "require_relative '../test_app'",
           "",
-          "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+          "use_flipper! false unless ENV['USE_FLIPPER']",
           "",
           "workspace 'Test.xcworkspace'",
           "",
@@ -612,7 +612,7 @@ describe("gatherConfig()", () => {
         "ios/Podfile": join(
           "require_relative '../../test_app'",
           "",
-          "use_flipper! false if ENV['USE_FLIPPER'] == '0'",
+          "use_flipper! false unless ENV['USE_FLIPPER']",
           "",
           "workspace 'Test.xcworkspace'",
           "",


### PR DESCRIPTION
### Description

While locally testing https://github.com/microsoft/react-native-test-app/pull/1655 I noticed that I was getting Flipper warnings even when technically Flipper was disabled (since in the `gradle.properties` the line was commented out). See here:

<img width="1361" alt="Screenshot 2023-10-23 at 16 14 30" src="https://github.com/microsoft/react-native-test-app/assets/16104054/0233af32-bf76-4be9-8cd8-19fc7f7f80c1">

So I read the comment right above it: `To disable Flipper, set it to false.` soooo I did that. And then it actually worked (= the Flipper warnings were not shown).

After the first draft, the PR has been expanded to cover also the iOS use case (for generating new projects we have a custom file `configure.js` that was generating the Podfile instead of copying the one in the example app - which instead happens for Android). 

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

The easiest way is to actually check out https://github.com/microsoft/react-native-test-app/pull/1655, and follow the steps:

```
cd example/android
./gradlew clean  # No Flipper warnings here
```

You will see that the warnings still show if the version stays as commented line, and will only properly disappear the change extracted here is done (meaning when the version is set to `false`).