### PR TITLE
fix: replace `minimist` with `util.parseArgs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "chalk": "^4.1.0",
     "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",
-    "minimist": "^1.2.8",
     "prompts": "^2.4.0",
     "semver": "^7.3.5",
     "uuid": "^8.3.2"
@@ -118,7 +117,6 @@
     "@rnx-kit/eslint-plugin": "^0.6.0",
     "@rnx-kit/tsconfig": "^1.0.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/minimist": "^1.2.2",
     "@types/mustache": "^4.0.0",
     "@types/node": "^20.0.0",
     "@types/prompts": "~2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,13 +3345,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimist@npm:^1.2.2":
-  version: 1.2.5
-  resolution: "@types/minimist@npm:1.2.5"
-  checksum: 3f791258d8e99a1d7d0ca2bda1ca6ea5a94e5e7b8fc6cde84dd79b0552da6fb68ade750f0e17718f6587783c24254bbca0357648dd59dc3812c150305cabdc46
-  languageName: node
-  linkType: hard
-
 "@types/mustache@npm:^4.0.0":
   version: 4.2.5
   resolution: "@types/mustache@npm:4.2.5"
@@ -9863,7 +9856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -11454,7 +11447,6 @@ __metadata:
     "@rnx-kit/react-native-host": "npm:^0.3.1"
     "@rnx-kit/tsconfig": "npm:^1.0.0"
     "@types/js-yaml": "npm:^4.0.5"
-    "@types/minimist": "npm:^1.2.2"
     "@types/mustache": "npm:^4.0.0"
     "@types/node": "npm:^20.0.0"
     "@types/prompts": "npm:~2.4.0"
@@ -11469,7 +11461,6 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     memfs: "npm:^4.0.0"
     minimatch: "npm:^9.0.0"
-    minimist: "npm:^1.2.8"
     prettier: "npm:^3.0.0"
     prompts: "npm:^2.4.0"
     react: "npm:18.2.0"


### PR DESCRIPTION
### Description

Now that we require Node 16, we can replace `minimist` with [`util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig).

Blocked by #1600.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`--help` and `--version` need to be tested manually, otherwise CI should test the rest:

```
yarn configure-test-app --help
yarn configure-test-app -h
yarn configure-test-app --version
yarn configure-test-app -v
```