### PR TITLE
ci(android): disable Jetifier to reduce memory consumption

### DIFF
--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -8,7 +8,7 @@ index 4ab4e21..9831319 100644
  # Automatically convert third-party libraries to use AndroidX
 -android.enableJetifier=true
 +android.enableJetifier=false
-
+ 
  # Version of Flipper to use with React Native. Default value is whatever React
  # Native defaults to. To enable Flipper, set the value to `X.Y.Z` (version you want to use).
 diff --git a/example/android/gradle/wrapper/gradle-wrapper.properties b/example/android/gradle/wrapper/gradle-wrapper.properties

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -1,5 +1,18 @@
+diff --git a/example/android/gradle.properties b/example/android/gradle.properties
+index 4ab4e21..9831319 100644
+--- a/example/android/gradle.properties
++++ b/example/android/gradle.properties
+@@ -25,7 +25,7 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
+ # https://developer.android.com/topic/libraries/support-library/androidx-rn
+ android.useAndroidX=true
+ # Automatically convert third-party libraries to use AndroidX
+-android.enableJetifier=true
++android.enableJetifier=false
+
+ # Version of Flipper to use with React Native. Default value is whatever React
+ # Native defaults to. To enable Flipper, set the value to `X.Y.Z` (version you want to use).
 diff --git a/example/android/gradle/wrapper/gradle-wrapper.properties b/example/android/gradle/wrapper/gradle-wrapper.properties
-index 66c01cf..3fa8f86 100644
+index 878fe04..3fa8f86 100644
 --- a/example/android/gradle/wrapper/gradle-wrapper.properties
 +++ b/example/android/gradle/wrapper/gradle-wrapper.properties
 @@ -1,6 +1,6 @@
@@ -11,10 +24,10 @@ index 66c01cf..3fa8f86 100644
  validateDistributionUrl=true
  zipStoreBase=GRADLE_USER_HOME
 diff --git a/example/package.json b/example/package.json
-index f801fbc..27df42e 100644
+index 97105c7..6c3a680 100644
 --- a/example/package.json
 +++ b/example/package.json
-@@ -35,7 +35,6 @@
+@@ -33,7 +33,6 @@
      "react": "18.2.0",
      "react-native": "^0.72.0",
      "react-native-macos": "^0.72.0",


### PR DESCRIPTION
### Description

Latest Android nightly ran out of heap space:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform hermes-android-0.74.0-nightly-20231026-6b3289bc7-SNAPSHOT-debug.aar (com.facebook.react:hermes-android:0.74.0-nightly-20231026-6b3289bc7-SNAPSHOT:20231026.220120-1) to match attributes {artifactType=android-aar-metadata, com.android.build.api.attributes.BuildTypeAttr=debug, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=integration, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: /home/runner/.gradle/caches/modules-2/files-2.1/com.facebook.react/hermes-android/0.74.0-nightly-20231026-6b3289bc7-SNAPSHOT/fe231a8514ad8ef5fce22ee3b419952a94e0600/hermes-android-0.74.0-nightly-20231026-6b3289bc7-SNAPSHOT-debug.aar.
         > Java heap space
```

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/6662722250/job/18107501553

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
git apply scripts/disable-safe-area-context.patch
git apply scripts/android-nightly.patch
npm run set-react-version nightly
yarn
cd example/android
./gradlew clean assembleDebug
```