### PR TITLE
chore(set-react-version): filter nightlies on stable versions

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -321,22 +321,23 @@ async function getProfile(v, coreOnly) {
     }
 
     default: {
+      const [reactNative, { version: rnmVersion }, { version: rnwVersion }] =
+        await Promise.all([
+          fetchPackageInfo(`react-native@^${v}.0-0`),
+          coreOnly
+            ? Promise.resolve({ version: undefined })
+            : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
+          coreOnly
+            ? Promise.resolve({ version: undefined })
+            : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
+        ]);
+      const target = reactNative.version?.includes("-") ? `^${v}.0-0` : `^${v}`;
       const [
         { version: rnBabelPresetVersion },
         { version: rnMetroConfigVersion },
-        reactNative,
-        { version: rnmVersion },
-        { version: rnwVersion },
       ] = await Promise.all([
-        fetchPackageInfo(`@react-native/babel-preset@^${v}.0-0`),
-        fetchPackageInfo(`@react-native/metro-config@^${v}.0-0`),
-        fetchPackageInfo(`react-native@^${v}.0-0`),
-        coreOnly
-          ? Promise.resolve({ version: undefined })
-          : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
-        coreOnly
-          ? Promise.resolve({ version: undefined })
-          : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
+        fetchPackageInfo(`@react-native/babel-preset@${target}`),
+        fetchPackageInfo(`@react-native/metro-config@${target}`),
       ]);
       const commonDeps = await resolveCommonDependencies(reactNative);
       return {


### PR DESCRIPTION
### Description

Before:

```js
{
  '@react-native-community/cli': '12.3.0',
  '@react-native-community/cli-platform-android': '12.3.0',
  '@react-native-community/cli-platform-ios': '12.3.0',
  'hermes-engine': undefined,
  'metro-react-native-babel-preset': undefined,
  react: '18.2.0',
  '@react-native/babel-preset': '0.73.0-nightly-20231002-0371014a3',
  '@react-native/metro-config': '0.73.2',
  'react-native': '0.73.1',
  'react-native-macos': '0.73.2',
  'react-native-windows': '0.73.2'
}
```

After:

```js
{
  '@react-native-community/cli': '12.3.0',
  '@react-native-community/cli-platform-android': '12.3.0',
  '@react-native-community/cli-platform-ios': '12.3.0',
  'hermes-engine': undefined,
  'metro-react-native-babel-preset': undefined,
  react: '18.2.0',
  '@react-native/babel-preset': '0.73.18',
  '@react-native/metro-config': '0.73.2',
  'react-native': '0.73.1',
  'react-native-macos': '0.73.2',
  'react-native-windows': '0.73.2'
}
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.73
```

Should no longer set a nightly version for `@react-native/babel-preset`.

```
npm run set-react-version 0.74
```

Should set a nightly version for both `@react-native/babel-preset` and `@react-native/metro-config`.