### PR TITLE
chore: address CVE-2023-42282

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "appium/yaml": "^2.3.4",
     "body-parser": "~1.20.2",
     "bplist-parser": "~0.3.2",
+    "ip": "2.0.0",
     "safe-buffer": "~5.2.1"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8772,14 +8772,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip@npm:^1.1.5, ip@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "ip@npm:1.1.8"
-  checksum: ab32a5ecfa678d4c158c1381c4c6744fce89a1d793e1b6635ba79d0753c069030b672d765887b6fff55670c711dfa47475895e5d6013efbbcf04687c51cb8db9
-  languageName: node
-  linkType: hard
-
-"ip@npm:^2.0.0":
+"ip@npm:2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
   checksum: 8d186cc5585f57372847ae29b6eba258c68862055e18a75cc4933327232cb5c107f89800ce29715d542eef2c254fbb68b382e780a7414f9ee7caf60b7a473958


### PR DESCRIPTION
### Description

The only difference between 1.1.8 and 2.0.0 is the use of `Buffer.alloc` instead of `new Buffer` ([diff](https://github.com/indutny/node-ip/compare/v1.1.8...v2.0.0)).

For details on the CVE, see https://github.com/advisories/GHSA-78xj-cgh5-2h22.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a