### PR TITLE
ci(macos): temporarily disable until publishing is fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,6 +336,7 @@ jobs:
   macos:
     name: "macOS"
     runs-on: macos-13
+    if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

macOS nightlies constantly fail because `react-native-macos` doesn't publish all the necessary packages:

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/bdb5ced3-792f-4764-9bfa-37b64293d1b3)

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a