### PR TITLE
fix(apple): fix build failing on 0.71.12 or lower

### DIFF
--- a/ios/ReactTestApp/React+Compatibility.h
+++ b/ios/ReactTestApp/React+Compatibility.h
@@ -1,3 +1,9 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+NSURL *RTADefaultJSBundleURL();
+
 IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector);
+
+NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -8,6 +8,8 @@
 
 #import <objc/runtime.h>
 
+#import <React/RCTBundleURLProvider.h>
+
 #define MAKE_VERSION(maj, min, patch) ((maj * 1000000) + (min * 1000) + patch)
 
 IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
@@ -29,6 +31,25 @@ IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
     }
 
     return originalImpl;
+}
+
+// MARK: - [0.71.13] The additional `inlineSourceMap:` was added in 0.71.13
+// See https://github.com/facebook/react-native/commit/f7219ec02d71d2f0f6c71af4d5c3d4850a898fd8
+
+NSURL *RTADefaultJSBundleURL()
+{
+#if REACT_NATIVE_VERSION < MAKE_VERSION(0, 71, 13)
+    return [RCTBundleURLProvider jsBundleURLForBundleRoot:@"index"
+                                             packagerHost:@"localhost"
+                                                enableDev:YES
+                                       enableMinification:NO];
+#else
+    return [RCTBundleURLProvider jsBundleURLForBundleRoot:@"index"
+                                             packagerHost:@"localhost"
+                                                enableDev:YES
+                                       enableMinification:NO
+                                          inlineSourceMap:YES];
+#endif
 }
 
 // MARK: - [0.70.0] Alerts don't show when using UIScene

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -7,13 +7,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
 
     static func jsBundleURL() -> URL {
         RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index") {
-            RCTBundleURLProvider.jsBundleURL(
-                forBundleRoot: "index",
-                packagerHost: "localhost",
-                enableDev: true,
-                enableMinification: false,
-                inlineSourceMap: true
-            )
+            RTADefaultJSBundleURL()
         }
     }
 


### PR DESCRIPTION
### Description

`+jsBundleURLForBundleRoot:packagerHost:enableDev:enableMinification:inlineSourceMap:` was first added in 0.71.13

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.71
yarn
cd example
pod install --project-directory=ios
yarn ios

# Manually downgrade to 0.71.12 and rebuild
```