### PR TITLE
fix(android): get Kotlin version from `react-native`

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -55,20 +55,6 @@ ext {
         }
     }
 
-    /**
-     * Returns the recommended Kotlin version for the specified React Native
-     * version.
-     */
-    def getDefaultKotlinVersion = { reactNativeVersion ->
-        // Kotlin version can be found in the template:
-        // https://github.com/facebook/react-native/blob/main/packages/react-native/template/android/build.gradle
-        if (reactNativeVersion == 0 || reactNativeVersion >= v(0, 73, 0)) {
-            return "1.8.22"
-        } else {
-            return "1.7.21"
-        }
-    }
-
     reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
     autodetectReactNativeVersion = reactNativeVersion == 0 || reactNativeVersion >= v(0, 71, 0)
     enableNewArchitecture = isNewArchitectureEnabled(project)
@@ -78,7 +64,7 @@ ext {
     androidPluginVersion = getDefaultGradlePluginVersion(reactNativeVersion)
     kotlinVersion = rootProject.hasProperty("KOTLIN_VERSION")
         ? rootProject.properties["KOTLIN_VERSION"]
-        : getDefaultKotlinVersion(reactNativeVersion)
+        : getKotlinVersion(rootDir)
     kspVersion = getKspVersion(kotlinVersion)
 
     // We need only set `ndkVersion` when building react-native from source.

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.security.MessageDigest
 
+ext._dependencies = [:]
 ext._manifest = null
 
 ext.checkEnvironment = { rootDir ->
@@ -83,6 +84,11 @@ ext.findFile = { fileName ->
  * path is a string.
  */
 ext.findNodeModulesPath = { packageName, baseDir ->
+    def module = _dependencies[packageName]
+    if (module != null) {
+        return module.path
+    }
+
     def basePath = baseDir.toPath().normalize()
 
     // Node's module resolution algorithm searches up to the root directory,
@@ -91,7 +97,9 @@ ext.findNodeModulesPath = { packageName, baseDir ->
         def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
         if (candidatePath.toFile().exists()) {
             // Resolve the real path in case we're dealing with symlinks
-            return candidatePath.toRealPath().toString()
+            def resolvedPath = candidatePath.toRealPath().toString()
+            _dependencies[packageName] = [path: resolvedPath]
+            return resolvedPath
         }
 
         basePath = basePath.getParent()
@@ -145,6 +153,21 @@ ext.getArchitectures = { project ->
         : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+ext.getKotlinVersion = { baseDir ->
+    def fallbackVersion = "1.7.21"
+
+    def packagePath = findNodeModulesPath("react-native", baseDir)
+    def versionCatalog = file("${packagePath}/gradle/libs.versions.toml")
+    if (!versionCatalog.exists()) {
+        return fallbackVersion
+    }
+
+    def m = versionCatalog.text =~ /kotlin = "([.0-9]+)"/
+    def version = m.size() > 0 ? m[0][1] : fallbackVersion
+    logger.info("Detected Kotlin version: ${version}")
+    return version
+}
+
 ext.getManifest = {
     if (_manifest == null) {
         def manifestFile = findFile("app.json")
@@ -157,10 +180,21 @@ ext.getManifest = {
     return _manifest
 }
 
-ext.getPackageVersion = { packageName, baseDir ->
+ext.getPackageManifest = { packageName, baseDir ->
+    def module = _dependencies[packageName]
+    if (module != null && module.manifest != null) {
+        return module.manifest
+    }
+
     def packagePath = findNodeModulesPath(packageName, baseDir)
     def packageJson = file("${packagePath}/package.json")
     def manifest = new JsonSlurper().parseText(packageJson.text)
+    _dependencies[packageName].manifest = manifest
+    return manifest
+}
+
+ext.getPackageVersion = { packageName, baseDir ->
+    def manifest = getPackageManifest(packageName, baseDir)
     return manifest["version"]
 }
 


### PR DESCRIPTION
### Description

Upstream recently bumped Kotlin to 1.9:

```
ksp-1.8.22-1.0.11 is too old for kotlin-1.9.22. Please upgrade ksp or downgrade kotlin-gradle-plugin to 1.8.22.
```

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/7910899026/job/21594219403

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

`gradle/libs.versions.toml` was first introduced in 0.73 so we need to test 0.72, 0.73, and nightly.

```
# Build nightly
npm run set-react-version nightly
yarn
cd example/android
./gradlew assembleDebug

# Build 0.72
cd ..
npm run set-react-version 0.72 -- --core-only
yarn clean
yarn
cd example/android
./gradlew assembleDebug

# 0.73 is already built by CI
```