### PR TITLE
fix(apple): fix dev server -> embedded bundle fallback not working

### DIFF
--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -5,10 +5,8 @@ final class ReactInstance: NSObject, RNXHostConfig {
     public static let scanForQRCodeNotification =
         NSNotification.Name("ReactInstance.scanForQRCodeNotification")
 
-    static func jsBundleURL() -> URL {
-        RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index") {
-            RTADefaultJSBundleURL()
-        }
+    static func jsBundleURL() -> URL? {
+        RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index") { nil }
     }
 
     var remoteBundleURL: URL? {
@@ -117,7 +115,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
                 )
             }
             .first
-        return embeddedBundleURL ?? ReactInstance.jsBundleURL()
+        return embeddedBundleURL ?? ReactInstance.jsBundleURL() ?? RTADefaultJSBundleURL()
     }
 
     // MARK: - Private


### PR DESCRIPTION
### Description

Fix dev server -> embedded bundle fallback not working.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
cd example
yarn build:ios
pod install --project-directory=ios
yarn ios

# Do NOT start the dev server
```