### PR TITLE
chore: replace `chalk` with `yoctocolors`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,8 +309,7 @@ via the [Dependency Dashboard].
   side or make things more complicated to maintain. An example of us holding
   back is the [`uuid`][] package; as of writing, the latest version is 9.x but
   we're on 8.x still because that's the version being used by most of our
-  dependencies. Another example is [`chalk`][]; we are stuck on 4.x until
-  `@react-native-community/cli` migrates to ESM.
+  dependencies.
 
 ### Development Dependencies
 
@@ -356,7 +355,6 @@ additions.
   https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps#contribution
 [`@rnx-kit/react-native-host`]:
   https://github.com/microsoft/rnx-kit/tree/main/packages/react-native-host#readme
-[`chalk`]: https://github.com/chalk/chalk
 [`dependencies.gradle`]:
   https://github.com/microsoft/react-native-test-app/blob/trunk/android/dependencies.gradle
 [`package.json`]:

--- a/package.json
+++ b/package.json
@@ -86,12 +86,12 @@
   "dependencies": {
     "@rnx-kit/react-native-host": "^0.4.4",
     "ajv": "^8.0.0",
-    "chalk": "^4.1.0",
     "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",
     "prompts": "^2.4.0",
     "semver": "^7.3.5",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "yoctocolors": "^2.0.0"
   },
   "peerDependencies": {
     "@expo/config-plugins": ">=5.0",

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // @ts-check
-import chalk from "chalk";
 import * as nodefs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import semverCoerce from "semver/functions/coerce.js";
 import semverSatisfies from "semver/functions/satisfies.js";
+import * as colors from "yoctocolors";
 import { cliPlatformIOSVersion } from "./configure-projects.js";
 import {
   getPackageVersion,
@@ -62,7 +62,7 @@ function readManifest() {
  * @param {string} message
  */
 export function error(message) {
-  console.error(chalk.red(`[!] ${message}`));
+  console.error(colors.red(`[!] ${message}`));
 }
 
 /**
@@ -134,7 +134,7 @@ export function sortByKeys(obj) {
  * @param {string=} tag
  */
 export function warn(message, tag = "[!]") {
-  console.warn(chalk.yellow(`${tag} ${message}`));
+  console.warn(colors.yellow(`${tag} ${message}`));
 }
 
 /**
@@ -661,7 +661,7 @@ export function configure(params, fs = nodefs) {
   if (!force && isDestructive(packagePath, config)) {
     error("Destructive file operations are required.");
     console.log(
-      `Re-run with ${chalk.bold("--force")} if you're fine with this.`
+      `Re-run with ${colors.bold("--force")} if you're fine with this.`
     );
     return 1;
   }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // @ts-check
-import chalk from "chalk";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as https from "node:https";
@@ -9,6 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import prompts from "prompts";
+import * as colors from "yoctocolors";
 import { configure, getDefaultPlatformPackageName } from "./configure.mjs";
 import { npm as npmSync, readJSONFile } from "./helpers.js";
 import { parseArgs } from "./parseargs.mjs";
@@ -121,11 +121,10 @@ function getVersion(platforms) {
 
   /** @type {(version: string, reason: string) => void} */
   const logVersion = (version, reason) => {
-    const fmtVersionFlag = chalk.bold("--version");
-    const fmtTarget = chalk.bold(version);
+    const bVersionFlag = colors.bold("--version");
+    const bTarget = colors.bold(version);
     console.log(
-      `Using ${fmtTarget} because ${reason} (use ${fmtVersionFlag} to ` +
-        `specify another version)`
+      `Using ${bTarget} because ${reason} (use ${bVersionFlag} to specify another version)`
     );
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12103,7 +12103,6 @@ __metadata:
     "@types/semver": "npm:^7.3.6"
     "@types/uuid": "npm:^8.3.1"
     ajv: "npm:^8.0.0"
-    chalk: "npm:^4.1.0"
     cliui: "npm:^8.0.0"
     eslint: "npm:^8.0.0"
     eslint-plugin-wdio: "npm:^8.20.0"
@@ -12122,6 +12121,7 @@ __metadata:
     suggestion-bot: "npm:^2.0.0"
     typescript: "npm:^5.0.0"
     uuid: "npm:^8.3.2"
+    yoctocolors: "npm:^2.0.0"
   peerDependencies:
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 18.2
@@ -15088,6 +15088,13 @@ __metadata:
   version: 1.0.0
   resolution: "yocto-queue@npm:1.0.0"
   checksum: 10c0/856117aa15cf5103d2a2fb173f0ab4acb12b4b4d0ed3ab249fdbbf612e55d1cadfd27a6110940e24746fb0a78cf640b522cc8bca76f30a3b00b66e90cf82abe0
+  languageName: node
+  linkType: hard
+
+"yoctocolors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "yoctocolors@npm:2.0.0"
+  checksum: 10c0/994f5d99e7647a1b333331ffecbbf7c4463d9c2823e371b44e21146a4496cad0f14fbe2f73f44383312a6f843d93523f830f1360009f0ac93027b167ef5c63be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Replace `chalk` with `yoctocolors` because it's simpler/smaller than most alternatives.

See benchmarks in their README: https://github.com/sindresorhus/yoctocolors?tab=readme-ov-file#benchmark

[picocolors](https://github.com/alexeyraspopov/picocolors) also has benchmarks (still in PR).

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass.