### PR TITLE
fix(android): handle simplified `ReactActivityDelegate`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -219,14 +219,18 @@ android {
                 ? "src/reactinstanceeventlistener-pre-0.68/java"
                 : "src/reactinstanceeventlistener-0.68/java",
 
-            // TODO: Remove this block when we drop support for 0.73
-            reactNativeVersion >= v(0, 74, 0)
-                ? "src/reactactivitydelegate-0.74/java"
-                // TODO: Remove this block when we drop support for 0.71
-                // https://github.com/facebook/react-native/commit/e5dd9cdc6688e63e75a7e0bebf380be1a9a5fe2b
-                : reactNativeVersion >= v(0, 72, 0)
-                    ? "src/reactactivitydelegate-0.72/java"
-                    : "src/reactactivitydelegate-pre-0.72/java",
+            // TODO: Remove this block when we drop support for 0.74
+            // https://github.com/facebook/react-native/commit/3283202248a36dbda553745afc46a3e3e2ab41a6
+            reactNativeVersion >= v(0, 75, 0)
+                ? "src/reactactivitydelegate-0.75/java"
+                // TODO: Remove this block when we drop support for 0.73
+                : reactNativeVersion >= v(0, 74, 0)
+                    ? "src/reactactivitydelegate-0.74/java"
+                    // TODO: Remove this block when we drop support for 0.71
+                    // https://github.com/facebook/react-native/commit/e5dd9cdc6688e63e75a7e0bebf380be1a9a5fe2b
+                    : reactNativeVersion >= v(0, 72, 0)
+                        ? "src/reactactivitydelegate-0.72/java"
+                        : "src/reactactivitydelegate-pre-0.72/java",
 
             // TODO: Remove this block when we drop support for 0.73
             // https://github.com/facebook/react-native/commit/cfa02eec50469059542ccbacbc51643b525ad461

--- a/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -1,0 +1,19 @@
+package com.microsoft.reacttestapp.component
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.microsoft.reacttestapp.BuildConfig
+
+class ComponentActivityDelegate(
+    activity: ReactActivity,
+    mainComponentName: String?
+) : ReactActivityDelegate(activity, mainComponentName) {
+    override fun getLaunchOptions(): Bundle? {
+        return plainActivity.intent.extras?.getBundle(
+            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+        )
+    }
+
+    override fun isFabricEnabled(): Boolean = BuildConfig.ReactTestApp_useFabric
+}

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -82,6 +82,7 @@ describe("npm pack", () => {
       "android/app/src/old-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt",
       "android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
+      "android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt",
       "android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt",


### PR DESCRIPTION
### Description

Android nightly build is failing because `ReactActivityDelegate` was simplified in https://github.com/facebook/react-native/commit/3283202248a36dbda553745afc46a3e3e2ab41a6:

```
> Task :app:compileDebugKotlin FAILED
e: file:///~/node_modules/react-native-test-app/android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt:24:5 'createRootView' overrides nothing
```

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
yarn android

# In a separate terminal
yarn start
```

### Screenshots

![Screenshot_1710409294](https://github.com/microsoft/react-native-test-app/assets/4123478/aa49ca2f-00d1-4ea9-a688-9f6c822ade81)
