### PR TITLE
chore: `@react-native-webapis/web-storage` is not compatible with 0.71

### DIFF
--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -252,8 +252,8 @@ ext.isBridgelessEnabled = { project, isNewArchEnabled ->
             def isSupported = version == 0 || version >= v(0, 73, 0)
             if (!isSupported) {
                 logger.warn([
-                    "react-native 0.73 or greater is required for Bridgeless",
-                    "Mode — disable `bridgelessEnabled` in your",
+                    "WARNING: react-native 0.73 or greater is required for",
+                    "Bridgeless Mode — disable `bridgelessEnabled` in your",
                     "`gradle.properties` or upgrade `react-native`"
                 ].join(" "))
             }

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "windows": "react-native run-windows --no-packager"
   },
   "dependencies": {
-    "@react-native-webapis/web-storage": "^0.1.3",
+    "@react-native-webapis/web-storage": "^0.2.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -470,6 +470,18 @@ if (import.meta.url.endsWith(script)) {
       } else if (numVersion < v(0, 73, 0)) {
         setGradleVersion("7.6.3");
       }
+
+      // `@react-native-webapis/web-storage` is not compatible with codegen 0.71
+      if (numVersion < v(0, 72, 0)) {
+        const exampleManifest = "example/package.json";
+        fs.writeFileSync(
+          exampleManifest,
+          readTextFile(exampleManifest).replace(
+            /\s+"@react-native-webapis\/web-storage":.*/,
+            ""
+          )
+        );
+      }
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,13 +2941,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-webapis/web-storage@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@react-native-webapis/web-storage@npm:0.1.3"
+"@react-native-webapis/web-storage@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@react-native-webapis/web-storage@npm:0.2.0"
   peerDependencies:
     react: ">=18.2.0"
-    react-native: ">=0.71.0-0"
-  checksum: a500a02f2a85b534cb0a55e0e91ba33ac54773321015926e60c660211e619a17035e40ffe508a05aa46b8ed9df45f322cb3d446f1e431b05acd3c43e98913f54
+    react-native: ">=0.72.0-0"
+  checksum: c2e420a1ab765409f49ac95de6663478669a1dc942508ffddfc6e3ef91a69e25689148feb59ac867c4c84c149c6a230b2033720d9c375413a18fd88a3d49530a
   languageName: node
   linkType: hard
 
@@ -7263,7 +7263,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.1.6"
     "@babel/preset-env": "npm:^7.1.6"
-    "@react-native-webapis/web-storage": "npm:^0.1.3"
+    "@react-native-webapis/web-storage": "npm:^0.2.0"
     "@react-native/babel-preset": "npm:^0.73.19"
     "@react-native/metro-config": "npm:^0.73.3"
     "@rnx-kit/metro-config": "npm:^1.3.14"


### PR DESCRIPTION
### Description

`set-react-version` should remove `@react-native-webapis/web-storage` since it's not compatible with 0.71.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`@react-native-webapis/web-storage` should be removed when switching to a version lower than 0.72:

```
git checkout .
npm run set-react-version 0.71 -- --core-only
```

Verify that `@react-native-webapis/web-storage` is removed from `example/package.json`.

```
git checkout .
npm run set-react-version 0.72 -- --core-only
```

Verify that `@react-native-webapis/web-storage` is NOT removed from `example/package.json`.