### PR TITLE
fix(init): copy missing `tsconfig.json` from the template

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -299,6 +299,9 @@ export const getConfig = (() => {
                         "App.tsx": {
                           source: path.join(templateDir, "App.tsx"),
                         },
+                        "tsconfig.json": {
+                          source: path.join(templateDir, "tsconfig.json"),
+                        },
                       }
                     : {
                         "App.js": { source: path.join(templateDir, "App.js") },

--- a/test/configure/getConfig.test.mjs
+++ b/test/configure/getConfig.test.mjs
@@ -54,6 +54,7 @@ describe("getConfig()", () => {
       "metro.config.js",
       "package.json",
       "react-native.config.js",
+      "tsconfig.json",
     ]);
     deepEqual(config.oldFiles, []);
     deepEqual(Object.keys(config.scripts).sort(), ["start"]);


### PR DESCRIPTION
### Description

Copy `tsconfig.json` from the template when generating a new project.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a