### PR TITLE
fix(android): hook up C++ TurboModules autolinking

### DIFF
--- a/android/app/src/main/jni/OnLoad.cpp
+++ b/android/app/src/main/jni/OnLoad.cpp
@@ -15,10 +15,14 @@ using facebook::react::TurboModule;
 
 namespace
 {
-    std::shared_ptr<TurboModule> cxxModuleProvider(const std::string &,
-                                                   const std::shared_ptr<CallInvoker> &)
+    std::shared_ptr<TurboModule> cxxModuleProvider(const std::string &name,
+                                                   const std::shared_ptr<CallInvoker> &jsInvoker)
     {
+#if __has_include(<ReactCommon/CxxReactPackage.h>)
+        return facebook::react::rncli_cxxModuleProvider(name, jsInvoker);
+#else
         return nullptr;
+#endif  // __has_include(<ReactCommon/CxxReactPackage.h>)
     }
 }  // namespace
 


### PR DESCRIPTION
### Description

Hook up C++ TurboModules autolinking: https://github.com/facebook/react-native/commit/4ecf57ead2a32294cb9ed19088e7cce59702794e

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

Run the following for 0.73 and 0.74:

```
npm run set-react-version 0.74 -- --core-only
# If 0.74, remove `@react-native-webapis/web-storage` from `example/package.json`
yarn
cd example/android
./gradlew assembleDebug -PnewArchEnabled=true
```

Build should succeed.