### PR TITLE
fix(apple): fix missing dev menu entries in bridgeless mode

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1018,7 +1018,7 @@ PODS:
     - React-jsi (= 0.73.4)
     - React-logger (= 0.73.4)
     - React-perflogger (= 0.73.4)
-  - ReactNativeHost (0.4.3):
+  - ReactNativeHost (0.4.4):
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -1026,7 +1026,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.1.3):
+  - RNWWebStorage (0.2.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1249,10 +1249,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 96c8bfa2ea02443b79cd9359afb91dfd1bf3b958
   React-utils: 6e5ad394416482ae21831050928ae27348f83487
   ReactCommon: 5fd44dbef85dfbafc87facae700c66d2da71b2cb
-  ReactNativeHost: a3d31b90decb050826112b8c16ddf8fd07300542
+  ReactNativeHost: 59d4565eee4fb44efb46d3bff7adbaf2cf29fa5f
   ReactTestApp-DevSupport: 8e43ae85b0a63bc023596bc70a9dc76f0ada60ef
   ReactTestApp-Resources: da77347b3f02b5d79ba3fecb3ad328b2f6a7ef4d
-  RNWWebStorage: 29162b6983109e281e9459d239ed90898e8c205e
+  RNWWebStorage: 865685be5b18e0f813f4daf5d9394ad7e25c5cf7
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1018,7 +1018,7 @@ PODS:
     - React-jsi (= 0.73.13)
     - React-logger (= 0.73.13)
     - React-perflogger (= 0.73.13)
-  - ReactNativeHost (0.4.3):
+  - ReactNativeHost (0.4.4):
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -1026,7 +1026,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.1.3):
+  - RNWWebStorage (0.2.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1250,10 +1250,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: c454512f5ad70c77e69c79a21ebeadbeac16addb
   React-utils: 76353092b296f76eb8f315c984ec454e0e964b76
   ReactCommon: 730cc6c7a5c473dee07856b4b521c08278d472f8
-  ReactNativeHost: a3d31b90decb050826112b8c16ddf8fd07300542
+  ReactNativeHost: 59d4565eee4fb44efb46d3bff7adbaf2cf29fa5f
   ReactTestApp-DevSupport: 8e43ae85b0a63bc023596bc70a9dc76f0ada60ef
   ReactTestApp-Resources: 8539dac0f8d2ef3821827a537e37812104c6ff78
-  RNWWebStorage: 29162b6983109e281e9459d239ed90898e8c205e
+  RNWWebStorage: 865685be5b18e0f813f4daf5d9394ad7e25c5cf7
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
   Yoga: a70dc333c0bbc9ff8b1321e79d9a62a12320b6b3
 

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "windows": "react-native run-windows --no-packager"
   },
   "dependencies": {
-    "@react-native-webapis/web-storage": "^0.2.0",
+    "@react-native-webapis/web-storage": "^0.2.1",
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",

--- a/ios/ReactTestApp/AppRegistryModule.mm
+++ b/ios/ReactTestApp/AppRegistryModule.mm
@@ -16,8 +16,6 @@ using facebook::jsi::Runtime;
 
 @implementation RTAAppRegistryModule
 
-@synthesize bridge = _bridge;
-
 RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
@@ -38,13 +36,14 @@ RCT_EXPORT_MODULE();
 
 - (void)javascriptDidLoadNotification:(NSNotification *)note
 {
-    if (![self.bridge isKindOfClass:[RCTCxxBridge class]] ||
-        ![self.bridge respondsToSelector:@selector(runtime)] ||
-        ![self.bridge respondsToSelector:@selector(invokeAsync:)]) {
+    id bridge = note.userInfo[@"bridge"];
+    if (![bridge isKindOfClass:[RCTCxxBridge class]] ||
+        ![bridge respondsToSelector:@selector(runtime)] ||
+        ![bridge respondsToSelector:@selector(invokeAsync:)]) {
         return;
     }
 
-    auto batchedBridge = (RCTCxxBridge *)self.bridge;
+    RCTCxxBridge *batchedBridge = (RCTCxxBridge *)bridge;
     [batchedBridge invokeAsync:[batchedBridge] {
         auto runtime = static_cast<Runtime *>(batchedBridge.runtime);
         if (runtime == nullptr) {

--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -10,4 +10,6 @@ extern NSNotificationName const ReactTestAppDidRegisterAppsNotification;
 
 extern NSNotificationName const ReactTestAppSceneDidOpenURLNotification;
 
+extern NSNotificationName const ReactInstanceDidLoadBundle;
+
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -112,7 +112,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
     // MARK: - RCTBridgeDelegate details
 
     func sourceURL(for _: RCTBridge) -> URL? {
-        return remoteBundleURL ?? bundleURL()
+        remoteBundleURL ?? bundleURL()
     }
 
     // MARK: - Private

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -12,3 +12,6 @@ NSNotificationName const ReactTestAppDidRegisterAppsNotification =
 
 NSNotificationName const ReactTestAppSceneDidOpenURLNotification =
     @"ReactTestAppSceneDidOpenURLNotification";
+
+// https://github.com/facebook/react-native/blob/v0.73.4/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm#L448
+NSNotificationName const ReactInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('./test/test_*.rb').each { |file| require(file) }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.4.3",
+    "@rnx-kit/react-native-host": "^0.4.4",
     "ajv": "^8.0.0",
     "chalk": "^4.1.0",
     "cliui": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,13 +2941,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-webapis/web-storage@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@react-native-webapis/web-storage@npm:0.2.0"
+"@react-native-webapis/web-storage@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@react-native-webapis/web-storage@npm:0.2.1"
   peerDependencies:
     react: ">=18.2.0"
     react-native: ">=0.72.0-0"
-  checksum: c2e420a1ab765409f49ac95de6663478669a1dc942508ffddfc6e3ef91a69e25689148feb59ac867c4c84c149c6a230b2033720d9c375413a18fd88a3d49530a
+  checksum: cd09dc323dd1a8f27d3d4d6843cdd469ecc671ddbcd2acd0c03e60ca1d35d19e777332386ce7a9a9dfc1ea2df3f8d20581d1fffd932bfe9c97ecc32fa35715b3
   languageName: node
   linkType: hard
 
@@ -3320,12 +3320,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@rnx-kit/react-native-host@npm:0.4.3"
+"@rnx-kit/react-native-host@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@rnx-kit/react-native-host@npm:0.4.4"
   peerDependencies:
     react-native: ">=0.66"
-  checksum: aa478a625bd9388759af9b390b448accfd9ee63fe55e847ec46ed7f0e35374c701f3f0438f9e55c7bbf3f2b9daff022aaf77db5d5ac06d2c558fbe8447cd7263
+  checksum: d694a385746c16d5dc40304640a68037e4a1e57afb29a1672d6bc1bf0747a3e4748e86465e335fe4eea61a26c3773c08e42f4db1fe2f83b25f2a7532a652d341
   languageName: node
   linkType: hard
 
@@ -7263,7 +7263,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.1.6"
     "@babel/preset-env": "npm:^7.1.6"
-    "@react-native-webapis/web-storage": "npm:^0.2.0"
+    "@react-native-webapis/web-storage": "npm:^0.2.1"
     "@react-native/babel-preset": "npm:^0.73.19"
     "@react-native/metro-config": "npm:^0.73.3"
     "@rnx-kit/metro-config": "npm:^1.3.14"
@@ -12099,7 +12099,7 @@ __metadata:
     "@microsoft/eslint-plugin-sdl": "npm:^0.2.0"
     "@react-native-community/cli": "npm:^12.3.0"
     "@rnx-kit/eslint-plugin": "npm:^0.6.0"
-    "@rnx-kit/react-native-host": "npm:^0.4.3"
+    "@rnx-kit/react-native-host": "npm:^0.4.4"
     "@rnx-kit/tsconfig": "npm:^1.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

"Load From Dev Server"/"Load Embedded JS Bundle" is missing in dev menu when in bridgeless mode.

Requires https://github.com/microsoft/rnx-kit/pull/2978.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/rnx-kit/pull/2978