### PR TITLE
chore: add `eslint-plugin-wdio`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,9 +7,15 @@ const compat = new FlatCompat({
 });
 
 module.exports = [
+  {
+    plugins: {
+      wdio: require("eslint-plugin-wdio"),
+    },
+  },
   ...compat.extends(
     "plugin:@microsoft/sdl/required",
-    "plugin:@rnx-kit/recommended"
+    "plugin:@rnx-kit/recommended",
+    "plugin:wdio/recommended"
   ),
   {
     ignores: ["!.yarn"],

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/semver": "^7.3.6",
     "@types/uuid": "^8.3.1",
     "eslint": "^8.0.0",
+    "eslint-plugin-wdio": "^8.20.0",
     "js-yaml": "^4.1.0",
     "memfs": "^4.0.0",
     "minimatch": "^9.0.0",

--- a/scripts/eslint/no-process-exit.js
+++ b/scripts/eslint/no-process-exit.js
@@ -32,9 +32,8 @@ module.exports = {
     type: "suggestion",
     docs: {
       description: "disallow the use of `process.exit()`",
-      category: "Possible Errors",
       recommended: false,
-      url: "https://github.com/eslint-community/eslint-plugin-n/blob/16.2.0/docs/rules/no-process-exit.md",
+      url: "https://github.com/eslint-community/eslint-plugin-n/blob/16.3.1/docs/rules/no-process-exit.md",
     },
     fixable: null,
     schema: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,6 +6303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-wdio@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "eslint-plugin-wdio@npm:8.20.0"
+  checksum: 4c6333cb4b414c82e3d282e0118f5dda9f72b988afa7632ccf24eb2b4063d7f196039fd4db2aeab1e18e9262096921bec638d1df99cc0c6907521c6d8df54d9f
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
@@ -11173,6 +11180,7 @@ fsevents@^2.3.2:
     chalk: ^4.1.0
     cliui: ^8.0.0
     eslint: ^8.0.0
+    eslint-plugin-wdio: ^8.20.0
     fast-xml-parser: ^4.0.0
     js-yaml: ^4.1.0
     memfs: ^4.0.0


### PR DESCRIPTION
### Description

Add `eslint-plugin-wdio` to lint e2e tests.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a