### PR TITLE
ci: `affected.mjs` can't find `origin/HEAD` on CI

### DIFF
--- a/scripts/affected.mjs
+++ b/scripts/affected.mjs
@@ -33,6 +33,14 @@ function git(...args) {
  * @returns {string}
  */
 function getDefaultBranch() {
+  if (process.env["CI"]) {
+    // CIs don't clone the repo, but use a different way to checkout a branch.
+    // This means that `origin/HEAD` is never created, which in turn means that
+    // we don't have a reliable way to get the default branch. For now, just
+    // return a hard-coded value.
+    return "origin/trunk";
+  }
+
   const defaultBranch = git("rev-parse", "--abbrev-ref", "origin/HEAD");
   if (!defaultBranch) {
     throw new Error("Failed to determine default branch");


### PR DESCRIPTION
### Description

`origin/HEAD` works locally, but on CI, we get:

```
fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a