### PR TITLE
fix: bump `@rnx-kit/react-native-host` to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('./test/test_*.rb').each { |file| require(file) }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.3.2",
+    "@rnx-kit/react-native-host": "^0.4.0",
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
     "cliui": "^8.0.0",

--- a/plugins/reanimated.js
+++ b/plugins/reanimated.js
@@ -43,7 +43,7 @@ function installerFor(version, indent = "    ") {
 
   if (version > 0 && version < v(0, 72, 0)) {
     const header = [
-      "#if !USE_TURBOMODULE",
+      "#if !USE_FABRIC",
       "#pragma clang diagnostic push",
       '#pragma clang diagnostic ignored "-Wnullability-completeness"',
       "",
@@ -62,7 +62,7 @@ function installerFor(version, indent = "    ") {
       "#endif",
       "",
       "#pragma clang diagnostic pop",
-      "#endif  // !USE_TURBOMODULE",
+      "#endif  // !USE_FABRIC",
     ].join("\n");
     const installer = [
       `${indent}const auto installer = reanimated::REAJSIExecutorRuntimeInstaller(bridge, nullptr);`,
@@ -74,10 +74,10 @@ function installerFor(version, indent = "    ") {
     // As of React Native 0.72, we need to call `REAInitializer` instead. See
     // https://github.com/software-mansion/react-native-reanimated/commit/a8206f383e51251e144cb9fd5293e15d06896df0.
     const header = [
-      "#if !USE_TURBOMODULE",
+      "#if !USE_FABRIC",
       `#define REACT_NATIVE_MINOR_VERSION ${minorVersion}`,
       "#import <RNReanimated/REAInitializer.h>",
-      "#endif  // !USE_TURBOMODULE",
+      "#endif  // !USE_FABRIC",
     ].join("\n");
     return [header, `${indent}reanimated::REAInitializer(bridge);`];
   }
@@ -115,7 +115,7 @@ function withReanimatedExecutor(config) {
       "installer",
       config.modResults.contents,
       installer,
-      /\/\/ jsExecutorFactoryForBridge: \(USE_TURBOMODULE=0\)/
+      /\/\/ jsExecutorFactoryForBridge: \(USE_FABRIC=0\)/
     );
 
     return config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,12 +2928,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@rnx-kit/react-native-host@npm:0.3.2"
+"@rnx-kit/react-native-host@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@rnx-kit/react-native-host@npm:0.4.0"
   peerDependencies:
     react-native: ">=0.66"
-  checksum: dd82840f4dd0a1d6b4f0265ec2f8acb16ade977ce36f6230a77fb2dbbc07c23c59210f8596836811883f804cede545bd1055c6b29ab3167735e55bbefcd06f4e
+  checksum: 7a03ee90caacf6f015e1c720ca8e1b50ff7af866265d01079ee4ef0f9689884e7839dd83940ffa97462232e5913f152a3a17b3975dd7b1aebb83f7a3ac88dae4
   languageName: node
   linkType: hard
 
@@ -11444,7 +11444,7 @@ __metadata:
     "@microsoft/eslint-plugin-sdl": "npm:^0.2.0"
     "@react-native-community/cli": "npm:^11.3.6"
     "@rnx-kit/eslint-plugin": "npm:^0.6.0"
-    "@rnx-kit/react-native-host": "npm:^0.3.2"
+    "@rnx-kit/react-native-host": "npm:^0.4.0"
     "@rnx-kit/tsconfig": "npm:^1.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Bump `@rnx-kit/react-native-host` to 0.4.0 and remove the last uses of `USE_TURBOMODULE`

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a