### PR TITLE
fix(windows): use proper NuGet feed for canaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -598,15 +598,6 @@ jobs:
       - name: Determine whether the Windows app needs to be built
         id: affected
         uses: ./.github/actions/affected
-      - name: Set up NuGet sources
-        # Temporarily disabled since builds using NuGet artifacts randomly fail
-        # with architecture mismatch error:
-        # https://github.com/microsoft/react-native-test-app/issues/1879
-        if: false # ${{ steps.affected.outputs.windows != '' && github.event_name == 'schedule' }}
-        run: |
-          nuget sources Add -Name react-native-windows -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -ConfigFile NuGet.Config
-          cp NuGet.Config ../node_modules/.generated/windows/ReactTestApp
-        working-directory: example/windows
       - name: Build
         if: ${{ steps.affected.outputs.windows != '' }}
         run: |

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -311,7 +311,9 @@ export function generateSolution(destPath, options, fs = nodefs) {
       copyTasks.push(
         writeTextFile(
           nugetConfigDestPath,
-          mustache.render(readTextFile(nugetConfigPath, fs), {}),
+          mustache.render(readTextFile(nugetConfigPath, fs), {
+            nuGetADOFeed: info.version.startsWith("0.0.0-"),
+          }),
           fs.promises
         )
       );


### PR DESCRIPTION
### Description

Use proper NuGet feed for canaries

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
cd example
yarn install-windows-test-app --use-nuget
cat windows/NuGet.Config
```

Perform the commands above for the current version, and once again for canary version (run `npm run set-react-version canary-windows`).

For the current version, `NuGet.Config` should **not** contain `https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json`. For the canary build, it should.