### PR TITLE
fix(android): fix nightly build issues

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -87,7 +87,7 @@ class TestAppReactNativeHost(
         reactInstanceManager.addReactInstanceEventListener(listener)
     }
 
-    fun reload(activity: Activity?, newSource: BundleSource) {
+    fun reload(activity: Activity, newSource: BundleSource) {
         if (BuildConfig.DEBUG && !hasInstance()) {
             error("init() must be called the first time ReactInstanceManager is created")
         }
@@ -104,9 +104,7 @@ class TestAppReactNativeHost(
 
                 reactInstanceManager.run {
                     createReactContextInBackground()
-                    if (activity != null) {
-                        onHostResume(activity)
-                    }
+                    onHostResume(activity)
                 }
             }
         }
@@ -114,13 +112,13 @@ class TestAppReactNativeHost(
         onBundleSourceChanged?.invoke(newSource)
     }
 
-    fun reloadJSFromServer(activity: Activity?, bundleURL: String) {
+    fun reloadJSFromServer(activity: Activity, bundleURL: String) {
         val uri = Uri.parse(bundleURL)
         PackagerConnectionSettings(activity).debugServerHost =
             if (uri.port > 0) {
                 "${uri.host}:${uri.port}"
             } else {
-                uri.host
+                uri.host ?: "localhost"
             }
         reload(activity, BundleSource.Server)
     }
@@ -166,12 +164,14 @@ class TestAppReactNativeHost(
         devSupportManager.addCustomDevOption(bundleOption) {
             when (source) {
                 BundleSource.Disk -> {
-                    val currentActivity = reactInstanceManager.currentReactContext?.currentActivity
-                    reload(currentActivity, BundleSource.Server)
+                    reactInstanceManager.currentReactContext?.currentActivity?.let {
+                        reload(it, BundleSource.Server)
+                    }
                 }
                 BundleSource.Server -> {
-                    val currentActivity = reactInstanceManager.currentReactContext?.currentActivity
-                    reload(currentActivity, BundleSource.Disk)
+                    reactInstanceManager.currentReactContext?.currentActivity?.let {
+                        reload(it, BundleSource.Disk)
+                    }
                 }
             }
         }

--- a/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -30,7 +30,7 @@ class TestApp : Application(), ReactApplication {
     private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider
     private lateinit var reactNativeHostInternal: TestAppReactNativeHost
 
-    fun reloadJSFromServer(activity: Activity?, bundleURL: String) {
+    fun reloadJSFromServer(activity: Activity, bundleURL: String) {
         reactNativeHostInternal.reloadJSFromServer(activity, bundleURL)
     }
 


### PR DESCRIPTION
### Description

`PackagerConnectionSettings.debugServerHost` is no longer nullable so we have to make some minor changes.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
cd example
yarn android

# In a separate terminal
yarn start
```