### PR TITLE
chore: fix code owners not being exhaustive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
-*  @kelset @tido64
+*                    @kelset @tido64
 
 # Android
-*.gradle  @ArazAbishov @sweggersen
-android/  @ArazAbishov @sweggersen
+*.gradle             @kelset @tido64
+android/             @kelset @tido64
 
 # iOS
-*.podspec  @Saadnajmi
-*.rb       @Saadnajmi
-ios/       @Saadnajmi
+*.podspec            @Saadnajmi @kelset @tido64
+*.rb                 @Saadnajmi @kelset @tido64
+ios/                 @Saadnajmi @kelset @tido64
 
 # macOS
-macos/  @Saadnajmi
+macos/               @Saadnajmi @kelset @tido64
 
 # Windows
-windows/  @acoates-ms
+windows/             @acoates-ms @kelset @tido64
 
 # Miscellaneous
 /CODE_OF_CONDUCT.md  @microsoftopensource


### PR DESCRIPTION
### Description

The `CODEOWNERS` file uses the [same syntax as `gitignore`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) so later entries take precedence.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

n/a