### PR TITLE
fix(windows): fix arch mismatch errors when enabling NuGet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,7 +589,7 @@ jobs:
           yarn build:windows
       - name: Generate Visual Studio solution
         run: |
-          yarn install-windows-test-app
+          yarn install-windows-test-app --use-nuget
         working-directory: example
       - name: Test `react-native config`
         run: |
@@ -649,8 +649,8 @@ jobs:
           yarn build:windows
       - name: Generate Visual Studio solution
         run: |
-          if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app }
-          else { yarn install-windows-test-app --project-directory=. }
+          if ("${{ matrix.template }}" -eq "all") { yarn install-windows-test-app --use-nuget }
+          else { yarn install-windows-test-app --project-directory=. --use-nuget }
         working-directory: template-example
       - name: Determine whether the Windows app needs to be built
         id: affected

--- a/windows/UWP/ReactTestApp.vcxproj
+++ b/windows/UWP/ReactTestApp.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)ExperimentalFeatures.props')" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -24,7 +24,6 @@
     <ReactAppUniversalDir Condition="'$(ReactAppUniversalDir)'==''">$(ReactAppWinDir)\UWP</ReactAppUniversalDir>
     <ReactAppGeneratedDir Condition="'$(ReactAppGeneratedDir)'==''">$(MSBuildProjectDirectory)\..\..</ReactAppGeneratedDir>
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-    <WinUI2xVersionDisabled />
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
   <PropertyGroup Label="Fallback Windows SDK Versions">
@@ -145,6 +144,7 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
+    <Image Include="Assets\LockScreenLogo.scale-200.png" />
     <Image Include="Assets\SplashScreen.scale-200.png" />
     <Image Include="Assets\Square150x150Logo.scale-200.png" />
     <Image Include="Assets\Square44x44Logo.scale-200.png" />
@@ -181,8 +181,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectRootDir)\app.json" />
-    <None Include="packages.config" />
+    <None Include="packages.config" Condition="$(ReactNativeWindowsVersionNumber)>=68000" />
     <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <ItemGroup Condition="$(ReactNativeWindowsVersionNumber)>=68000">
+    <PackageReference Include="nlohmann.json" Version="3.11.2" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">
@@ -200,20 +203,12 @@
     <ReactNativeWindowsVersion Condition="'$(ReactNativeWindowsVersion)'==''">$(ReactNativeWindowsNpmVersion)</ReactNativeWindowsVersion>
   </PropertyGroup>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
-    <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)'=='true'" />
-    <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
-    <Import Project="$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets" Condition="Exists('$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
+    <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)'=='true'" />
+    <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+    <Import Project="$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" />
     <!-- ReactTestApp additional targets -->
   </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\nlohmann.json.3.10.4\build\native\nlohmann.json.targets'))" />
-  </Target>
 </Project>

--- a/windows/UWP/packages.config
+++ b/windows/UWP/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.UI.Xaml" version="0.0.0" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.211028.7" targetFramework="native"/>
   <!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->
-  <package id="nlohmann.json" version="3.10.4" targetFramework="native"/>
+  <package id="nlohmann.json" version="3.11.2" targetFramework="native"/>
   <!-- additional packages -->
 </packages>

--- a/windows/uwp.mjs
+++ b/windows/uwp.mjs
@@ -15,74 +15,78 @@ export function configureForUWP(
   },
   { useNuGet }
 ) {
+  /** @type {import("../scripts/types").MSBuildProjectParams["projectFiles"]} */
+  const projectFiles = [
+    ["Assets"],
+    ["AutolinkedNativeModules.g.cpp"],
+    ["AutolinkedNativeModules.g.props"],
+    ["AutolinkedNativeModules.g.targets"],
+    ["Package.appxmanifest"],
+    ["PropertySheet.props"],
+    [
+      "ReactTestApp.vcxproj",
+      {
+        "\\$\\(ReactNativeWindowsVersionNumber\\)": versionNumber.toString(),
+        "REACT_NATIVE_VERSION=1000000000;": `REACT_NATIVE_VERSION=${versionNumber};`,
+        "\\$\\(ReactTestAppPackageManifest\\)": bundle.appxManifest,
+        "\\$\\(ReactNativeWindowsNpmVersion\\)": version,
+        "<!-- ReactTestApp asset items -->": bundle.assetItems,
+        "<!-- ReactTestApp additional targets -->":
+          importTargets(nugetDependencies),
+        ...(typeof bundle.singleApp === "string"
+          ? { "ENABLE_SINGLE_APP_MODE=0;": "ENABLE_SINGLE_APP_MODE=1;" }
+          : undefined),
+        ...(bundle.packageCertificate
+          ? {
+              "<AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>":
+                bundle.packageCertificate,
+            }
+          : undefined),
+      },
+    ],
+    [
+      "ReactTestApp.vcxproj.filters",
+      {
+        "<!-- ReactTestApp asset item filters -->": bundle.assetItemFilters,
+        "<!-- ReactTestApp asset filters -->": bundle.assetFilters,
+        "\\$\\(ReactTestAppPackageManifest\\)": bundle.appxManifest,
+      },
+    ],
+  ];
+
+  // TODO: `packages.config` was removed in 0.68
+  // https://github.com/microsoft/react-native-windows/commit/bcdf9ad68eeda2967062f5137bc0f248e2ce7897
+  if (!usePackageReferences) {
+    projectFiles.push([
+      "packages.config",
+      {
+        '<package id="Microsoft.UI.Xaml" version="0.0.0" targetFramework="native"/>':
+          nugetPackage("Microsoft.UI.Xaml", xamlVersion),
+        "<!-- additional packages -->": nugetDependencies
+          .map(([id, version]) => nugetPackage(id, version))
+          .join("\n  "),
+        ...(useNuGet
+          ? {
+              '<!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native"/ -->':
+                nugetPackage("Microsoft.ReactNative", version),
+              '<!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native"/ -->':
+                nugetPackage("Microsoft.ReactNative.Cxx", version),
+            }
+          : undefined),
+        ...(hermesVersion
+          ? {
+              '<!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->':
+                nugetPackage("ReactNative.Hermes.Windows", hermesVersion),
+            }
+          : undefined),
+      },
+    ]);
+  }
+
   return {
     projDir: "UWP",
     projectFileName: "ReactTestApp.vcxproj",
-    projectFiles: [
-      ["Assets"],
-      ["AutolinkedNativeModules.g.cpp"],
-      ["AutolinkedNativeModules.g.props"],
-      ["AutolinkedNativeModules.g.targets"],
-      ["Package.appxmanifest"],
-      ["PropertySheet.props"],
-      [
-        "ReactTestApp.vcxproj",
-        {
-          "REACT_NATIVE_VERSION=1000000000;": `REACT_NATIVE_VERSION=${versionNumber};`,
-          "\\$\\(ReactTestAppPackageManifest\\)": bundle.appxManifest,
-          "\\$\\(ReactNativeWindowsNpmVersion\\)": version,
-          "<!-- ReactTestApp asset items -->": bundle.assetItems,
-          "<!-- ReactTestApp additional targets -->":
-            importTargets(nugetDependencies),
-          ...(typeof bundle.singleApp === "string"
-            ? { "ENABLE_SINGLE_APP_MODE=0;": "ENABLE_SINGLE_APP_MODE=1;" }
-            : undefined),
-          ...(useNuGet
-            ? {
-                "<WinUI2xVersionDisabled />": `<WinUI2xVersion>${xamlVersion}</WinUI2xVersion>`,
-              }
-            : undefined),
-          ...(bundle.packageCertificate
-            ? {
-                "<AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>":
-                  bundle.packageCertificate,
-              }
-            : undefined),
-        },
-      ],
-      [
-        "ReactTestApp.vcxproj.filters",
-        {
-          "<!-- ReactTestApp asset item filters -->": bundle.assetItemFilters,
-          "<!-- ReactTestApp asset filters -->": bundle.assetFilters,
-          "\\$\\(ReactTestAppPackageManifest\\)": bundle.appxManifest,
-        },
-      ],
-      [
-        "packages.config",
-        {
-          '<package id="Microsoft.UI.Xaml" version="0.0.0" targetFramework="native"/>':
-            nugetPackage("Microsoft.UI.Xaml", xamlVersion),
-          "<!-- additional packages -->": nugetDependencies
-            .map(([id, version]) => nugetPackage(id, version))
-            .join("\n  "),
-          ...(useNuGet && !usePackageReferences
-            ? {
-                '<!-- package id="Microsoft.ReactNative" version="1000.0.0" targetFramework="native"/ -->':
-                  nugetPackage("Microsoft.ReactNative", version),
-                '<!-- package id="Microsoft.ReactNative.Cxx" version="1000.0.0" targetFramework="native"/ -->':
-                  nugetPackage("Microsoft.ReactNative.Cxx", version),
-              }
-            : undefined),
-          ...(hermesVersion && !usePackageReferences
-            ? {
-                '<!-- package id="ReactNative.Hermes.Windows" version="0.0.0" targetFramework="native"/ -->':
-                  nugetPackage("ReactNative.Hermes.Windows", hermesVersion),
-              }
-            : undefined),
-        },
-      ],
-    ],
+    projectFiles,
     solutionTemplatePath: path.join("template", "cpp-app", "proj", "MyApp.sln"),
   };
 }


### PR DESCRIPTION
### Description

Update Visual Studio project and attempt to fix NuGet issues.

Resolves #1879.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a

### Screenshots

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/ab6459e3-9836-400c-98dd-99beb69853e4)
