### PR TITLE
fix(android): fix TurboModule modules not loading properly

### DIFF
--- a/android/app/src/main/jni/OnLoad.cpp
+++ b/android/app/src/main/jni/OnLoad.cpp
@@ -8,11 +8,6 @@
 
 #include <ReactCommon/CallInvoker.h>
 
-namespace facebook::react
-{
-    class TurboModule;
-}
-
 using facebook::react::CallInvoker;
 using facebook::react::DefaultComponentsRegistry;
 using facebook::react::DefaultTurboModuleManagerDelegate;

--- a/android/app/src/main/jni/OnLoad.cpp
+++ b/android/app/src/main/jni/OnLoad.cpp
@@ -1,3 +1,45 @@
+#if __has_include(<DefaultTurboModuleManagerDelegate.h>)
+
+#include <DefaultComponentsRegistry.h>
+#include <DefaultTurboModuleManagerDelegate.h>
+#include <rncli.h>
+
+#include <fbjni/fbjni.h>
+
+#include <ReactCommon/CallInvoker.h>
+
+namespace facebook::react
+{
+    class TurboModule;
+}
+
+using facebook::react::CallInvoker;
+using facebook::react::DefaultComponentsRegistry;
+using facebook::react::DefaultTurboModuleManagerDelegate;
+using facebook::react::TurboModule;
+
+namespace
+{
+    std::shared_ptr<TurboModule> cxxModuleProvider(const std::string &,
+                                                   const std::shared_ptr<CallInvoker> &)
+    {
+        return nullptr;
+    }
+}  // namespace
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *)
+{
+    return facebook::jni::initialize(vm, [] {
+        DefaultTurboModuleManagerDelegate::cxxModuleProvider = &cxxModuleProvider;
+        DefaultTurboModuleManagerDelegate::javaModuleProvider =
+            &facebook::react::rncli_ModuleProvider;
+        DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint =
+            &facebook::react::rncli_registerProviders;
+    });
+}
+
+#else  // __has_include(<DefaultTurboModuleManagerDelegate.h>)
+
 #include <fbjni/fbjni.h>
 
 #include "ComponentsRegistry.h"
@@ -13,3 +55,5 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *)
         ComponentsRegistry::registerNatives();
     });
 }
+
+#endif  // __has_include(<DefaultTurboModuleManagerDelegate.h>)


### PR DESCRIPTION
### Description

Sync to [upstream `OnLoad.cpp`](https://github.com/facebook/react-native/blob/0.73-stable/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp) when New Arch is enabled.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

For 0.71-0.73, if the Android app successfully builds, it's fine.

```sh
git reset --hard @
npm run set-react-version <version>
yarn clean
yarn
sed -i '' 's/#newArchEnabled/newArchEnabled/' example/android/gradle.properties
cd example
yarn android
```