### PR TITLE
fix: print error message for CocoaPods 1.15.0

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -373,6 +373,12 @@ def make_project!(xcodeproj, project_root, target_platform, options)
 end
 
 def use_test_app_internal!(target_platform, options)
+  if Pod::VERSION == '1.15.0'
+    raise 'CocoaPods 1.15.0 is not compatible with React Native; for details ' \
+          'and workaround, see ' \
+          'https://github.com/facebook/react-native/issues/42698'
+  end
+
   assert(%i[ios macos].include?(target_platform), "Unsupported platform: #{target_platform}")
 
   xcodeproj = 'ReactTestApp.xcodeproj'


### PR DESCRIPTION
### Description

CocoaPods 1.15.0 is not compatible with React Native.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
% pod install --project-directory=ios

[!] Invalid `Podfile` file: CocoaPods 1.15.0 is not compatible with React Native; for details and workaround, see https://github.com/facebook/react-native/issues/42698.

 #  from /~/example/ios/Podfile:10
 #  -------------------------------------------
 #
 >  use_test_app! options do |target|
 #    target.tests do
 #  -------------------------------------------
```