### PR TITLE
ci(windows): disable NuGet setup since we build from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -496,7 +496,8 @@ jobs:
         uses: ./.github/actions/affected
       - name: Set up NuGet sources
         # Temporarily disabled since builds using NuGet artifacts randomly fail
-        # with architecture mismatch error
+        # with architecture mismatch error:
+        # https://github.com/microsoft/react-native-test-app/issues/1879
         if: false # ${{ steps.affected.outputs.windows != '' && github.event_name == 'schedule' }}
         run: |
           nuget sources Add -Name react-native-windows -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -495,7 +495,9 @@ jobs:
         id: affected
         uses: ./.github/actions/affected
       - name: Set up NuGet sources
-        if: ${{ steps.affected.outputs.windows != '' && github.event_name == 'schedule' }}
+        # Temporarily disabled since builds using NuGet artifacts randomly fail
+        # with architecture mismatch error
+        if: false # ${{ steps.affected.outputs.windows != '' && github.event_name == 'schedule' }}
         run: |
           nuget sources Add -Name react-native-windows -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
           cp NuGet.Config ../node_modules/.generated/windows/ReactTestApp


### PR DESCRIPTION
### Description

Disable NuGet setup since we build from source.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows

### Test plan

n/a