### PR TITLE
fix: only apply config plugins for current platform

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -24,7 +24,7 @@ def app_config(project_root)
   [manifest['name'], manifest['displayName'], manifest['version'], manifest['singleApp']]
 end
 
-def apply_config_plugins(project_root)
+def apply_config_plugins(project_root, target_platform)
   begin
     resolve_module('@expo/config-plugins')
   rescue StandardError
@@ -33,7 +33,7 @@ def apply_config_plugins(project_root)
   end
 
   apply_config_plugins = File.join(__dir__, '..', 'scripts', 'apply-config-plugins.mjs')
-  result = system("node \"#{apply_config_plugins}\" \"#{project_root}\"")
+  result = system("node \"#{apply_config_plugins}\" \"#{project_root}\" --#{target_platform}")
   raise 'Failed to apply config plugins' unless result
 end
 
@@ -472,7 +472,7 @@ def use_test_app_internal!(target_platform, options)
       end
     end
 
-    apply_config_plugins(project_root)
+    apply_config_plugins(project_root, target_platform)
 
     Pod::UI.notice(
       "`#{xcodeproj}` was sourced from `react-native-test-app`. " \

--- a/scripts/apply-config-plugins.mjs
+++ b/scripts/apply-config-plugins.mjs
@@ -7,6 +7,7 @@ import { parseArgs } from "node:util";
 import { findFile } from "./validate-manifest.js";
 
 /**
+ * @typedef {import("./config-plugins/types.mjs").ProjectInfo["platforms"]} Platforms
  * @param {string} projectRoot
  * @param {string[]} platforms
  */
@@ -29,7 +30,7 @@ async function main(projectRoot = process.cwd(), platforms) {
   const { applyConfigPlugins } = await import("./config-plugins/index.mjs");
   return applyConfigPlugins({
     projectRoot: path.dirname(appJsonPath),
-    platforms,
+    platforms: /** @type {Platforms} */ (platforms),
     packageJsonPath,
     appJsonPath,
   });

--- a/scripts/apply-config-plugins.mjs
+++ b/scripts/apply-config-plugins.mjs
@@ -3,9 +3,14 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { parseArgs } from "node:util";
 import { findFile } from "./validate-manifest.js";
 
-async function main(projectRoot = process.cwd()) {
+/**
+ * @param {string} projectRoot
+ * @param {string[]} platforms
+ */
+async function main(projectRoot = process.cwd(), platforms) {
   const packageJsonPath = findFile("package.json", projectRoot);
   if (!packageJsonPath) {
     throw new Error("Failed to find `package.json`");
@@ -24,10 +29,35 @@ async function main(projectRoot = process.cwd()) {
   const { applyConfigPlugins } = await import("./config-plugins/index.mjs");
   return applyConfigPlugins({
     projectRoot: path.dirname(appJsonPath),
+    platforms,
     packageJsonPath,
     appJsonPath,
   });
 }
 
-const { [2]: projectRoot } = process.argv;
-main(projectRoot);
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    android: {
+      description: "Apply Android config plugins",
+      type: "boolean",
+    },
+    ios: {
+      description: "Apply iOS config plugins",
+      type: "boolean",
+    },
+    macos: {
+      description: "Apply macOS config plugins",
+      type: "boolean",
+    },
+    windows: {
+      description: "Apply Windows config plugins",
+      type: "boolean",
+    },
+  },
+  strict: true,
+  allowPositionals: true,
+  tokens: false,
+});
+
+main(positionals[0], Object.keys(values));

--- a/scripts/config-plugins/types.mjs
+++ b/scripts/config-plugins/types.mjs
@@ -2,7 +2,7 @@
 /**
  * @typedef {{
  *   projectRoot: string;
- *   platforms: string[];
+ *   platforms: import("@expo/config-plugins").ModPlatform[];
  *   packageJsonPath: string;
  *   appJsonPath: string;
  * }} ProjectInfo

--- a/scripts/config-plugins/types.mjs
+++ b/scripts/config-plugins/types.mjs
@@ -2,6 +2,7 @@
 /**
  * @typedef {{
  *   projectRoot: string;
+ *   platforms: string[];
  *   packageJsonPath: string;
  *   appJsonPath: string;
  * }} ProjectInfo

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -5,7 +5,7 @@ import org.gradle.initialization.DefaultSettings
 import java.nio.file.Paths
 
 private static void applyConfigPlugins(String testAppDir, File rootDir) {
-    String[] patch = ["node", "${testAppDir}/scripts/apply-config-plugins.mjs"]
+    String[] patch = ["node", "${testAppDir}/scripts/apply-config-plugins.mjs", "--android"]
     def stderr = new StringBuffer()
     def proc = Runtime.runtime.exec(patch, null, rootDir)
     proc.waitForProcessOutput(null, stderr)


### PR DESCRIPTION
### Description

Only apply config plugins for current platform.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

1. Apply changes to https://github.com/sparkfabrik/sparkfabrik-react-native-idfa-aaid/pull/73
2. `npm run android` should not throw an exception
3. `npm run ios` should add `NSUserTrackingUsageDescription` to `node_modules/react-native-test-app/ios/ReactTestApp/Info.plist`