### PR TITLE
fix: use correct Gradle version for new projects

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -384,7 +384,8 @@ const getConfig = (() => {
     disableCache = false
   ) => {
     if (disableCache || typeof configuration === "undefined") {
-      const { name, templatePath, testAppPath, flatten, init } = params;
+      const { name, templatePath, testAppPath, targetVersion, flatten, init } =
+        params;
 
       // `.gitignore` files are only renamed when published.
       const gitignore = ["_gitignore", ".gitignore"].find((filename) => {
@@ -465,16 +466,24 @@ const getConfig = (() => {
                 "gradle-wrapper.jar"
               ),
             },
-            "gradle/wrapper/gradle-wrapper.properties": {
-              source: path.join(
+            "gradle/wrapper/gradle-wrapper.properties": (() => {
+              const gradleWrapperProperties = path.join(
                 testAppPath,
                 "example",
                 "android",
                 "gradle",
                 "wrapper",
                 "gradle-wrapper.properties"
-              ),
-            },
+              );
+              const props = readTextFile(gradleWrapperProperties);
+              if (toVersionNumber(targetVersion) < v(0, 73, 0)) {
+                return props.replace(
+                  /gradle-[.0-9]*-bin\.zip/,
+                  "gradle-7.6.3-bin.zip"
+                );
+              }
+              return props;
+            })(),
             "gradle.properties": {
               source: path.join(
                 testAppPath,

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -218,6 +218,11 @@ function main() {
           description: "Destination path for the app",
           type: "string",
         },
+        version: {
+          description: "React Native version",
+          type: "string",
+          short: "v",
+        },
       },
       async (args) => {
         const prompts = require("prompts");

--- a/scripts/parseargs.js
+++ b/scripts/parseargs.js
@@ -117,7 +117,7 @@ function parseArgs(description, options, callback) {
 
   if (values.help) {
     console.log(formatHelp(description, mergedOptions));
-  } else if (values.version) {
+  } else if (typeof values.version === "boolean" && values.version) {
     const { name, version } = require("../package.json");
     console.log(`${name} ${version}`);
   } else {

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -36,7 +36,7 @@ describe("gatherConfig()", () => {
 
   const gradleWrapper = readTextFile(
     "example/android/gradle/wrapper/gradle-wrapper.properties"
-  );
+  ).replace(/\r/g, "");
 
   it("returns configuration for all platforms", () => {
     deepEqual(gatherConfig(mockParams()), {

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -2,6 +2,7 @@
 import { deepEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { gatherConfig as gatherConfigActual } from "../../scripts/configure.js";
+import { readTextFile } from "../../scripts/helpers.js";
 import { join } from "../../scripts/template.js";
 import { mockParams } from "./mockParams.mjs";
 
@@ -32,6 +33,10 @@ describe("gatherConfig()", () => {
     config.oldFiles = config.oldFiles.map(normalize);
     return config;
   }
+
+  const gradleWrapper = readTextFile(
+    "example/android/gradle/wrapper/gradle-wrapper.properties"
+  );
 
   it("returns configuration for all platforms", () => {
     deepEqual(gatherConfig(mockParams()), {
@@ -81,9 +86,7 @@ describe("gatherConfig()", () => {
         "android/gradle/wrapper/gradle-wrapper.jar": {
           source: "example/android/gradle/wrapper/gradle-wrapper.jar",
         },
-        "android/gradle/wrapper/gradle-wrapper.properties": {
-          source: "example/android/gradle/wrapper/gradle-wrapper.properties",
-        },
+        "android/gradle/wrapper/gradle-wrapper.properties": gradleWrapper,
         "android/gradlew": {
           source: "example/android/gradlew",
         },
@@ -390,9 +393,7 @@ describe("gatherConfig()", () => {
         "android/gradle/wrapper/gradle-wrapper.jar": {
           source: "example/android/gradle/wrapper/gradle-wrapper.jar",
         },
-        "android/gradle/wrapper/gradle-wrapper.properties": {
-          source: "example/android/gradle/wrapper/gradle-wrapper.properties",
-        },
+        "android/gradle/wrapper/gradle-wrapper.properties": gradleWrapper,
         "android/gradlew": {
           source: "example/android/gradlew",
         },
@@ -572,9 +573,7 @@ describe("gatherConfig()", () => {
         "android/gradle/wrapper/gradle-wrapper.jar": {
           source: "example/android/gradle/wrapper/gradle-wrapper.jar",
         },
-        "android/gradle/wrapper/gradle-wrapper.properties": {
-          source: "example/android/gradle/wrapper/gradle-wrapper.properties",
-        },
+        "android/gradle/wrapper/gradle-wrapper.properties": gradleWrapper,
         "android/gradlew": {
           source: "example/android/gradlew",
         },


### PR DESCRIPTION
### Description

Use correct Gradle version for new projects

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
yarn init-test-app --destination test-app --name TestApp -p android -p ios -p macos -p windows
cat test-app/android/gradle/wrapper/gradle-wrapper.properties
# This should point to `gradle-8.4-bin.zip`

rm -r test-app
yarn init-test-app --destination test-app --name TestApp -p android -p ios -p macos -p windows --version 0.72
cat test-app/android/gradle/wrapper/gradle-wrapper.properties
# This should point to `gradle-7.6.3-bin.zip`
```