### PR TITLE
fix(apple): respect `USE_HERMES` env var

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -66,6 +66,13 @@ def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
 
+def use_hermes?(options)
+  use_hermes = ENV.fetch('USE_HERMES', nil)
+  return use_hermes == '1' unless use_hermes.nil?
+
+  options[:hermes_enabled] == true
+end
+
 def use_new_architecture!(options, react_native_version)
   return unless new_architecture_enabled?(options, react_native_version)
 

--- a/ios/use_react_native-0.64.rb
+++ b/ios/use_react_native-0.64.rb
@@ -5,6 +5,7 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
+  options[:hermes_enabled] = use_hermes?(options)
   use_react_native!(options)
 
   # If we're using react-native@main, we'll also need to prepare

--- a/ios/use_react_native-0.68.rb
+++ b/ios/use_react_native-0.68.rb
@@ -7,6 +7,7 @@ def include_react_native!(options)
 
   require_relative(File.join(project_root, react_native, 'scripts', 'react_native_pods'))
 
+  options[:hermes_enabled] = use_hermes?(options)
   use_react_native!(options)
 
   # If we're using react-native@main, we'll also need to prepare

--- a/ios/use_react_native-0.70.rb
+++ b/ios/use_react_native-0.70.rb
@@ -10,7 +10,7 @@ def include_react_native!(options)
   use_react_native!(
     path: react_native,
     production: options.key?(:production) ? options[:production] : ENV['PRODUCTION'] == '1',
-    hermes_enabled: options[:hermes_enabled] == true,
+    hermes_enabled: use_hermes?(options),
     app_path: options[:app_path] || '..',
     config_file_dir: options[:config_file_dir] || ''
   )

--- a/ios/use_react_native-0.71.rb
+++ b/ios/use_react_native-0.71.rb
@@ -13,7 +13,7 @@ def include_react_native!(options)
     fabric_enabled: options[:fabric_enabled] == true,
     new_arch_enabled: options[:new_arch_enabled] == true,
     production: options.key?(:production) ? options[:production] : ENV['PRODUCTION'] == '1',
-    hermes_enabled: options[:hermes_enabled] == true,
+    hermes_enabled: use_hermes?(options),
     app_path: options[:app_path] || '..',
     config_file_dir: options[:config_file_dir] || ''
   )

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -29,14 +29,14 @@ class TestPodHelpers < Minitest::Test
     refute(bridgeless_enabled?({}, 0))
     refute(bridgeless_enabled?({}, available_version))
 
-    options = { :bridgeless_enabled => true, :fabric_enabled => true }
+    options = { bridgeless_enabled: true, fabric_enabled: true }
 
     refute(bridgeless_enabled?(options, v(0, 72, 999)))
     assert(bridgeless_enabled?(options, available_version))
 
     # Bridgeless mode is enabled by default starting with 0.74 unless opted-out of
-    assert(bridgeless_enabled?({ :fabric_enabled => true }, default_version))
-    refute(bridgeless_enabled?({ :bridgeless_enabled => false, :fabric_enabled => true },
+    assert(bridgeless_enabled?({ fabric_enabled: true }, default_version))
+    refute(bridgeless_enabled?({ bridgeless_enabled: false, fabric_enabled: true },
                                default_version))
 
     # `RCT_NEW_ARCH_ENABLED` does not enable bridgeless
@@ -45,7 +45,7 @@ class TestPodHelpers < Minitest::Test
     refute(bridgeless_enabled?({}, v(0, 72, 999)))
     refute(bridgeless_enabled?({}, available_version))
     assert(bridgeless_enabled?({}, default_version))
-    refute(bridgeless_enabled?({ :bridgeless_enabled => false }, default_version))
+    refute(bridgeless_enabled?({ bridgeless_enabled: false }, default_version))
   end
 
   def test_new_architecture_enabled?
@@ -58,18 +58,39 @@ class TestPodHelpers < Minitest::Test
     refute(new_architecture_enabled?({}, available_version))
 
     # New architecture is first publicly available in 0.68, but we'll require 0.71
-    refute(new_architecture_enabled?({ :fabric_enabled => true }, v(0, 70, 999)))
-    assert(new_architecture_enabled?({ :fabric_enabled => true }, available_version))
+    refute(new_architecture_enabled?({ fabric_enabled: true }, v(0, 70, 999)))
+    assert(new_architecture_enabled?({ fabric_enabled: true }, available_version))
 
     # TODO: `:turbomodule_enabled` is scheduled for removal in 4.0
-    refute(new_architecture_enabled?({ :turbomodule_enabled => true }, v(0, 70, 999)))
-    assert(new_architecture_enabled?({ :turbomodule_enabled => true }, available_version))
+    refute(new_architecture_enabled?({ turbomodule_enabled: true }, v(0, 70, 999)))
+    assert(new_architecture_enabled?({ turbomodule_enabled: true }, available_version))
 
     # `RCT_NEW_ARCH_ENABLED` enables everything
     ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 
     refute(new_architecture_enabled?({}, v(0, 70, 999)))
     assert(new_architecture_enabled?({}, available_version))
+
+    ENV.delete('RCT_NEW_ARCH_ENABLED')
+  end
+
+  def test_use_hermes?
+    ENV.delete('USE_HERMES')
+
+    refute(use_hermes?({}))
+    assert(use_hermes?({ hermes_enabled: true }))
+
+    ENV['USE_HERMES'] = '0'
+
+    refute(use_hermes?({}))
+    refute(use_hermes?({ hermes_enabled: true }))
+
+    ENV['USE_HERMES'] = '1'
+
+    assert(use_hermes?({}))
+    assert(use_hermes?({ hermes_enabled: true }))
+
+    ENV.delete('USE_HERMES')
   end
 
   def test_v


### PR DESCRIPTION
### Description

`USE_HERMES` as added in 0.71

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
cd example
USE_HERMES=1 pod install --project-directory=ios
```

Verify that the output includes `React-hermes`.