### PR TITLE
ci: use `macos-14` runner image

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -55,9 +55,9 @@ runs:
       uses: microsoft/setup-msbuild@v1.3
     - name: Set up Ruby
       if: ${{ runner.os != 'Windows' }}
-      uses: ruby/setup-ruby@v1.169.0
+      uses: ruby/setup-ruby@v1.171.0
       with:
-        ruby-version: "3.0"
+        ruby-version: "3.2.3"
         bundler: Gemfile.lock
         bundler-cache: true
     - name: Set up VSTest.console.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
     timeout-minutes: 60
   ios:
     name: "iOS"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         template: [all, ios]
-    runs-on: macos-13
+    runs-on: macos-14
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
@@ -334,7 +334,7 @@ jobs:
     timeout-minutes: 60
   macos:
     name: "macOS"
-    runs-on: macos-13
+    runs-on: macos-14
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
@@ -407,7 +407,7 @@ jobs:
     strategy:
       matrix:
         template: [all, macos]
-    runs-on: macos-13
+    runs-on: macos-14
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

The Sonoma runner images are available:
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a