### PR TITLE
ci: replace `gradle/gradle-build-action` with `gradle/actions/setup-gradle`

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -21,12 +21,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.project-root }}
     - name: Build
-      uses: gradle/gradle-build-action@v2.12.0
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: wrapper
-        build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}
         gradle-home-cache-excludes: |
           caches
           jdks
-        arguments: ${{ inputs.arguments }}
         gradle-home-cache-cleanup: true
+        arguments: ${{ inputs.arguments }}
+        build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           yarn test:rb
           echo "::remove-matcher owner=minitest::"
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Populate Gradle cache
         uses: ./.github/actions/gradle
         with:

--- a/.github/workflows/rnx-build.yml
+++ b/.github/workflows/rnx-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install npm dependencies
         run: ${{ github.event.inputs.packageManager }} install
       - name: Build Android app
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: wrapper
           arguments: --no-daemon clean assembleDebug
@@ -58,7 +58,7 @@ jobs:
   build-ios:
     name: Build iOS
     if: ${{ github.event.inputs.platform == 'ios' }}
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       CERTIFICATE_FILE: build-certificate.p12
       KEYCHAIN_FILE: app-signing.keychain-db
@@ -117,7 +117,7 @@ jobs:
   build-macos:
     name: Build macOS
     if: ${{ github.event.inputs.platform == 'macos' }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

`gradle/gradle-build-action` was superceded by `gradle/actions/setup-gradle`: https://github.com/gradle/gradle-build-action#readme

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a