### PR TITLE
fix(android): get JS executor name directly via the executor

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -190,7 +190,7 @@ class MainActivity : ReactActivity() {
                 ReactNativeVersion.VERSION["major"] as Int,
                 ReactNativeVersion.VERSION["minor"] as Int,
                 ReactNativeVersion.VERSION["patch"] as Int,
-                reactInstanceManager.jsExecutorName,
+                testApp.reactNativeHost.jsExecutorName,
                 if (BuildConfig.ReactTestApp_useFabric) "+Fabric" else ""
             )
         }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -46,6 +46,9 @@ class TestAppReactNativeHost(
     application: Application,
     private val reactBundleNameProvider: ReactBundleNameProvider
 ) : ReactNativeHostCompat(application) {
+    val jsExecutorName: String
+        get() = javaScriptExecutorFactory.toString()
+
     var source: BundleSource =
         if (reactBundleNameProvider.bundleName == null || isPackagerRunning(application)) {
             BundleSource.Server

--- a/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
+++ b/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
@@ -13,10 +13,8 @@ abstract class ReactNativeHostCompat(application: Application) : DefaultReactNat
         init {
             try {
                 DefaultNewArchitectureEntryPoint.load(
-                    /* turboModulesEnabled */
-                    BuildConfig.ReactTestApp_useFabric,
-                    /* fabricEnabled */
-                    BuildConfig.ReactTestApp_useFabric
+                    turboModulesEnabled = BuildConfig.ReactTestApp_useFabric,
+                    fabricEnabled = BuildConfig.ReactTestApp_useFabric
                 )
             } catch (e: UnsatisfiedLinkError) {
                 // Older versions of `DefaultNewArchitectureEntryPoint` is

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -39,7 +39,7 @@ ext.checkEnvironment = { rootDir ->
         }
     } else {
         if (gradleVersion < v(7, 5, 1) || gradleVersion >= v(8, 0, 0)) {
-            warnGradle("7.6.1", "7.x", "0.71 and older")
+            warnGradle("7.6.3", "7.x", "0.71 and older")
         }
     }
 }


### PR DESCRIPTION
### Description

Get JS executor name directly via the executor. This fixes a startup crash when bridgeless mode is enabled.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

This changes how we fetch the JS executor name for the string at the bottom right on the home screen:

| 0.66 | 0.73 |
| :-: | :-: |
| ![Screenshot_1705934910](https://github.com/microsoft/react-native-test-app/assets/4123478/4d226d74-bd88-44fe-bf58-c75b0346ed72) | ![Screenshot_1705935048](https://github.com/microsoft/react-native-test-app/assets/4123478/35fa9546-3ef1-408c-9a4d-ac7d39158348) |