### PR TITLE
fix(apple): fix `ReactTestApp_DevSupport` missing bridging header

### DIFF
--- a/ReactTestApp-DevSupport.podspec
+++ b/ReactTestApp-DevSupport.podspec
@@ -36,6 +36,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
     'DEFINES_MODULE' => 'YES',
+    'SWIFT_OBJC_BRIDGING_HEADER' =>
+      'ios/ReactTestApp/Public/ReactTestApp-DevSupport-Bridging-Header.h',
   }
 
   s.source_files         = 'common/AppRegistry.{cpp,h}',

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1249,7 +1249,7 @@ SPEC CHECKSUMS:
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: a42e89b49d88c3890dfb6fd98a33ac80d555be19
   ReactNativeHost: 87c7181cb3b0ce016e094ede3cc03b4f61c97dd5
-  ReactTestApp-DevSupport: 684f374b53c868cd08a0337839a7fcc5ce1e25aa
+  ReactTestApp-DevSupport: 8e43ae85b0a63bc023596bc70a9dc76f0ada60ef
   ReactTestApp-Resources: da77347b3f02b5d79ba3fecb3ad328b2f6a7ef4d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1243,7 +1243,7 @@ SPEC CHECKSUMS:
   React-utils: 68f5b33b6957324718290e3c7eda822db1da9b56
   ReactCommon: e80b030b22caf9def0e375bb5a46c02305b95e10
   ReactNativeHost: 87c7181cb3b0ce016e094ede3cc03b4f61c97dd5
-  ReactTestApp-DevSupport: 684f374b53c868cd08a0337839a7fcc5ce1e25aa
+  ReactTestApp-DevSupport: 8e43ae85b0a63bc023596bc70a9dc76f0ada60ef
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 79fe7ee86686c885279b1e0bd5f780a982f22eb9

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport-Bridging-Header.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "ReactTestApp-DevSupport.h"

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ReactNativeHost
+import ReactTestApp_DevSupport
 
 final class ReactInstance: NSObject, RNXHostConfig {
     public static let scanForQRCodeNotification =

--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -14,8 +14,6 @@
 #import <React/RCTVersion.h>
 #pragma clang diagnostic pop
 
-@import ReactTestApp_DevSupport;
-
 #import "React+Compatibility.h"
 #import "UIViewController+ReactTestApp.h"
 

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import ReactTestApp_DevSupport
 
 @main
 final class AppDelegate: NSObject, NSApplicationDelegate {

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -120,6 +120,7 @@ describe("npm pack", () => {
       "ios/ReactTestApp/Info.plist",
       "ios/ReactTestApp/Manifest+Decoder.swift",
       "ios/ReactTestApp/Manifest.swift",
+      "ios/ReactTestApp/Public/ReactTestApp-DevSupport-Bridging-Header.h",
       "ios/ReactTestApp/Public/ReactTestApp-DevSupport.h",
       "ios/ReactTestApp/QRCodeScannerViewController.swift",
       "ios/ReactTestApp/React+Compatibility.h",


### PR DESCRIPTION
### Description

Addresses this non-fatal build error:

```
fatal error: module 'ReactTestApp_DevSupport' in AST file [...] is not
defined in any loaded module map file; maybe you need to load
'/~/macos/Pods/Headers/Public/ReactTestApp_DevSupport/ReactTestApp-DevSupport.modulemap'?
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Verify that these annotations are gone from build summary:

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/5649e4cc-89bd-4827-b21e-cafa76a39d09)
