### PR TITLE
fix(android): add `reactNativeArchitectures` to template

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -32,6 +32,11 @@ android.enableJetifier=true
 # To disable Flipper, set it to `false`.
 FLIPPER_VERSION=false
 
+# Use this property to specify which architecture you want to build.
+# You can also override it from the CLI using
+# ./gradlew <task> -PreactNativeArchitectures=x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
 # Enable Fabric at runtime.
 #USE_FABRIC=1
 

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "react-native"
   },
   "include": [
-    "App.js",
+    "App.tsx",
     "index.js"
   ]
 }


### PR DESCRIPTION
### Description

We support `reactNativeArchitectures` but it's currently missing in newly generated projects.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a