### PR TITLE
fix(windows): fix `init` failing on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,10 @@ jobs:
           echo "::add-matcher::.github/swiftlint.json"
           swiftlint
           echo "::remove-matcher owner=swiftlint::"
+      - name: Smoke test `npx --package react-native-test-app@latest init`
+        run: |
+          node ./react-native-test-app/scripts/init.js --destination app --name App -p android -p ios -p macos -p windows
+        working-directory: ..
       - name: Smoke test `setup-react-native` action
         uses: ./.github/actions/setup-react-native
         with:

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,7 +1,18 @@
 // @ts-check
 "use strict";
 
+const { spawnSync } = require("node:child_process");
 const path = require("node:path");
+const os = require("node:os");
+
+/**
+ * Escapes given string for use in Command Prompt.
+ * @param {string} str
+ * @returns {string}
+ */
+function cmdEscape(str) {
+  return str.replace(/([\^])/g, "^^^$1");
+}
 
 /**
  * Finds nearest relative path to a file or directory from current path.
@@ -29,6 +40,27 @@ function findNearest(
   }
 
   return null;
+}
+
+/**
+ * Invokes `npm` on the command line.
+ * @param {...string} args
+ */
+function npm(...args) {
+  switch (os.platform()) {
+    case "win32": {
+      return spawnSync(
+        "cmd.exe",
+        ["/d", "/s", "/c", `"npm ${args.map(cmdEscape).join(" ")}"`],
+        {
+          encoding: "utf-8",
+          windowsVerbatimArguments: true,
+        }
+      );
+    }
+    default:
+      return spawnSync("npm", args, { encoding: "utf-8" });
+  }
 }
 
 /**
@@ -108,6 +140,7 @@ function v(major, minor, patch) {
 
 exports.findNearest = findNearest;
 exports.getPackageVersion = getPackageVersion;
+exports.npm = npm;
 exports.readJSONFile = readJSONFile;
 exports.readTextFile = readTextFile;
 exports.requireTransitive = requireTransitive;

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -4,6 +4,7 @@
 
 const { spawnSync } = require("node:child_process");
 const path = require("node:path");
+const { npm: npmSync } = require("./helpers");
 
 /**
  * @template T
@@ -26,9 +27,7 @@ function memo(fn) {
  * @param {...string} args
  */
 function npm(...args) {
-  const { error, stderr, stdout } = spawnSync("npm", args, {
-    encoding: "utf-8",
-  });
+  const { error, stderr, stdout } = npmSync(...args);
   if (!stdout) {
     if (stderr) {
       console.error(stderr);

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -1,18 +1,13 @@
 // @ts-check
 import { deepEqual, equal } from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import * as os from "node:os";
 import { describe, it } from "node:test";
+import { npm } from "../scripts/helpers.js";
 
 describe("npm pack", () => {
   // Ensure we include all files regardless of future changes in `npm-packlist`.
   // For more details, see https://github.com/npm/npm-packlist/issues/152.
   it("includes all files", () => {
-    const { status, stdout } = spawnSync(
-      os.platform() === "win32" ? "npm.cmd" : "npm",
-      ["pack", "--silent", "--dry-run", "--json"],
-      { encoding: "utf-8" }
-    );
+    const { status, stdout } = npm("pack", "--silent", "--dry-run", "--json");
 
     equal(status, 0);
 


### PR DESCRIPTION
### Description

Fix `init` failing on Windows.

Resolves #1849.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

Run `init` outside RNTA repo on Windows:

```
cd ..
node ./react-native-test-app/scripts/init.js --destination app --name App -p android -p ios -p macos -p windows
```

This should trigger the path where we run `npm` to fetch latest `react-native` version.

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/9da84681-26c8-497d-bcac-5f730e4b76f7)
