### PR TITLE
fix(android): add support for scoped Gradle properties

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,7 +58,7 @@ project.ext.react = [
     abiSplit             : false,
     appName              : getAppName(),
     applicationId        : getApplicationId(),
-    architectures        : getArchitectures(),
+    architectures        : getArchitectures(project),
     bundleInRelease      : false,
     enableCamera         : !getSingleAppMode(),
     enableHermes         : true,

--- a/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -20,11 +20,11 @@ class TestApp : Application(), ReactApplication {
     val manifestProvider: ManifestProvider
         get() = manifestProviderInternal
 
-    override val reactNativeHost: TestAppReactNativeHost
-        get() = reactNativeHostInternal
-
     override val reactHost: ReactHost
         get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+    override val reactNativeHost: TestAppReactNativeHost
+        get() = reactNativeHostInternal
 
     private lateinit var manifestProviderInternal: ManifestProvider
     private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -4,7 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.security.MessageDigest
 
-ext.manifest = null
+ext._manifest = null
 
 ext.checkEnvironment = { rootDir ->
     def warnGradle = { gradleVersion, gradleVersionRange, reactNativeVersion ->
@@ -100,6 +100,10 @@ ext.findNodeModulesPath = { packageName, baseDir ->
     return null
 }
 
+ext.tryGetProperty = { project, property ->
+    return project.hasProperty(property) ? project.getProperty(property) : null
+}
+
 ext.getAppName = {
     def manifest = getManifest()
     if (manifest != null) {
@@ -129,21 +133,28 @@ ext.getApplicationId = {
     return "com.microsoft.reacttestapp"
 }
 
-ext.getArchitectures = {
-    def value = project.getProperties().get("reactNativeArchitectures")
-    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+ext.getArchitectures = { project ->
+    def reactArchs = tryGetProperty(project, "react.nativeArchitectures")
+    if (reactArchs != null) {
+        return reactArchs.split(",")
+    }
+
+    def archs = tryGetProperty(project, "reactNativeArchitectures")
+    return archs != null
+        ? archs.split(",")
+        : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
 ext.getManifest = {
-    if (manifest == null) {
+    if (_manifest == null) {
         def manifestFile = findFile("app.json")
         if (manifestFile == null) {
             return null
         }
 
-        manifest = new JsonSlurper().parseText(manifestFile.text)
+        _manifest = new JsonSlurper().parseText(manifestFile.text)
     }
-    return manifest
+    return _manifest
 }
 
 ext.getPackageVersion = { packageName, baseDir ->
@@ -237,23 +248,21 @@ ext.isFabricEnabled = { project ->
 }
 
 ext.isNewArchitectureEnabled = { project ->
-    if (isPropertySet(project, "newArchEnabled", "true")) {
+    def reactNewArchEnabled = tryGetProperty(project, "react.newArchEnabled")
+    def newArchEnabled = tryGetProperty(project, "newArchEnabled")
+    if (reactNewArchEnabled == "true" || newArchEnabled == "true") {
         def version = getPackageVersionNumber("react-native", project.rootDir)
         def isSupported = version == 0 || version >= v(0, 71, 0)
         if (!isSupported) {
             throw new GradleException([
-                "react-native 0.71 or greater is required for New",
-                "Architecture — disable `newArchEnabled` in your",
-                "`gradle.properties` or upgrade `react-native`"
+                "react-native 0.71 or greater is required for New Architecture",
+                "— disable `newArchEnabled` in your `gradle.properties` or",
+                "upgrade `react-native`"
             ].join(" "))
         }
         return isSupported
     }
     return false
-}
-
-ext.isPropertySet = { project, propertyName, value ->
-    return project.hasProperty(propertyName) && project.getProperty(propertyName) == value
 }
 
 ext.toVersionNumber = { version ->


### PR DESCRIPTION
### Description

Scoped Gradle properties were introduced in 0.73:
https://github.com/facebook/react-native/commit/1a765b6d08e6fb2ee889c16939ee7345a9a40fd5

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.