### PR TITLE
fix(apple): assert CocoaPods version

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -1,3 +1,22 @@
+def assert(condition, message)
+  raise message unless condition
+end
+
+def assert_version(pod_version)
+  if pod_version == '1.15.0'
+    raise 'CocoaPods 1.15.0 is not compatible with React Native; for details ' \
+          'and workaround, see ' \
+          'https://github.com/facebook/react-native/issues/42698'
+  end
+
+  version = Gem::Version.new(pod_version).segments
+  version = v(version[0], version[1], version[2])
+  return unless version < v(1, 13, 0)
+
+  raise 'React Native requires a more recent version of CocoaPods; found ' \
+        "#{pod_version}, expected >=1.13 <1.15"
+end
+
 def bridgeless_enabled?(options, react_native_version)
   return false unless new_architecture_enabled?(options, react_native_version)
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -3,10 +3,6 @@ require('pathname')
 
 require_relative('pod_helpers')
 
-def assert(condition, message)
-  raise message unless condition
-end
-
 def app_manifest(project_root)
   @app_manifest ||= {}
   return @app_manifest[project_root] if @app_manifest.key?(project_root)
@@ -379,12 +375,7 @@ def make_project!(xcodeproj, project_root, target_platform, options)
 end
 
 def use_test_app_internal!(target_platform, options)
-  if Pod::VERSION == '1.15.0'
-    raise 'CocoaPods 1.15.0 is not compatible with React Native; for details ' \
-          'and workaround, see ' \
-          'https://github.com/facebook/react-native/issues/42698'
-  end
-
+  assert_version(Pod::VERSION)
   assert(%i[ios macos].include?(target_platform), "Unsupported platform: #{target_platform}")
 
   xcodeproj = 'ReactTestApp.xcodeproj'

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -3,6 +3,22 @@ require('minitest/autorun')
 require_relative('../ios/pod_helpers')
 
 class TestPodHelpers < Minitest::Test
+  def test_assert_version
+    assert_raises(RuntimeError) do
+      assert_version('1.12.999')
+    end
+
+    assert_raises(RuntimeError) do
+      assert_version('1.15.0')
+    end
+
+    assert_silent do
+      assert_version('1.13.0')
+      assert_version('1.14.0')
+      assert_version('1.15.1')
+    end
+  end
+
   def test_bridgeless_enabled?
     ENV.delete('RCT_NEW_ARCH_ENABLED')
 


### PR DESCRIPTION
### Description

Ensure the right CocoaPods version is being used.

Resolves #1817.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

Using an older version of CocoaPods, like 1.12.1, run `pod install`:

```
 % pod install --project-directory=ios

[!] Invalid `Podfile` file: React Native requires a more recent version of CocoaPods; found 1.12.1, expected >=1.13 <1.15.

 #  from /Users/tido/Source/react-native-test-app/example/ios/Podfile:11
 #  -------------------------------------------
 #
 >  use_test_app! options do |target|
 #    target.tests do
 #  -------------------------------------------
```