### PR TITLE
fix(windows): align color use with `@react-native-community/cli`

### DIFF
--- a/test/windows-test-app/getBundleResources.test.mjs
+++ b/test/windows-test-app/getBundleResources.test.mjs
@@ -91,7 +91,7 @@ describe("getBundleResources()", () => {
     });
 
     equal(
-      spy(console.warn).calls[0].arguments[0],
+      spy(console.warn).calls[0].arguments[1],
       "Could not find 'app.json' file."
     );
   });
@@ -110,7 +110,7 @@ describe("getBundleResources()", () => {
     });
 
     match(
-      spy(console.warn).calls[0].arguments[0],
+      spy(console.warn).calls[0].arguments[1],
       /^Could not parse 'app.json':\n/
     );
   });

--- a/test/windows-test-app/parseResources.test.mjs
+++ b/test/windows-test-app/parseResources.test.mjs
@@ -67,12 +67,12 @@ describe("parseResources()", () => {
     deepEqual(parseResources(["dist/assets", "dist/main.bundle"], "."), empty);
 
     equal(
-      spy(console.warn).calls[0].arguments[0],
-      "warning: resource not found: dist/assets"
+      spy(console.warn).calls[0].arguments[1],
+      "Resource not found: dist/assets"
     );
     equal(
-      spy(console.warn).calls[1].arguments[0],
-      "warning: resource not found: dist/main.bundle"
+      spy(console.warn).calls[1].arguments[1],
+      "Resource not found: dist/main.bundle"
     );
   });
 });

--- a/windows/project.mjs
+++ b/windows/project.mjs
@@ -3,6 +3,7 @@ import { XMLParser } from "fast-xml-parser";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { v5 as uuidv5 } from "uuid";
+import * as colors from "yoctocolors";
 import {
   findNearest,
   getPackageVersion,
@@ -90,6 +91,14 @@ function generateCertificateItems(
 }
 
 /**
+ * @param {string} message
+ */
+function warn(message) {
+  const tag = colors.yellow(colors.bold("warn"));
+  console.warn(tag, message);
+}
+
+/**
  * @param {string[]} resources
  * @param {string} projectPath
  * @param {AssetItems} assets
@@ -111,7 +120,7 @@ function generateContentItems(
       ? path.relative(projectPath, resource)
       : resource;
     if (!fs.existsSync(resourcePath)) {
-      console.warn(`warning: resource not found: ${resource}`);
+      warn(`Resource not found: ${resource}`);
       continue;
     }
 
@@ -363,13 +372,13 @@ export function getBundleResources(manifestFilePath, fs = nodefs) {
       };
     } catch (e) {
       if (isErrorLike(e)) {
-        console.warn(`Could not parse 'app.json':\n${e.message}`);
+        warn(`Could not parse 'app.json':\n${e.message}`);
       } else {
         throw e;
       }
     }
   } else {
-    console.warn("Could not find 'app.json' file.");
+    warn("Could not find 'app.json' file.");
   }
 
   return {
@@ -416,9 +425,7 @@ export function projectInfo(
   const newArch =
     Boolean(useFabric) && (versionNumber === 0 || versionNumber >= v(0, 74, 0));
   if (useFabric && !newArch) {
-    console.warn(
-      "warning: New Architecture requires `react-native-windows` 0.74+"
-    );
+    warn("New Architecture requires `react-native-windows` 0.74+");
   }
 
   return {

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -5,6 +5,7 @@ import * as nodefs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import * as colors from "yoctocolors";
 import {
   findNearest,
   isMain,
@@ -232,7 +233,10 @@ export function generateSolution(destPath, options, fs = nodefs) {
     destPath,
     experimentalFeaturesPropsFilename
   );
-  if (!fs.existsSync(experimentalFeaturesPropsPath)) {
+  if (fs.existsSync(experimentalFeaturesPropsPath)) {
+    const props = path.relative(process.cwd(), experimentalFeaturesPropsPath);
+    console.log(colors.cyan(colors.bold("info")), `'${props}' already exists`);
+  } else {
     const { useHermes } = options;
     const {
       hermesVersion,


### PR DESCRIPTION
### Description

Align color use with `@react-native-community/cli`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
cd example
yarn install-windows-test-app
```

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/12eb39e3-6034-41b8-a0db-e6579cdda4d5)

The colors can be found here: https://github.com/react-native-community/cli/blob/main/packages/cli-tools/src/logger.ts