### PR TITLE
fix: print selected version when generating projects

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -110,8 +110,20 @@ function getVersion(platforms) {
     return process.argv[index + 1];
   }
 
+  /** @type {(version: string, reason: string) => void} */
+  const logVersion = (version, reason) => {
+    const chalk = require("chalk");
+    const fmtVersionFlag = chalk.bold("--version");
+    const fmtTarget = chalk.bold(version);
+    console.log(
+      `Using ${fmtTarget} because ${reason} (use ${fmtVersionFlag} to ` +
+        `specify another version)`
+    );
+  };
+
   const version = getInstalledVersion();
   if (version) {
+    logVersion(version, "the current project uses it");
     return version;
   }
 
@@ -132,14 +144,7 @@ function getVersion(platforms) {
   const minor = maxSupportedVersion % 100;
 
   const target = `^${major}.${minor}`;
-
-  const chalk = require("chalk");
-  const fmtTarget = chalk.bold(target);
-  const fmtVersionFlag = chalk.bold("--version");
-  console.log(
-    `Using ${fmtTarget} because it supports all specified platforms (use ` +
-      `${fmtVersionFlag} to manually specify a version)`
-  );
+  logVersion(target, "it supports all specified platforms");
 
   return target;
 }


### PR DESCRIPTION
### Description

Print the selected version when generating projects within an existing project.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
% yarn init-test-app --destination test-app --name TestApp -p android -p ios -p macos -p windows
Using 0.73.2 because the current project uses it (use --version to specify another version)
```