### PR TITLE
fix(apple): `sourceURL(for:)` can return `nil` again

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -47,7 +47,7 @@ function getHermesVersion(): string | undefined {
 function getReactNativeVersion(): string {
   const { major, minor, patch, prerelease } = coreVersion;
   const version = `${major}.${minor}.${patch}`;
-  return prerelease ? `${version}-${prerelease}` : version;
+  return prerelease ? `${version}-${prerelease.replace("-", "\n")}` : version;
 }
 
 function isBridgeless() {
@@ -142,6 +142,7 @@ function useStyles() {
       groupItemValue: {
         color: isDarkMode ? Colors.light : Colors.dark,
         fontSize: fontSize,
+        textAlign: "right",
       },
       separator: {
         backgroundColor: isDarkMode ? Colors.dark : Colors.light,

--- a/example/test/specs/app.spec.mjs
+++ b/example/test/specs/app.spec.mjs
@@ -47,7 +47,7 @@ describe("App", () => {
 
     const manifest = fs.readFileSync(rnPath, { encoding: "utf-8" });
     const { version } = JSON.parse(manifest);
-    return version;
+    return version.replace("-nightly-", "-nightly\n");
   })();
 
   /** @type {Browser} */

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -102,7 +102,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
 
     // MARK: - RCTBridgeDelegate details
 
-    func sourceURL(for _: RCTBridge) -> URL {
+    func sourceURL(for _: RCTBridge) -> URL? {
         if let remoteBundleURL {
             return remoteBundleURL
         }
@@ -116,7 +116,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
                 )
             }
             .first
-        return embeddedBundleURL ?? ReactInstance.jsBundleURL() ?? RTADefaultJSBundleURL()
+        return embeddedBundleURL ?? ReactInstance.jsBundleURL()
     }
 
     // MARK: - Private

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -430,7 +430,7 @@ def use_test_app_internal!(target_platform, options)
 
     installer.pods_project.targets.each do |target|
       case target.name
-      when /\AReact/, 'RCT-Folly', 'Yoga'
+      when /\AReact/, 'RCT-Folly', 'SocketRocket', 'Yoga', 'fmt', 'glog'
         target.build_configurations.each do |config|
           # TODO: Drop `_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION` when
           #       we no longer support 0.72


### PR DESCRIPTION
### Description

The signature of `sourceURL(for:)` changed back: https://github.com/facebook/react-native/commit/12e4a5745d54a7be86c005e4ed954c42171541b2

Last night's build log: https://github.com/microsoft/react-native-test-app/actions/runs/7839434753

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/64a423ca-6beb-4df9-abeb-9ae7a48f317d)
