### PR TITLE
fix(apple): fix `pod install` failing if no resources are declared

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -136,7 +136,7 @@ def generate_info_plist!(project_root, target_platform, destination)
   font_files = ['.otf', '.ttf']
   fonts = []
   resources = resolve_resources(manifest, target_platform)
-  resources.each do |filename|
+  resources&.each do |filename|
     fonts << File.basename(filename) if font_files.include?(File.extname(filename))
   end
   unless fonts.empty?


### PR DESCRIPTION
### Description

Fix `pod install` failing if no resources are declared:

```
% pod install --project-directory=ios

[!] Invalid `Podfile` file: undefined method `each' for nil.
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

1. Remove the `resources` field from `example/app.json`
2. Run `pod install` in `example/ios`