### PR TITLE
fix(windows): use default value for `UseHermes`

### DIFF
--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -6,7 +6,7 @@
 
       See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
-    <UseHermes>false</UseHermes>
+    <!-- UseHermes>true</UseHermes -->
 
     <!--
       Changes compilation to assume use of WinUI 3 instead of System XAML.

--- a/windows/test-app.js
+++ b/windows/test-app.js
@@ -663,9 +663,11 @@ function generateSolution(
   const usePackageReferences =
     rnWindowsVersionNumber === 0 || rnWindowsVersionNumber >= v(0, 68, 0);
   const xamlVersion =
-    rnWindowsVersionNumber > 0 && rnWindowsVersionNumber < v(0, 67, 0)
-      ? "2.6.0"
-      : "2.7.0";
+    rnWindowsVersionNumber === 0 || rnWindowsVersionNumber >= v(0, 73, 0)
+      ? "2.8.0"
+      : rnWindowsVersionNumber >= v(0, 67, 0)
+        ? "2.7.0"
+        : "2.6.0";
 
   const nuGetDependencies = getNuGetDependencies(rnWindowsPath);
 
@@ -813,8 +815,10 @@ function generateSolution(
       path.join(__dirname, experimentalFeaturesPropsFilename),
       experimentalFeaturesPropsPath,
       {
-        ...(hermesVersion
-          ? { "<UseHermes>false</UseHermes>": `<UseHermes>true</UseHermes>` }
+        ...(useHermes != null && (usePackageReferences || hermesVersion)
+          ? {
+              "<!-- UseHermes>true</UseHermes -->": `<UseHermes>${useHermes}</UseHermes>`,
+            }
           : undefined),
       },
       undefined,
@@ -954,7 +958,6 @@ if (require.main === module) {
       "use-hermes": {
         description: "Use Hermes JavaScript engine (experimental)",
         type: "boolean",
-        default: false,
       },
       "use-nuget": {
         description: "Use NuGet packages (experimental)",


### PR DESCRIPTION
### Description

Hermes is default JS engine in 0.73: https://github.com/microsoft/react-native-windows/commit/ffbe2eacb01a3169e5d2cd3e9f69f52c1b7735dd

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

```
% yarn install-windows-test-app
% grep UseHermes windows/ExperimentalFeatures.props
    <!-- UseHermes>true</UseHermes -->

% rm windows/ExperimentalFeatures.props
% yarn install-windows-test-app --use-hermes
% grep UseHermes windows/ExperimentalFeatures.props
    <UseHermes>true</UseHermes>
```

### Screenshot

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/b69f5b79-df75-46d1-9136-03a42efc0c8a)