### PR TITLE
fix(android): fix `onReactContextInitialized()` signature

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -79,24 +79,25 @@ class MainActivity : ReactActivity() {
 
                 useAppRegistry = components.isEmpty()
                 if (useAppRegistry) {
-                    val reactInstanceListener = object : ReactInstanceEventListener {
-                        override fun onReactContextInitialized(context: ReactContext) {
-                            val ctx = context as ReactApplicationContext
-                            ctx.runOnJSQueueThread {
-                                val appKeys = AppRegistry.getAppKeys(ctx)
-                                val viewModels = appKeys.map { appKey ->
-                                    ComponentViewModel(appKey, appKey, null, null)
-                                }
-                                mainThreadHandler.post {
-                                    componentListAdapter.setComponents(viewModels)
-                                    if (isTopResumedActivity && viewModels.count() == 1) {
-                                        startComponent(viewModels[0])
+                    testApp.reactNativeHost.addReactInstanceEventListener(
+                        object : ReactInstanceEventListener {
+                            override fun onReactContextInitialized(context: ReactContext) {
+                                val ctx = context as ReactApplicationContext
+                                ctx.runOnJSQueueThread {
+                                    val appKeys = AppRegistry.getAppKeys(ctx)
+                                    val viewModels = appKeys.map { appKey ->
+                                        ComponentViewModel(appKey, appKey, null, null)
+                                    }
+                                    mainThreadHandler.post {
+                                        componentListAdapter.setComponents(viewModels)
+                                        if (isTopResumedActivity && viewModels.count() == 1) {
+                                            startComponent(viewModels[0])
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                    testApp.reactNativeHost.addReactInstanceEventListener(reactInstanceListener)
+                    )
                 } else {
                     val index =
                         if (components.count() == 1) 0 else session.lastOpenedComponent(checksum)

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -68,7 +68,7 @@ class TestAppReactNativeHost(
         }
 
         val reactInstanceListener = object : ReactInstanceEventListener {
-            override fun onReactContextInitialized(context: ReactContext?) {
+            override fun onReactContextInitialized(context: ReactContext) {
                 afterReactNativeInit()
 
                 // proactively removing the listener to avoid leaking memory

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -103,7 +103,7 @@ class TestAppReactNativeHost(
         }
     }
 
-    fun addReactInstanceEventListener(listener: (ReactContext) -> Unit) {
+    fun addReactInstanceEventListener(listener: ReactInstanceEventListener) {
         reactInstanceEventListeners.add(listener)
         reactInstanceManager.addReactInstanceEventListener(listener)
     }


### PR DESCRIPTION
### Description

The signature of `onReactContextInitialized()` changed a bit when it was migrated to Kotlin upstream: https://github.com/facebook/react-native/commit/ac7b158b3bd913e666726cd8fb08a02ddf09d0aa

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
git apply scripts/android-nightly.patch
git apply scripts/disable-safe-area-context.patch
npm run set-react-version nightly
yarn
cd example
yarn android

# In a separate terminal
yarn start
```

Make sure the following works:

- Remember last opened component:
  - Enable "Remember last opened component" in the hamburger menu
  - Navigate to App
  - Restart the app and verify that App gets opened automatically
- Autodetection:
  - Disable "Remember last opened component" in the hamburger menu
  - Empty the `components` array in `app.json` (see diff below)
  - Uninstall, rebuild and run the app
  - Verify that App automatically gets opened
  - Navigate back and verify that `Example` is the only entry in the list

```diff
diff --git a/example/app.json b/example/app.json
index ef69fa7..c7cc580 100644
--- a/example/app.json
+++ b/example/app.json
@@ -3,15 +3,6 @@
   "name": "Example",
   "displayName": "Example",
   "components": [
-    {
-      "appKey": "Example",
-      "displayName": "App"
-    },
-    {
-      "appKey": "Example",
-      "displayName": "App (modal)",
-      "presentationStyle": "modal"
-    }
   ],
   "resources": {
     "android": [
```