### PR TITLE
fix(ios): fix crash on startup on nightlies

### DIFF
--- a/ios/ReactTestApp/ContentView.swift
+++ b/ios/ReactTestApp/ContentView.swift
@@ -111,7 +111,9 @@ final class ContentViewController: UITableViewController {
         onComponentsRegistered(components, checksum: checksum)
 
         let bundleRoot = manifest.bundleRoot
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        // As of 0.74, we can no longer instantiate on a background thread:
+        // https://github.com/facebook/react-native/commit/b7025fe1569349d90d26821b2b8de64a8ec9f352
+        DispatchQueue.main.async { [weak self] in
             self?.reactInstance.initReact(bundleRoot: bundleRoot) {
                 if !components.isEmpty,
                    let index = components.count == 1 ? 0 : Session.lastOpenedComponent(checksum)

--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -138,7 +138,9 @@ extension AppDelegate {
         onComponentsRegistered(components, enable: false)
 
         let bundleRoot = manifest.bundleRoot
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        // As of 0.74, we can no longer instantiate on a background thread:
+        // https://github.com/facebook/react-native/commit/b7025fe1569349d90d26821b2b8de64a8ec9f352
+        DispatchQueue.main.async { [weak self] in
             self?.reactInstance.initReact(bundleRoot: bundleRoot) {
                 DispatchQueue.main.async { [weak self] in
                     guard let strongSelf = self, !components.isEmpty else {


### PR DESCRIPTION
### Description

An assertion was introduced, causing a crash on startup: https://github.com/facebook/react-native/blob/50bd9e367bb8a0c18be43f751a2fc95908df1ff1/packages/react-native/React/CxxBridge/RCTCxxBridge.mm#L439

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
yarn ios

# In a separate terminal
yarn start
```