### PR TITLE
fix(ios): fix device not detecting dev server

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Enables iOS devices to get the IP address of the machine running Metro\nif [[ ! \"$SKIP_BUNDLING_METRO_IP\" && \"$CONFIGURATION\" = *Debug* && ! \"$PLATFORM_NAME\" == *simulator ]]; then\n  for num in 0 1 2 3 4 5 6 7 8; do\n    IP=$(ipconfig getifaddr en${num} || echo \"\")\n    if [ ! -z \"$IP\" ]; then\n      break\n    fi\n  done\n  if [ -z \"$IP\" ]; then\n    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\\   -f2  | awk 'NR==1{print $1}')\n  fi\n  echo \"$IP\" > \"$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/ip.txt\"\nfi\n";
+			shellScript = "# https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/scripts/react-native-xcode.sh#L13-L28\nif [[ ! \"$SKIP_BUNDLING_METRO_IP\" && \"$CONFIGURATION\" = *Debug* && ! \"$PLATFORM_NAME\" == *simulator ]]; then\n  for num in 0 1 2 3 4 5 6 7 8; do\n    IP=$(ipconfig getifaddr en${num} || echo \"\")\n    if [ ! -z \"$IP\" ]; then\n      break\n    fi\n  done\n  if [ -z \"$IP\" ]; then\n    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\\   -f2  | awk 'NR==1{print $1}')\n  fi\n  echo \"$IP\" > \"$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/ip.txt\"\nfi\n";
 		};
 		1936CB1C2768EC280085FD98 /* Validate Manifest */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 				19ECD0CE232ED425003D8557 /* Sources */,
 				19ECD0CF232ED425003D8557 /* Frameworks */,
 				19ECD0D0232ED425003D8557 /* Resources */,
+				1914113F2B8E31F6005AD0B7 /* Generate `ip.txt` */,
 			);
 			buildRules = (
 			);
@@ -284,6 +285,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1914113F2B8E31F6005AD0B7 /* Generate `ip.txt` */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 12;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate `ip.txt`";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Enables iOS devices to get the IP address of the machine running Metro\nif [[ ! \"$SKIP_BUNDLING_METRO_IP\" && \"$CONFIGURATION\" = *Debug* && ! \"$PLATFORM_NAME\" == *simulator ]]; then\n  for num in 0 1 2 3 4 5 6 7 8; do\n    IP=$(ipconfig getifaddr en${num} || echo \"\")\n    if [ ! -z \"$IP\" ]; then\n      break\n    fi\n  done\n  if [ -z \"$IP\" ]; then\n    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\\   -f2  | awk 'NR==1{print $1}')\n  fi\n  echo \"$IP\" > \"$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/ip.txt\"\nfi\n";
+		};
 		1936CB1C2768EC280085FD98 /* Validate Manifest */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -198,7 +198,7 @@ def resources_pod(project_root, target_platform, platforms)
       'ios' => platforms[:ios],
       'osx' => platforms[:macos],
     },
-    'resources' => [*resources],
+    'resources' => resources,
   }
 
   podspec_path = File.join(app_dir, 'ReactTestApp-Resources.podspec.json')


### PR DESCRIPTION
### Description

Upstream generates an `ip.txt` file with the IP address when deploying to device. Copied the same script into our project: https://github.com/facebook/react-native/blob/15f0895b857bdd452381ff340a7a04ff93a37b97/packages/react-native/scripts/react-native-xcode.sh#L13-L28

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows

### Test plan

```
cd example
pod install --project-directory=ios
yarn ios --list-devices

# In a separate terminal
yarn start
```

App should launch on device, and load bundle from your dev server.