### PR TITLE
chore(ios): patch `React-Fabric` build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .vs/
 .watchman-*
 .yarn/*
+!.yarn/patches/
 !.yarn/plugins/
 !.yarn/releases/
 Pods/

--- a/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch
+++ b/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch
@@ -1,0 +1,16 @@
+diff --git a/ReactCommon/react/renderer/core/PropsParserContext.h b/ReactCommon/react/renderer/core/PropsParserContext.h
+index 7297fbba321e86e7b5eb3438a1eae7063988dddd..c589380bd27382e97dc98ff0fe983d6d3c3864ad 100644
+--- a/ReactCommon/react/renderer/core/PropsParserContext.h
++++ b/ReactCommon/react/renderer/core/PropsParserContext.h
+@@ -17,6 +17,11 @@ namespace react {
+ // It should be used as infrequently as possible - most props can and should
+ // be parsed without any context.
+ struct PropsParserContext {
++  PropsParserContext(
++      SurfaceId const surfaceId,
++      ContextContainer const &contextContainer)
++      : surfaceId(surfaceId), contextContainer(contextContainer) {}
++
+   // Non-copyable
+   PropsParserContext(const PropsParserContext &) = delete;
+   PropsParserContext &operator=(const PropsParserContext &) = delete;

--- a/example/package.json
+++ b/example/package.json
@@ -31,7 +31,7 @@
     "appium": "^2.0.0",
     "metro-react-native-babel-preset": "^0.76.8",
     "react": "18.2.0",
-    "react-native": "^0.72.0",
+    "react-native": "patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch",
     "react-native-macos": "^0.72.0",
     "react-native-safe-area-context": "^4.5.3",
     "react-native-test-app": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "minimatch": "^9.0.0",
     "prettier": "^3.0.0",
     "react": "18.2.0",
-    "react-native": "^0.72.0",
+    "react-native": "patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch",
     "react-native-macos": "^0.72.0",
     "react-native-windows": "^0.72.0",
     "semantic-release": "^22.0.0",

--- a/scripts/android-nightly.patch
+++ b/scripts/android-nightly.patch
@@ -24,12 +24,12 @@ index 878fe04..3fa8f86 100644
  validateDistributionUrl=true
  zipStoreBase=GRADLE_USER_HOME
 diff --git a/example/package.json b/example/package.json
-index 97105c7..6c3a680 100644
+index 83ac89d..6d6a21d 100644
 --- a/example/package.json
 +++ b/example/package.json
 @@ -33,7 +33,6 @@
      "react": "18.2.0",
-     "react-native": "^0.72.0",
+     "react-native": "patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch",
      "react-native-macos": "^0.72.0",
 -    "react-native-safe-area-context": "^4.5.3",
      "react-native-test-app": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6595,7 +6595,7 @@ __metadata:
     appium: "npm:^2.0.0"
     metro-react-native-babel-preset: "npm:^0.76.8"
     react: "npm:18.2.0"
-    react-native: "npm:^0.72.0"
+    react-native: "patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch"
     react-native-macos: "npm:^0.72.0"
     react-native-safe-area-context: "npm:^4.5.3"
     react-native-test-app: "workspace:*"
@@ -11478,7 +11478,7 @@ __metadata:
     prettier: "npm:^3.0.0"
     prompts: "npm:^2.4.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.72.0"
+    react-native: "patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch"
     react-native-macos: "npm:^0.72.0"
     react-native-windows: "npm:^0.72.0"
     semantic-release: "npm:^22.0.0"
@@ -11558,7 +11558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:^0.72.0":
+"react-native@npm:0.72.8":
   version: 0.72.8
   resolution: "react-native@npm:0.72.8"
   dependencies:
@@ -11604,6 +11604,55 @@ __metadata:
   bin:
     react-native: cli.js
   checksum: fae1ce6c806993e7413b2fc69115941b185c5b39b1223744c1fa3d396f340ec891864ab38f42f3a47a088e641058c9169d95711bd399befd3e7c64c83fd281be
+  languageName: node
+  linkType: hard
+
+"react-native@patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch":
+  version: 0.72.8
+  resolution: "react-native@patch:react-native@npm%3A0.72.8#~/.yarn/patches/react-native-npm-0.72.8-5af30d9693.patch::version=0.72.8&hash=55998a"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.2.1"
+    "@react-native-community/cli": "npm:11.3.10"
+    "@react-native-community/cli-platform-android": "npm:11.3.10"
+    "@react-native-community/cli-platform-ios": "npm:11.3.10"
+    "@react-native/assets-registry": "npm:^0.72.0"
+    "@react-native/codegen": "npm:^0.72.8"
+    "@react-native/gradle-plugin": "npm:^0.72.11"
+    "@react-native/js-polyfills": "npm:^0.72.1"
+    "@react-native/normalize-colors": "npm:^0.72.0"
+    "@react-native/virtualized-lists": "npm:^0.72.8"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    base64-js: "npm:^1.1.2"
+    deprecated-react-native-prop-types: "npm:^4.2.3"
+    event-target-shim: "npm:^5.0.1"
+    flow-enums-runtime: "npm:^0.0.5"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.2.1"
+    jsc-android: "npm:^250231.0.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:0.76.8"
+    metro-source-map: "npm:0.76.8"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^26.5.2"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^4.27.2"
+    react-refresh: "npm:^0.4.0"
+    react-shallow-renderer: "npm:^16.15.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
+    stacktrace-parser: "npm:^0.1.10"
+    use-sync-external-store: "npm:^1.0.0"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^6.2.2"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    react: 18.2.0
+  bin:
+    react-native: cli.js
+  checksum: 7c03e2a1d703497198855974efab2baf921886d94168755faa88eb824db279a76a685e594ac9b9eaf4f9cad1145297d0e40298ac8f999e096c2820b38cc9238a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

```
❌ /~/example/ios/Pods/Headers/Public/React-Fabric/react/renderer/core/RawPropsParser.h:50:24: no matching constructor for initialization of 'PropsParserContext'
    PropsParserContext parserContext{-1, contextContainer};
                       ^            ~~~~~~~~~~~~~~~~~~~~~~
```

Upstream fix: https://github.com/facebook/react-native/pull/42138

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

You will have to manually downgrade `react-native-safe-area-context` to 4.7.4 first, then run:

```
yarn
cd example
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```