### PR TITLE
fix(android): change signature to build pre73 (72,71)

### DIFF
--- a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -22,7 +22,7 @@ class TestApp : Application(), ReactApplication {
     private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider
     private lateinit var reactNativeHostInternal: TestAppReactNativeHost
 
-    fun reloadJSFromServer(activity: Activity?, bundleURL: String) {
+    fun reloadJSFromServer(activity: Activity, bundleURL: String) {
         reactNativeHostInternal.reloadJSFromServer(activity, bundleURL)
     }
 


### PR DESCRIPTION
### Description

While testing https://github.com/microsoft/react-native-test-app/pull/1837#issuecomment-1941437582 I realized that the old pre 73 kotlin signature was erroring out at build time. It's a quick patch

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

The "easiest" way to test this it to 
```
npm run set-react-version 0.72 -- --core-only
yarn
cd example
yarn android
# in a separate window
yarn start
```
and then do the same for 0.71.

I've done it as part of the testing for this PR https://github.com/microsoft/rnx-kit/pull/2968 since on new arch on 71 and 72 (without the fix in that PR) webstorage will also cause a build error.

You can check out my testing on [this comment](https://github.com/microsoft/rnx-kit/pull/2968#issuecomment-1943559284).