### PR TITLE
fix(apple): fix unable to resolve `@react-native-community/cli-platform-ios`

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -51,7 +51,8 @@ def resolve_module_relative(request)
 end
 
 def resolve_module_uncached(request, start_dir)
-  package_json = find_file("node_modules/#{request}/package.json", start_dir)
+  # Always resolve `start_dir` as it may be a symlink
+  package_json = find_file("node_modules/#{request}/package.json", start_dir.realdirpath)
   raise "Cannot find module '#{request}'" if package_json.nil?
 
   package_json.dirname


### PR DESCRIPTION
### Description

Setups using Yarn 4 in pnpm mode may be unable to resolve `@react-native-community/cli-platform-ios` during `pod install`.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/rnx-kit/pull/3004