### PR TITLE
fix(apple): update compatible CocoaPods versions

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -3,9 +3,9 @@ def assert(condition, message)
 end
 
 def assert_version(pod_version)
-  if pod_version == '1.15.0'
-    raise 'CocoaPods 1.15.0 has a known issue with React Native; upgrade to ' \
-          '1.15.1 or higher'
+  if ['1.15.0', '1.15.1'].include?(pod_version)
+    raise "CocoaPods #{pod_version} does not work with React Native; upgrade " \
+          'to 1.15.2 or higher'
   end
 
   version = Gem::Version.new(pod_version).segments

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -4,18 +4,16 @@ require_relative('../ios/pod_helpers')
 
 class TestPodHelpers < Minitest::Test
   def test_assert_version
-    assert_raises(RuntimeError) do
-      assert_version('1.12.999')
-    end
-
-    assert_raises(RuntimeError) do
-      assert_version('1.15.0')
+    ['1.12.999', '1.15.0', '1.15.1'].each do |version|
+      assert_raises(RuntimeError) do
+        assert_version(version)
+      end
     end
 
     assert_silent do
-      assert_version('1.13.0')
-      assert_version('1.14.0')
-      assert_version('1.15.1')
+      ['1.13.0', '1.14.0', '1.15.2'].each do |version|
+        assert_version(version)
+      end
     end
   end
 


### PR DESCRIPTION
### Description

Update compatible CocoaPods versions. 1.15.1 is still broken, unfortunately.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a