### PR TITLE
fix(text-matrix): tweak options for rmSync to make it more likely to succeed

### DIFF
--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -130,7 +130,12 @@ function configure(platform, { hermes, newArch }) {
  * @param {"ios" | "macos"} platform
  */
 function installPods(platform) {
-  const options = { force: true, maxRetries: 3, recursive: true };
+  const options = {
+    force: true,
+    maxRetries: 3,
+    recursive: true,
+    retryDelay: 500,
+  };
   fs.rmSync(`${platform}/Podfile.lock`, options);
   fs.rmSync(`${platform}/Pods`, options);
   fs.rmSync(`${platform}/build`, options);


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

While doing my [second round of testing for the 3.0 PR](https://github.com/microsoft/react-native-test-app/pull/1600#pullrequestreview-1813512524), I kept hitting this problem of a race condition for the rmSync method. Increasing the delay from 100 (default) to 500 made it all work smoothly.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Run `test-matrix` with any version >= 71, it works without hitting any issues.

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
