### PR TITLE
refactor: reduce out-of-tree platform package name dupes

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -33,9 +33,10 @@ import {
  * @typedef {import("./types").Configuration} Configuration
  * @typedef {import("./types").ConfigureParams} ConfigureParams
  * @typedef {import("./types").FileCopy} FileCopy
- * @typedef {import("./types").PlatformConfiguration} PlatformConfiguration
- * @typedef {import("./types").Platform} Platform
  * @typedef {Required<import("./types").Manifest>} Manifest
+ * @typedef {import("./types").PlatformConfiguration} PlatformConfiguration
+ * @typedef {import("./types").PlatformPackage} PlatformPackage
+ * @typedef {import("./types").Platform} Platform
  */
 
 /**
@@ -137,8 +138,27 @@ export function warn(message, tag = "[!]") {
 }
 
 /**
+ * Returns the default npm package name for the specified platform.
+ * @param {Platform} platform
+ * @returns {PlatformPackage}
+ */
+export function getDefaultPlatformPackageName(platform) {
+  switch (platform) {
+    case "android":
+    case "ios":
+      return "react-native";
+    case "macos":
+      return "react-native-macos";
+    case "windows":
+      return "react-native-windows";
+    default:
+      throw new Error(`Unsupported platform: ${platform}`);
+  }
+}
+
+/**
  * Returns platform package at target version if it satisfies version range.
- * @param {"react-native" | "react-native-macos" | "react-native-windows"} packageName
+ * @param {PlatformPackage} packageName
  * @param {string} targetVersion
  * @returns {Record<string, string> | undefined}
  */
@@ -388,7 +408,8 @@ export const getConfig = (() => {
           },
           dependencies: {},
           getDependencies: ({ targetVersion }) => {
-            return getPlatformPackage("react-native-macos", targetVersion);
+            const pkgName = getDefaultPlatformPackageName("macos");
+            return getPlatformPackage(pkgName, targetVersion);
           },
         },
         windows: {
@@ -409,7 +430,8 @@ export const getConfig = (() => {
           },
           dependencies: {},
           getDependencies: ({ targetVersion }) => {
-            return getPlatformPackage("react-native-windows", targetVersion);
+            const pkgName = getDefaultPlatformPackageName("windows");
+            return getPlatformPackage(pkgName, targetVersion);
           },
         },
       };

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -9,7 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import prompts from "prompts";
-import { configure } from "./configure.mjs";
+import { configure, getDefaultPlatformPackageName } from "./configure.mjs";
 import { npm as npmSync, readJSONFile } from "./helpers.js";
 import { parseArgs } from "./parseargs.mjs";
 
@@ -102,25 +102,6 @@ const getInstalledVersion = memo(() => {
 });
 
 /**
- * Returns the npm package name for the specified platform.
- * @param {string} platform
- * @returns {string}
- */
-function getPackageName(platform) {
-  switch (platform) {
-    case "android":
-    case "ios":
-      return "react-native";
-    case "macos":
-      return "react-native-macos";
-    case "windows":
-      return "react-native-windows";
-    default:
-      throw new Error(`Unsupported platform: ${platform}`);
-  }
-}
-
-/**
  * Returns the desired `react-native` version.
  *
  * Checks the following in order:
@@ -129,7 +110,7 @@ function getPackageName(platform) {
  *   - Currently installed `react-native` version
  *   - Latest version from npm
  *
- * @param {import("./configure.mjs").Platform[]} platforms
+ * @param {import("./types").Platform[]} platforms
  * @returns {string}
  */
 function getVersion(platforms) {
@@ -157,7 +138,7 @@ function getVersion(platforms) {
   console.log("No version was specified; fetching available versions...");
 
   const maxSupportedVersion = platforms.reduce((result, p) => {
-    const pkgName = getPackageName(p);
+    const pkgName = getDefaultPlatformPackageName(p);
     if (!pkgName) {
       return result;
     }
@@ -178,7 +159,7 @@ function getVersion(platforms) {
 
 /**
  * Returns the React Native version and path to the template.
- * @param {import("./configure.mjs").Platform[]} platforms
+ * @param {import("./types").Platform[]} platforms
  * @returns {Promise<[string] | [string, string]>}
  */
 function getTemplate(platforms) {
@@ -264,7 +245,7 @@ function main() {
          * @type {{
          *   name?: string;
          *   packagePath?: string;
-         *   platforms?: import("./configure.mjs").Platform[];
+         *   platforms?: import("./types").Platform[];
          * }}
          */
         const { name, packagePath, platforms } = await prompts([

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -22,6 +22,11 @@ export type PlatformConfiguration = {
   windows: Configuration;
 };
 
+export type PlatformPackage =
+  | "react-native"
+  | "react-native-macos"
+  | "react-native-windows";
+
 export type Platform = keyof PlatformConfiguration;
 
 export type ConfigureParams = {


### PR DESCRIPTION
### Description

Reduce out-of-tree platform package name dupes

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows

### Test plan

CI should pass