### PR TITLE
fix: declare support for `react-native-macos`/`-windows` 0.73

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -285,7 +285,7 @@ PODS:
   - React-jsinspector (0.72.8)
   - React-logger (0.72.8):
     - glog
-  - react-native-safe-area-context (4.7.4):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - React-NativeModulesApple (0.72.8):
     - React-callinvoker
@@ -565,7 +565,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 818e03cc244596c7c2468e8cf086ba36ba7b1ad4
   React-jsinspector: fdf0a09bddecf9ce8da830bcb89a9814230c04a4
   React-logger: c2e7bb772d6e9fc3d0109d1243b81546a9c93c0f
-  react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-NativeModulesApple: 6c4ffd70a5ea234a3c574bd6488ee97d25d4f151
   React-perflogger: 2a7d221549cd5b69e95c5afa2e8d336f0465e1ec
   React-RCTActionSheet: 449042d31545790748a97d9b35d4acb683e2ad00

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.72.10)
-  - FBReactNativeSpec (0.72.10):
+  - FBLazyVector (0.72.12)
+  - FBReactNativeSpec (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.72.10)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Core (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
+    - RCTRequired (= 0.72.12)
+    - RCTTypeSafety (= 0.72.12)
+    - React-Core (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2021.07.22.00):
@@ -25,26 +25,26 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.72.10)
-  - RCTTypeSafety (0.72.10):
-    - FBLazyVector (= 0.72.10)
-    - RCTRequired (= 0.72.10)
-    - React-Core (= 0.72.10)
-  - React (0.72.10):
-    - React-Core (= 0.72.10)
-    - React-Core/DevSupport (= 0.72.10)
-    - React-Core/RCTWebSocket (= 0.72.10)
-    - React-RCTActionSheet (= 0.72.10)
-    - React-RCTAnimation (= 0.72.10)
-    - React-RCTBlob (= 0.72.10)
-    - React-RCTImage (= 0.72.10)
-    - React-RCTLinking (= 0.72.10)
-    - React-RCTNetwork (= 0.72.10)
-    - React-RCTSettings (= 0.72.10)
-    - React-RCTText (= 0.72.10)
-    - React-RCTVibration (= 0.72.10)
-  - React-callinvoker (0.72.10)
-  - React-Codegen (0.72.10):
+  - RCTRequired (0.72.12)
+  - RCTTypeSafety (0.72.12):
+    - FBLazyVector (= 0.72.12)
+    - RCTRequired (= 0.72.12)
+    - React-Core (= 0.72.12)
+  - React (0.72.12):
+    - React-Core (= 0.72.12)
+    - React-Core/DevSupport (= 0.72.12)
+    - React-Core/RCTWebSocket (= 0.72.12)
+    - React-RCTActionSheet (= 0.72.12)
+    - React-RCTAnimation (= 0.72.12)
+    - React-RCTBlob (= 0.72.12)
+    - React-RCTImage (= 0.72.12)
+    - React-RCTLinking (= 0.72.12)
+    - React-RCTNetwork (= 0.72.12)
+    - React-RCTSettings (= 0.72.12)
+    - React-RCTText (= 0.72.12)
+    - React-RCTVibration (= 0.72.12)
+  - React-callinvoker (0.72.12)
+  - React-Codegen (0.72.12):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -59,10 +59,10 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.72.10):
+  - React-Core (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.10)
+    - React-Core/Default (= 0.72.12)
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -72,47 +72,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.72.10):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.72.10):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.72.10):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.10)
-    - React-Core/RCTWebSocket (= 0.72.10)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.72.10)
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.72.10):
+  - React-Core/CoreModulesHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -125,7 +85,34 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.72.10):
+  - React-Core/Default (0.72.12):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.72.12):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.72.12)
+    - React-Core/RCTWebSocket (= 0.72.12)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.72.12)
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -138,7 +125,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.72.10):
+  - React-Core/RCTAnimationHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -151,7 +138,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.72.10):
+  - React-Core/RCTBlobHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -164,7 +151,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.72.10):
+  - React-Core/RCTImageHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -177,7 +164,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.72.10):
+  - React-Core/RCTLinkingHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -190,7 +177,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.72.10):
+  - React-Core/RCTNetworkHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -203,7 +190,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.72.10):
+  - React-Core/RCTSettingsHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -216,7 +203,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.72.10):
+  - React-Core/RCTTextHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -229,10 +216,10 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.72.10):
+  - React-Core/RCTVibrationHeaders (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.10)
+    - React-Core/Default
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -242,50 +229,63 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.72.10):
+  - React-Core/RCTWebSocket (0.72.12):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Codegen (= 0.72.10)
-    - React-Core/CoreModulesHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
+    - React-Core/Default (= 0.72.12)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.72.12):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.72.12)
+    - React-Codegen (= 0.72.12)
+    - React-Core/CoreModulesHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
     - React-RCTBlob
-    - React-RCTImage (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
+    - React-RCTImage (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.72.10):
+  - React-cxxreact (0.72.12):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.10)
-    - React-debug (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-jsinspector (= 0.72.10)
-    - React-logger (= 0.72.10)
-    - React-perflogger (= 0.72.10)
-    - React-runtimeexecutor (= 0.72.10)
-  - React-debug (0.72.10)
-  - React-jsc (0.72.10):
-    - React-jsc/Fabric (= 0.72.10)
-    - React-jsi (= 0.72.10)
-  - React-jsc/Fabric (0.72.10):
-    - React-jsi (= 0.72.10)
-  - React-jsi (0.72.10):
+    - React-callinvoker (= 0.72.12)
+    - React-debug (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-jsinspector (= 0.72.12)
+    - React-logger (= 0.72.12)
+    - React-perflogger (= 0.72.12)
+    - React-runtimeexecutor (= 0.72.12)
+  - React-debug (0.72.12)
+  - React-jsc (0.72.12):
+    - React-jsc/Fabric (= 0.72.12)
+    - React-jsi (= 0.72.12)
+  - React-jsc/Fabric (0.72.12):
+    - React-jsi (= 0.72.12)
+  - React-jsi (0.72.12):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.72.10):
+  - React-jsiexecutor (0.72.12):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-perflogger (= 0.72.10)
-  - React-jsinspector (0.72.10)
-  - React-logger (0.72.10):
+    - React-cxxreact (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-perflogger (= 0.72.12)
+  - React-jsinspector (0.72.12)
+  - React-logger (0.72.12):
     - glog
-  - React-NativeModulesApple (0.72.10):
+  - React-NativeModulesApple (0.72.12):
     - React-callinvoker
     - React-Core
     - React-cxxreact
@@ -293,17 +293,17 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.72.10)
-  - React-RCTActionSheet (0.72.10):
-    - React-Core/RCTActionSheetHeaders (= 0.72.10)
-  - React-RCTAnimation (0.72.10):
+  - React-perflogger (0.72.12)
+  - React-RCTActionSheet (0.72.12):
+    - React-Core/RCTActionSheetHeaders (= 0.72.12)
+  - React-RCTAnimation (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTAnimationHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTAppDelegate (0.72.10):
+    - RCTTypeSafety (= 0.72.12)
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTAnimationHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTAppDelegate (0.72.12):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -315,81 +315,81 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.72.10):
+  - React-RCTBlob (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTBlobHeaders (= 0.72.10)
-    - React-Core/RCTWebSocket (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-RCTNetwork (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTImage (0.72.10):
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTBlobHeaders (= 0.72.12)
+    - React-Core/RCTWebSocket (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-RCTNetwork (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTImage (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTImageHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-RCTNetwork (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTLinking (0.72.10):
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTLinkingHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTNetwork (0.72.10):
+    - RCTTypeSafety (= 0.72.12)
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTImageHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-RCTNetwork (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTLinking (0.72.12):
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTLinkingHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTNetwork (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTNetworkHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTSettings (0.72.10):
+    - RCTTypeSafety (= 0.72.12)
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTNetworkHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTSettings (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.10)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTSettingsHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-RCTText (0.72.10):
-    - React-Core/RCTTextHeaders (= 0.72.10)
-  - React-RCTVibration (0.72.10):
+    - RCTTypeSafety (= 0.72.12)
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTSettingsHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-RCTText (0.72.12):
+    - React-Core/RCTTextHeaders (= 0.72.12)
+  - React-RCTVibration (0.72.12):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.10)
-    - React-Core/RCTVibrationHeaders (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - ReactCommon/turbomodule/core (= 0.72.10)
-  - React-rncore (0.72.10)
-  - React-runtimeexecutor (0.72.10):
-    - React-jsi (= 0.72.10)
-  - React-runtimescheduler (0.72.10):
+    - React-Codegen (= 0.72.12)
+    - React-Core/RCTVibrationHeaders (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - ReactCommon/turbomodule/core (= 0.72.12)
+  - React-rncore (0.72.12)
+  - React-runtimeexecutor (0.72.12):
+    - React-jsi (= 0.72.12)
+  - React-runtimescheduler (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker
     - React-debug
     - React-jsi
     - React-runtimeexecutor
-  - React-utils (0.72.10):
+  - React-utils (0.72.12):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-debug
-  - ReactCommon/turbomodule/bridging (0.72.10):
+  - ReactCommon/turbomodule/bridging (0.72.12):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.10)
-    - React-cxxreact (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-logger (= 0.72.10)
-    - React-perflogger (= 0.72.10)
-  - ReactCommon/turbomodule/core (0.72.10):
+    - React-callinvoker (= 0.72.12)
+    - React-cxxreact (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-logger (= 0.72.12)
+    - React-perflogger (= 0.72.12)
+  - ReactCommon/turbomodule/core (0.72.12):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.10)
-    - React-cxxreact (= 0.72.10)
-    - React-jsi (= 0.72.10)
-    - React-logger (= 0.72.10)
-    - React-perflogger (= 0.72.10)
+    - React-callinvoker (= 0.72.12)
+    - React-cxxreact (= 0.72.12)
+    - React-jsi (= 0.72.12)
+    - React-logger (= 0.72.12)
+    - React-perflogger (= 0.72.12)
   - ReactNativeHost (0.2.9):
     - React-Core
     - React-cxxreact
@@ -541,47 +541,47 @@ SPEC CHECKSUMS:
   boost: 8fa3cd00fa17ef6c3221e5fd283fa93e81d23017
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
   Example-Tests: e3a0c1aa41706608d102daa2239aa6d79fcb6e51
-  FBLazyVector: 44b7e5a3c412bd051a6dbb828253b729a0f8f4c5
-  FBReactNativeSpec: b13f68533488452e920b5994161d4f64e63afbc2
+  FBLazyVector: 1224851890c748f0ce3a418ef375a1236ed08529
+  FBReactNativeSpec: 9639a4d964a54b1d056a3ea9e44c8c59be056977
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
   RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
-  RCTRequired: 1369228c675228da1310b72e52ccb5433b26a95b
-  RCTTypeSafety: 26a3983edc8c30ed2da313cf108135691d7473c7
-  React: 3010bd4ee2aed2c74cf7214ea1712289b96d9bd5
-  React-callinvoker: 48b298c78d622329f52abd689644c830d969aa93
-  React-Codegen: e1d447e163eb6992c3bfca99afecae75f2be923e
-  React-Core: 3861e1ec2fadc7dee77d0ce137a0f7f1567b7460
-  React-CoreModules: d6a36fe84bd18825bbc53cfb4d9313b906fc15fd
-  React-cxxreact: 9a86bd83a07c97606e4b895f418e784a1a53de0f
-  React-debug: 93c638a188962106c1c44755da5f010446e38a46
-  React-jsc: 8d20a1ecd3bb9534d316044747621d5aa5bf7222
-  React-jsi: eae1abfb5853ec6674f9ed7c4a4023f68c617b87
-  React-jsiexecutor: e6683549b4dcca1ebd8c3a8a446ac600725d8911
-  React-jsinspector: 91e7f804a37d63c4fd36e530021edd0e8dbb685c
-  React-logger: eff74cefd7794e473ae09ab7956549579603d7d6
-  React-NativeModulesApple: 0ec023b1d35632fcaf74bc4b45e29ece1d2fef7b
-  React-perflogger: 11e9180508289725c23242420f8815ac6760921f
-  React-RCTActionSheet: 14097fdd1b7fce51a7ab8ff9f5d28e5dc6e85ddb
-  React-RCTAnimation: 11aaf1addce5f5f52b99387e8a3ea348f90e8c31
-  React-RCTAppDelegate: 68fc784bc600b6cdc3b4586a0119651483731f90
-  React-RCTBlob: dd2814cb042dcc578ea0bfda0f91c73d11b83b53
-  React-RCTImage: b81984d56f19f9ed6a0b6ad10314b98cfae369a4
-  React-RCTLinking: b3c11d73b705c2530385b7ab33199280519f1c63
-  React-RCTNetwork: f31e042ebe3e8a93797500219ca6178bbec1dcb2
-  React-RCTSettings: 063540cf82839f031cb95a5b17d74f00f7c33815
-  React-RCTText: e1113b678400cccd18e739dd8d46d5b09cf9744b
-  React-RCTVibration: 82a7427a5c45ca4ef747dad3900d7385a89f42fe
-  React-rncore: c6456861759392e3cea4a298bd199060541f8c43
-  React-runtimeexecutor: ad4791bd8af0e1f5c3776d499b3ff7dacc00e01d
-  React-runtimescheduler: 0bc45213a24435960b71daf4cb4b95933b200980
-  React-utils: 9097e90f9eb8df45d8ffe687e4c84d3f0c543818
-  ReactCommon: 264af40c40bf5632f3773f33334173b746818235
+  RCTRequired: bfacf9ecfae24ae67ff4a62929d49f2471f95fcc
+  RCTTypeSafety: dcaad8825a650ae7aadaf9300b781e07ab8614d3
+  React: cc4714942fd88f864e20e8ad3e6edbf4222c54d9
+  React-callinvoker: c96aba9bca657eb16707e997a6718a0903178e27
+  React-Codegen: 65ed8d9fffa64a8081ee35e6fae3ef029cd2c7c0
+  React-Core: 831200b62d8971463d17039327a0550d982aea91
+  React-CoreModules: f601235f579bf9449a941a29fbe224e01d44f9e1
+  React-cxxreact: 633d2677d3527ef75a040c5b99dee9cdc2bf9c52
+  React-debug: 5cccb088017cb4adf008b1f4f908c16970d99e9d
+  React-jsc: ce1a661ad9b8c21d0b68c6d36ae0343c67fe49d2
+  React-jsi: 37b821edd936ea97187d18c29945cfdd5358278e
+  React-jsiexecutor: 2cba74981485b7ffdfd50a00078c1693eecc43f4
+  React-jsinspector: a9c2e6a72f3758359c3ec5eebc936c79db9a2f0d
+  React-logger: 6ae6640b72ecb8b555e1c30d6e9d4916ea0f87b0
+  React-NativeModulesApple: 82b3afc5e24ed572cab703c9462c3269f8ab41c5
+  React-perflogger: 62d39324878a31defe4bef979b927c4499e349ee
+  React-RCTActionSheet: 37c154868b4a36006e0db1f0e96648066dac5a55
+  React-RCTAnimation: 025d2298d4bfb61f662e029a0b738967b536fd09
+  React-RCTAppDelegate: 853ae4f815d96bcd11c7677c13b6d0da6cac7ee3
+  React-RCTBlob: 103ee176c12166af95fc688886d3eb31a16da207
+  React-RCTImage: edacf710fb5c3c99e9731d2e5614ad216d9ac4fb
+  React-RCTLinking: 5157b301fb9696c650872ef48b68b53d78d0a359
+  React-RCTNetwork: 6362aee6925bbbe6bc1b5908659b768376eca9f3
+  React-RCTSettings: 45d0e321c6b1fddeadce314b611a21366d1ab777
+  React-RCTText: 22200832f3890a9cd561591457baa347813e92b1
+  React-RCTVibration: e77697f8a2f1f08f8ee07820e93847ffead6ea07
+  React-rncore: 646f2cea30a1181f91ec687969a5e30f6f5df595
+  React-runtimeexecutor: f3f631473672673b0dedf32b6d0ce39f59fefd01
+  React-runtimescheduler: e26baec9132d9a85a257904e378d0a63b8b26d05
+  React-utils: f1241058a1fa08735e7af55dee37230f849ad27d
+  ReactCommon: 3cfbcac9c34b9779ae9ccc262122a78dfc607ddb
   ReactNativeHost: 3cc863b178e289d813b92816b149a3acde276d6e
   ReactTestApp-DevSupport: 5fd0815a03f06e26b120ac7b8a7ff29824fa700b
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 7ef818e41d5a09eb22b8a8d4ef5a5f9e2eff4292
+  Yoga: 5a5557fa1f32858eb391dfcc1afd0772966e6f5c
 
 PODFILE CHECKSUM: 39314e677d5ddf7e1e4c81e5e81f66cddabd661a
 

--- a/example/package.json
+++ b/example/package.json
@@ -20,8 +20,8 @@
   "peerDependencies": {
     "react": "17.0.1 - 18.2",
     "react-native": "^0.0.0-0 || 0.64 - 0.73 || 1000.0.0",
-    "react-native-macos": "^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72",
-    "react-native-windows": "^0.0.0-0 || 0.64 - 0.72"
+    "react-native-macos": "^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.73",
+    "react-native-windows": "^0.0.0-0 || 0.64 - 0.73"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "@expo/config-plugins": ">=5.0",
     "react": "17.0.1 - 18.2",
     "react-native": "^0.0.0-0 || 0.64 - 0.73 || 1000.0.0",
-    "react-native-macos": "^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72",
-    "react-native-windows": "^0.0.0-0 || 0.64 - 0.72"
+    "react-native-macos": "^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.73",
+    "react-native-windows": "^0.0.0-0 || 0.64 - 0.73"
   },
   "peerDependenciesMeta": {
     "@expo/config-plugins": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6604,8 +6604,8 @@ __metadata:
   peerDependencies:
     react: 17.0.1 - 18.2
     react-native: ^0.0.0-0 || 0.64 - 0.73 || 1000.0.0
-    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72
-    react-native-windows: ^0.0.0-0 || 0.64 - 0.72
+    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.73
+    react-native-windows: ^0.0.0-0 || 0.64 - 0.73
   languageName: unknown
   linkType: soft
 
@@ -11490,8 +11490,8 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 18.2
     react-native: ^0.0.0-0 || 0.64 - 0.73 || 1000.0.0
-    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72
-    react-native-windows: ^0.0.0-0 || 0.64 - 0.72
+    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.73
+    react-native-windows: ^0.0.0-0 || 0.64 - 0.73
   peerDependenciesMeta:
     "@expo/config-plugins":
       optional: true


### PR DESCRIPTION
### Description

Declare support for `react-native-macos`/`react-native-windows` 0.73

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [x] Windows

### Test plan

#### macOS

```
npm run set-react-version 0.73
yarn
cd example
rm macos/Podfile.lock
pod install --project-directory=macos
yarn macos

# In a separate terminal:
yarn start
```

#### Windows

```
npm run set-react-version 0.73
yarn
cd example
yarn install-windows-test-app
yarn windows

# In a separate terminal:
yarn start
```

### Screenshots

| macOS | Windows |
| :-: | :-: |
| ![macOS](https://github.com/microsoft/react-native-test-app/assets/4123478/01d727bc-3901-4a4c-a2fa-f94a7654079a) | ![Windows](https://github.com/microsoft/react-native-test-app/assets/4123478/e2d0130a-f2c3-450c-b5a1-edfdd629ec0f) |