### PR TITLE
fix(apple): enable bridgeless by default with New Arch in 0.74

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -7,7 +7,6 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 workspace 'Example.xcworkspace'
 
 options = {
-  :bridgeless_enabled => false,
   :fabric_enabled => false,
   :hermes_enabled => false,
 }

--- a/example/visionos/Podfile
+++ b/example/visionos/Podfile
@@ -8,7 +8,6 @@ workspace 'Example.xcworkspace'
 
 options = {
   :fabric_enabled => false,
-  :bridgless_enabled => false,
   :hermes_enabled => false,
 }
 

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -17,10 +17,10 @@ def assert_version(pod_version)
 end
 
 def bridgeless_enabled?(options, react_native_version)
-  return false unless new_architecture_enabled?(options, react_native_version)
-
-  supports_bridgeless = react_native_version.zero? || react_native_version >= v(0, 73, 0)
-  supports_bridgeless && options[:bridgeless_enabled]
+  new_architecture_enabled?(options, react_native_version) && (
+    (react_native_version >= v(0, 74, 0) && options[:bridgeless_enabled] != false) ||
+    (react_native_version >= v(0, 73, 0) && options[:bridgeless_enabled])
+  )
 end
 
 def find_file(file_name, current_dir)

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -23,6 +23,9 @@ class TestPodHelpers < Minitest::Test
     # Bridgeless mode is first publicly available in 0.73
     available_version = v(0, 73, 0)
 
+    # Bridgeless mode is enabled by default starting with 0.74
+    default_version = v(0, 74, 0)
+
     refute(bridgeless_enabled?({}, 0))
     refute(bridgeless_enabled?({}, available_version))
 
@@ -31,11 +34,18 @@ class TestPodHelpers < Minitest::Test
     refute(bridgeless_enabled?(options, v(0, 72, 999)))
     assert(bridgeless_enabled?(options, available_version))
 
+    # Bridgeless mode is enabled by default starting with 0.74 unless opted-out of
+    assert(bridgeless_enabled?({ :fabric_enabled => true }, default_version))
+    refute(bridgeless_enabled?({ :bridgeless_enabled => false, :fabric_enabled => true },
+                               default_version))
+
     # `RCT_NEW_ARCH_ENABLED` does not enable bridgeless
     ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 
     refute(bridgeless_enabled?({}, v(0, 72, 999)))
     refute(bridgeless_enabled?({}, available_version))
+    assert(bridgeless_enabled?({}, default_version))
+    refute(bridgeless_enabled?({ :bridgeless_enabled => false }, default_version))
   end
 
   def test_new_architecture_enabled?


### PR DESCRIPTION
### Description

Enable bridgeless by default with New Arch in 0.74

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a