### PR TITLE
ci: update Windows CI for Node 20

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -52,7 +52,7 @@ runs:
         java-version: ${{ inputs.java-version }}
     - name: Set up MSBuild
       if: ${{ inputs.platform == 'windows' }}
-      uses: microsoft/setup-msbuild@v1.3
+      uses: microsoft/setup-msbuild@v2
     - name: Set up Ruby
       if: ${{ runner.os != 'Windows' }}
       uses: ruby/setup-ruby@v1.171.0
@@ -60,9 +60,6 @@ runs:
         ruby-version: "3.2.3"
         bundler: Gemfile.lock
         bundler-cache: true
-    - name: Set up VSTest.console.exe
-      if: ${{ inputs.platform == 'windows' }}
-      uses: darenm/Setup-VSTest@v1.2
     - name: Set up Node.js
       uses: actions/setup-node@v4.0.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,7 +509,7 @@ jobs:
         if: ${{ steps.affected.outputs.windows != '' && matrix.platform == 'x64' }}
         run: |
           ../../../scripts/MSBuild.ps1 -Configuration ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Target Build ReactTestAppTests.vcxproj
-          VSTest.Console.exe ${{ matrix.platform }}\${{ matrix.configuration }}\ReactTestAppTests.dll
+          ../../../scripts/VSTest.ps1 ${{ matrix.platform }}\${{ matrix.configuration }}\ReactTestAppTests.dll
         working-directory: example/windows/ReactTestAppTests
     timeout-minutes: 60
   windows-template:

--- a/scripts/VSTest.ps1
+++ b/scripts/VSTest.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+
+$path = vswhere -latest -products * -requires Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.Web -requiresAny -property installationPath
+$path = join-path $path "Common7\IDE\CommonExtensions\Microsoft\TestWindow\VSTest.Console.exe"
+& $path $args


### PR DESCRIPTION
### Description

Node 16 actions are deprecated, and `darenm/Setup-VSTest` is no longer maintained.

For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

n/a