### PR TITLE
fix(ios): deprecate `:use_turbomodule` for `:use_fabric`

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -5,7 +5,6 @@ workspace 'Example.xcworkspace'
 options = {
   :fabric_enabled => false,
   :hermes_enabled => false,
-  :turbomodule_enabled => false,
 }
 
 use_test_app! options do |target|

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -25,7 +25,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
 
         super.init()
 
-        #if USE_TURBOMODULE
+        #if USE_FABRIC
         RCTEnableTurboModule(true)
         #endif
 

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -1,10 +1,3 @@
-def fabric_enabled?(options, react_native_version)
-  return true if new_architecture_enabled?(options, react_native_version)
-
-  supports_new_architecture = supports_new_architecture?(react_native_version)
-  supports_new_architecture && options[:fabric_enabled]
-end
-
 def find_file(file_name, current_dir)
   return if current_dir.expand_path.to_s == '/'
 
@@ -16,7 +9,8 @@ end
 
 def new_architecture_enabled?(options, react_native_version)
   supports_new_architecture = supports_new_architecture?(react_native_version)
-  supports_new_architecture && ENV.fetch('RCT_NEW_ARCH_ENABLED', options[:turbomodule_enabled])
+  supports_new_architecture && ENV.fetch('RCT_NEW_ARCH_ENABLED',
+                                         options[:fabric_enabled] || options[:turbomodule_enabled])
 end
 
 def resolve_module(request, start_dir = Pod::Config.instance.installation_root)
@@ -48,29 +42,16 @@ end
 
 def use_new_architecture!(options)
   new_arch_enabled = new_architecture_enabled?(options, v(1_000, 0, 0))
-
-  if new_arch_enabled || options[:fabric_enabled]
-    Pod::UI.warn(
-      'As of writing, Fabric is still experimental and subject to change. ' \
-      'For more information, please see ' \
-      'https://reactnative.dev/docs/next/new-architecture-intro.'
-    )
-    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-  end
-
   return unless new_arch_enabled
 
   Pod::UI.warn(
-    'As of writing, TurboModule is still experimental and subject to change. ' \
-    'For more information, please see ' \
+    'As of writing, New Architecture (Fabric) is still experimental and ' \
+    'subject to change. For more information, please see ' \
     'https://reactnative.dev/docs/next/new-architecture-intro.'
   )
 
-  # At the moment, Fabric and TurboModule code are intertwined. We need to
-  # enable Fabric for some code that TurboModule relies on.
   options[:fabric_enabled] = true
   options[:new_arch_enabled] = true
-  options[:turbomodule_enabled] = true
   ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 end
 

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -103,8 +103,8 @@ function configure(platform, { hermes, newArch }) {
       }
       if (newArch) {
         content = content.replace(
-          ":turbomodule_enabled => false",
-          ":turbomodule_enabled => true"
+          ":fabric_enabled => false",
+          ":fabric_enabled => true"
         );
       }
       fs.writeFileSync(podfile, content);

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -3,27 +3,6 @@ require('minitest/autorun')
 require_relative('../ios/pod_helpers')
 
 class TestPodHelpers < Minitest::Test
-  def test_fabric_enabled?
-    ENV.delete('RCT_NEW_ARCH_ENABLED')
-
-    refute(fabric_enabled?({}, 0))
-    refute(fabric_enabled?({}, v(0, 68, 0)))
-
-    # Fabric is first publicly available in 0.68, but we'll require 0.71
-    refute(fabric_enabled?({ :fabric_enabled => true }, v(0, 70, 999)))
-    assert(fabric_enabled?({ :fabric_enabled => true }, v(0, 71, 0)))
-
-    # TurboModule implies Fabric
-    refute(fabric_enabled?({ :turbomodule_enabled => true }, v(0, 70, 999)))
-    assert(fabric_enabled?({ :turbomodule_enabled => true }, v(0, 71, 0)))
-
-    # `RCT_NEW_ARCH_ENABLED` enables everything
-    ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-
-    refute(fabric_enabled?({}, v(0, 70, 999)))
-    assert(fabric_enabled?({}, v(0, 71, 0)))
-  end
-
   def test_new_architecture_enabled?
     ENV.delete('RCT_NEW_ARCH_ENABLED')
 
@@ -31,11 +10,12 @@ class TestPodHelpers < Minitest::Test
     refute(new_architecture_enabled?({}, v(0, 71, 0)))
 
     # New architecture is first publicly available in 0.68, but we'll require 0.71
+    refute(new_architecture_enabled?({ :fabric_enabled => true }, v(0, 70, 999)))
+    assert(new_architecture_enabled?({ :fabric_enabled => true }, v(0, 71, 0)))
+
+    # TODO: `:turbomodule_enabled` is scheduled for removal in 4.0
     refute(new_architecture_enabled?({ :turbomodule_enabled => true }, v(0, 70, 999)))
     assert(new_architecture_enabled?({ :turbomodule_enabled => true }, v(0, 71, 0)))
-
-    # Fabric does not imply TurboModule
-    refute(new_architecture_enabled?({ :fabric_enabled => true }, v(0, 71, 0)))
 
     # `RCT_NEW_ARCH_ENABLED` enables everything
     ENV['RCT_NEW_ARCH_ENABLED'] = '1'


### PR DESCRIPTION
### Description

To better align with `react-native`, we will no longer maintain separate Fabric and Turbo Modules options. Enabling Fabric now will be the same as enabling New Architecture.

`:use_turbomodule` will still be present, but you should consider migrating to `:use_fabric`. We will remove the former in the next major release.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
# Run full test matrix for current version
node scripts/test-matrix.mjs

# Verify that `:use_turbomodule => true` still works
sed -i '' 's/fabric_enabled/turbomodule_enabled/' example/ios/Podfile
cd example
pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```

Verify that Fabric was enabled.