### PR TITLE
chore(macos): treat Swift warnings as errors

### DIFF
--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }()
 
     private var manifestChecksum: String?
+    private var contentDidAppearToken: NSObjectProtocol?
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
         true
@@ -237,18 +238,19 @@ extension AppDelegate {
             let modalFrame = NSRect(size: WindowSize.modalSize)
             rootView.frame = modalFrame
 
-            var token: NSObjectProtocol?
-            token = NotificationCenter.default.addObserver(
+            contentDidAppearToken = NotificationCenter.default.addObserver(
                 forName: .RCTContentDidAppear,
                 object: rootView,
                 queue: nil,
-                using: { _ in
+                using: { [weak self] _ in
                     #if USE_FABRIC
                     rootView.frame = modalFrame
                     #else
                     (rootView as? RCTRootView)?.contentView.frame = modalFrame
                     #endif
-                    NotificationCenter.default.removeObserver(token!)
+                    if let token = self?.contentDidAppearToken {
+                        NotificationCenter.default.removeObserver(token)
+                    }
                 }
             )
 

--- a/macos/ReactTestApp/ReactTestApp.common.xcconfig
+++ b/macos/ReactTestApp/ReactTestApp.common.xcconfig
@@ -16,4 +16,5 @@ MTL_FAST_MATH = YES
 OTHER_CFLAGS = $(inherited) -fstack-protector-strong
 OTHER_LDFLAGS = $(inherited) -fstack-protector-strong
 SDKROOT = macosx
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
 WARNING_CFLAGS = -Wall


### PR DESCRIPTION
### Description

Enable `SWIFT_TREAT_WARNINGS_AS_ERRORS` and fix errors.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a