### PR TITLE
fix(apple): fix `ReactTestApp` overrides `USER_HEADER_SEARCH_PATHS` warnings

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -369,7 +369,7 @@ def make_project!(xcodeproj, project_root, target_platform, options)
           config.build_settings['OTHER_SWIFT_FLAGS'] << '-DENABLE_SINGLE_APP_MODE'
         end
 
-        config.build_settings['USER_HEADER_SEARCH_PATHS'] ||= []
+        config.build_settings['USER_HEADER_SEARCH_PATHS'] ||= ['$(inherited)']
         config.build_settings['USER_HEADER_SEARCH_PATHS'] << File.dirname(destination)
       end
     when 'ReactTestAppTests'


### PR DESCRIPTION
### Description

This warning appears with some native modules in certain setups:

```
[!] The `ReactTestApp [Debug]` target overrides the `USER_HEADER_SEARCH_PATHS` build setting defined in `../../../ios/Pods/Target Support Files/Pods-ReactTestApp/Pods-ReactTestApp.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `ReactTestApp [Release]` target overrides the `USER_HEADER_SEARCH_PATHS` build setting defined in `../../../ios/Pods/Target Support Files/Pods-ReactTestApp/Pods-ReactTestApp.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [ ] Windows

### Test plan

n/a