### PR TITLE
docs: fix description of `ios.alternateIcons`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'CFPropertyList'
 gem 'minitest'
 gem 'rubocop', require: false
 gem 'rubocop-minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  CFPropertyList
   minitest
   rubocop
   rubocop-minitest

--- a/schema.json
+++ b/schema.json
@@ -44,8 +44,8 @@
               ]
             },
             "alternateIcons": {
-              "description": "The primary icon for the Home screen and Settings app, among others.",
-              "markdownDescription": "The primary icon for the Home screen and Settings app, among others.\n\nThe equivalent key in `Info.plist` is\n[`CFBundleAlternateIcons`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleicons/cfbundlealternateicons).",
+              "description": "List of alternate icons for the Home screen and Settings app.",
+              "markdownDescription": "List of alternate icons for the Home screen and Settings app.\n\nThe equivalent key in `Info.plist` is\n[`CFBundleAlternateIcons`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleicons/cfbundlealternateicons).",
               "type": "object",
               "additionalProperties": {
                 "allOf": [

--- a/scripts/docs/ios.icons.alternateIcons.md
+++ b/scripts/docs/ios.icons.alternateIcons.md
@@ -1,4 +1,4 @@
-The primary icon for the Home screen and Settings app, among others.
+List of alternate icons for the Home screen and Settings app.
 
 The equivalent key in `Info.plist` is
 [`CFBundleAlternateIcons`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleicons/cfbundlealternateicons).


### PR DESCRIPTION
### Description

Fix description of `ios.alternateIcons`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a