### PR TITLE
chore: use `@rnx-kit/tsconfig` as base

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@microsoft/eslint-plugin-sdl": "^0.2.0",
     "@react-native-community/cli": "^11.3.6",
     "@rnx-kit/eslint-plugin": "^0.6.0",
+    "@rnx-kit/tsconfig": "^1.0.0",
     "@types/js-yaml": "^4.0.5",
     "@types/minimist": "^1.2.2",
     "@types/mustache": "^4.0.0",

--- a/scripts/config-plugins/provider.mjs
+++ b/scripts/config-plugins/provider.mjs
@@ -4,12 +4,12 @@ import { findFile } from "../validate-manifest.js";
 import { BaseMods } from "./ExpoConfigPlugins.mjs";
 
 /**
- * @typedef {import("@expo/config-plugins/build/plugins/createBaseMod").ForwardedBaseModOptions} ForwardedBaseModOptions
+ * @typedef {import("@expo/config-plugins/build/plugins/createBaseMod.js").ForwardedBaseModOptions} ForwardedBaseModOptions
  */
 /**
  * @template ModType
  * @template {ForwardedBaseModOptions} Props
- * @typedef {import("@expo/config-plugins/build/plugins/createBaseMod").BaseModProviderMethods<ModType, Props>} BaseModProviderMethods
+ * @typedef {import("@expo/config-plugins/build/plugins/createBaseMod.js").BaseModProviderMethods<ModType, Props>} BaseModProviderMethods
  */
 
 export function makeNullProvider(defaultRead = {}) {

--- a/test/android-test-app/gradle.mjs
+++ b/test/android-test-app/gradle.mjs
@@ -29,7 +29,7 @@ function projectPath(name) {
 /**
  * Initializes a React Native project.
  * @param {string} name
- * @param {import("../../scripts/configure").ConfigureParams["platforms"]} platforms
+ * @param {import("../../scripts/configure.js").ConfigureParams["platforms"]} platforms
  * @param {Record<string, string | string[]>=} setupFiles
  */
 async function makeProject(name, platforms, setupFiles = {}) {
@@ -110,7 +110,7 @@ function runGradle(cwd, ...args) {
 /**
  * Initializes a new React Native project and runs Gradle.
  * @param {string} name
- * @param {import("../../scripts/configure").ConfigureParams["platforms"]} platforms
+ * @param {import("../../scripts/configure.js").ConfigureParams["platforms"]} platforms
  * @param {Record<string, string | string[]>=} setupFiles
  */
 export async function runGradleWithProject(name, platforms, setupFiles = {}) {

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -13,8 +13,8 @@ describe("gatherConfig()", () => {
    * File content should not be normalized because they should only contain
    * forward-slashes.
    *
-   * @param {import("../../scripts/configure").ConfigureParams} params
-   * @returns {import("../../scripts/configure").Configuration}
+   * @param {import("../../scripts/configure.js").ConfigureParams} params
+   * @returns {import("../../scripts/configure.js").Configuration}
    */
   function gatherConfig(params) {
     /** @type {(p: string) => string} */

--- a/test/configure/getConfig.test.mjs
+++ b/test/configure/getConfig.test.mjs
@@ -12,8 +12,8 @@ describe("getConfig()", () => {
 
   /**
    * Gets the list of dependencies from specified config.
-   * @param {import("../../scripts/configure").Configuration} config
-   * @param {import("../../scripts/configure").ConfigureParams} params
+   * @param {import("../../scripts/configure.js").Configuration} config
+   * @param {import("../../scripts/configure.js").ConfigureParams} params
    * @returns {string[] | undefined}
    */
   function getDependencies({ getDependencies }, params) {

--- a/test/configure/mockParams.mjs
+++ b/test/configure/mockParams.mjs
@@ -3,8 +3,8 @@
 
 /**
  * Returns mock parameters.
- * @param {Partial<import("../../scripts/configure").ConfigureParams>} [overrides]
- * @returns {import("../../scripts/configure").ConfigureParams}
+ * @param {Partial<import("../../scripts/configure.js").ConfigureParams>} [overrides]
+ * @returns {import("../../scripts/configure.js").ConfigureParams}
  */
 export function mockParams(overrides) {
   return {

--- a/test/configure/reactNativeConfig.test.mjs
+++ b/test/configure/reactNativeConfig.test.mjs
@@ -5,7 +5,7 @@ import { reactNativeConfig as reactNativeConfigActual } from "../../scripts/conf
 import { mockParams } from "./mockParams.mjs";
 
 describe("reactNativeConfig()", () => {
-  /** @type {(params: import("../../scripts/configure").ConfigureParams) => string} */
+  /** @type {(params: import("../../scripts/configure.js").ConfigureParams) => string} */
   const reactNativeConfig = (params) => {
     const config = reactNativeConfigActual(params);
     if (typeof config !== "string") {

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,9 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "@rnx-kit/tsconfig/tsconfig.esm.json",
   "compilerOptions": {
-    "module": "ES2022"
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "noEmit": true
   },
   "include": [
     "**/*.mjs"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,7 @@
 {
+  "extends": "@rnx-kit/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strict": true,
-    "module": "CommonJS",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "noEmit": true,
-    "sourceMap": true,
-    "allowJs": true,
-    "checkJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "jsx": "react",
-    "target": "ES2019",
-    "pretty": true,
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "noEmit": true
   },
   "include": [
     "plugins/**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2932,6 +2932,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rnx-kit/tsconfig@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@rnx-kit/tsconfig@npm:1.0.0"
+  checksum: 1c1c911dfae07c57d70fe272bd9d1c988a0f12be17e68a90d7cf75c8cd2c3f9dd59d568d4be78c1b3ff8e829ea17f0b261b21656e70062202f5a5d8d10aa1ebe
+  languageName: node
+  linkType: hard
+
 "@semantic-release/commit-analyzer@npm:^11.0.0":
   version: 11.0.0
   resolution: "@semantic-release/commit-analyzer@npm:11.0.0"
@@ -11452,6 +11459,7 @@ __metadata:
     "@react-native-community/cli": "npm:^11.3.6"
     "@rnx-kit/eslint-plugin": "npm:^0.6.0"
     "@rnx-kit/react-native-host": "npm:^0.2.9"
+    "@rnx-kit/tsconfig": "npm:^1.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/minimist": "npm:^1.2.2"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Use `@rnx-kit/tsconfig` as base for our TypeScript configs.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a