### PR TITLE
fix: replace `mkdirp` with an inline script

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -289,6 +289,8 @@ export const getConfig = (() => {
           },
           oldFiles: [],
           scripts: {
+            mkdist:
+              'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
             start: "react-native start",
           },
           dependencies: {},
@@ -349,7 +351,7 @@ export const getConfig = (() => {
           scripts: {
             android: "react-native run-android",
             "build:android":
-              "mkdirp dist/res && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
+              "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
           },
           dependencies: {},
         },
@@ -365,7 +367,7 @@ export const getConfig = (() => {
           ],
           scripts: {
             "build:ios":
-              "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+              "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
             ios: `react-native run-ios${projectPathFlag}`,
           },
           dependencies: {},
@@ -382,7 +384,7 @@ export const getConfig = (() => {
           ],
           scripts: {
             "build:macos":
-              "mkdirp dist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
+              "npm run mkdist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
             macos: `react-native run-macos --scheme ${name}${projectPathFlag}`,
           },
           dependencies: {},
@@ -399,7 +401,7 @@ export const getConfig = (() => {
           ],
           scripts: {
             "build:visionos":
-              "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.visionos.jsbundle --assets-dest dist",
+              "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.visionos.jsbundle --assets-dest dist",
             visionos: "react-native run-visionos",
           },
           dependencies: {},
@@ -417,7 +419,7 @@ export const getConfig = (() => {
           ],
           scripts: {
             "build:windows":
-              "mkdirp dist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
+              "npm run mkdist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
             windows: `react-native run-windows --sln ${flatten ? "" : "windows/"}${name}.sln`,
           },
           dependencies: {},
@@ -583,7 +585,6 @@ export function updatePackageManifest(
   const { name: rntaName, version: rntaVersion } = readManifest();
   manifest["devDependencies"] = mergeObjects(manifest["devDependencies"], {
     "@rnx-kit/metro-config": "^1.3.15",
-    mkdirp: "^1.0.0",
     [rntaName]: `^${rntaVersion}`,
   });
 

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -289,8 +289,7 @@ export const getConfig = (() => {
           },
           oldFiles: [],
           scripts: {
-            mkdist:
-              'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+            mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
             start: "react-native start",
           },
           dependencies: {},

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -210,15 +210,17 @@ describe("gatherConfig()", () => {
       scripts: {
         android: "react-native run-android",
         "build:android":
-          "mkdirp dist/res && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
         "build:ios":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         "build:macos":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform macos --dev true --bundle-output dist/main.macos.jsbundle --assets-dest dist",
         "build:windows":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
         ios: "react-native run-ios",
         macos: "react-native run-macos --scheme Test",
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
         windows: "react-native run-windows --sln windows/Test.sln",
       },
@@ -309,6 +311,8 @@ describe("gatherConfig()", () => {
       },
       oldFiles: [],
       scripts: {
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
       },
     });
@@ -378,8 +382,10 @@ describe("gatherConfig()", () => {
       ],
       scripts: {
         "build:ios":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
       },
     });
@@ -533,10 +539,12 @@ describe("gatherConfig()", () => {
       scripts: {
         android: "react-native run-android",
         "build:android":
-          "mkdirp dist/res && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
         "build:ios":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
       },
     });
@@ -594,8 +602,10 @@ describe("gatherConfig()", () => {
       oldFiles: ["Podfile.lock", "Pods", "Test.xcodeproj", "Test.xcworkspace"],
       scripts: {
         "build:ios":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
       },
     });
@@ -747,10 +757,12 @@ describe("gatherConfig()", () => {
       scripts: {
         android: "react-native run-android",
         "build:android":
-          "mkdirp dist/res && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
         "build:ios":
-          "mkdirp dist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
+          "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
+        mkdist:
+          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
         start: "react-native start",
       },
     });

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -219,8 +219,7 @@ describe("gatherConfig()", () => {
           "npm run mkdist && react-native bundle --entry-file index.js --platform windows --dev true --bundle-output dist/main.windows.bundle --assets-dest dist",
         ios: "react-native run-ios",
         macos: "react-native run-macos --scheme Test",
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
         windows: "react-native run-windows --sln windows/Test.sln",
       },
@@ -311,8 +310,7 @@ describe("gatherConfig()", () => {
       },
       oldFiles: [],
       scripts: {
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
       },
     });
@@ -384,8 +382,7 @@ describe("gatherConfig()", () => {
         "build:ios":
           "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
       },
     });
@@ -543,8 +540,7 @@ describe("gatherConfig()", () => {
         "build:ios":
           "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
       },
     });
@@ -604,8 +600,7 @@ describe("gatherConfig()", () => {
         "build:ios":
           "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
       },
     });
@@ -761,8 +756,7 @@ describe("gatherConfig()", () => {
         "build:ios":
           "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
         ios: "react-native run-ios",
-        mkdist:
-          'node -e \'require("node:fs").mkdirSync("dist", { recursive: true, mode: 0o755 })\'',
+        mkdist: `node -e "require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })"`,
         start: "react-native start",
       },
     });

--- a/test/configure/getConfig.test.mjs
+++ b/test/configure/getConfig.test.mjs
@@ -36,7 +36,7 @@ describe("getConfig()", () => {
       "react-native.config.js",
     ]);
     deepEqual(config.oldFiles, []);
-    deepEqual(Object.keys(config.scripts).sort(), ["start"]);
+    deepEqual(Object.keys(config.scripts).sort(), ["mkdist", "start"]);
     deepEqual(getDependencies("common", params), []);
   });
 
@@ -57,7 +57,7 @@ describe("getConfig()", () => {
       "tsconfig.json",
     ]);
     deepEqual(config.oldFiles, []);
-    deepEqual(Object.keys(config.scripts).sort(), ["start"]);
+    deepEqual(Object.keys(config.scripts).sort(), ["mkdist", "start"]);
     deepEqual(getDependencies("common", params), []);
   });
 

--- a/test/configure/updatePackageManifest.test.mjs
+++ b/test/configure/updatePackageManifest.test.mjs
@@ -21,7 +21,6 @@ describe("updatePackageManifest()", () => {
   const devDependencies = {
     "@rnx-kit/metro-config":
       exampleManifest["devDependencies"]?.["@rnx-kit/metro-config"],
-    mkdirp: "^1.0.0",
     "react-native-test-app": "^0.0.1-dev",
   };
 


### PR DESCRIPTION
### Description

For newly generated projects, we can drop `mkdirp` for an inline script.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a