### PR TITLE
fix(macos): ignore undefined `TARGET_OS_*` macros

### DIFF
--- a/macos/ReactTestApp/ReactTestApp.common.xcconfig
+++ b/macos/ReactTestApp/ReactTestApp.common.xcconfig
@@ -17,4 +17,4 @@ OTHER_CFLAGS = $(inherited) -fstack-protector-strong
 OTHER_LDFLAGS = $(inherited) -fstack-protector-strong
 SDKROOT = macosx
 SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
-WARNING_CFLAGS = -Wall
+WARNING_CFLAGS = -Wall -Wno-error=undef-prefix


### PR DESCRIPTION
### Description

CI is currently failing because `TARGET_OS_VISION` is undefined:

```
Error: 'TARGET_OS_VISION' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
#if TARGET_OS_VISION // [visionOS
    ^
Error: could not build module 'ReactNativeHost'
#import <ReactNativeHost/ReactNativeHost.h>
 ~~~~~~~^
[ReactTestApp] Compiling React+Compatibility.m
Error: Process completed with exit code 1.
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] Windows

### Test plan

CI should pass. `TARGET_OS_VISION` being undefined should no longer be fatal:

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/c8f57fb4-53a8-4b8b-afc0-805685d963e7)
