### PR TITLE
fix(visionos): declare support for 0.74

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "macos": "react-native run-macos --no-packager --scheme Example",
     "set-react-version": "yarn workspace react-native-test-app set-react-version",
     "start": "react-native start",
-    "visionos": "react-native run-visionos --no-packager",
+    "visionos": "react-native run-visionos",
     "windows": "react-native run-windows --no-packager"
   },
   "dependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
     "macos": "react-native run-macos --no-packager --scheme Example",
     "set-react-version": "yarn workspace react-native-test-app set-react-version",
     "start": "react-native start",
+    "visionos": "react-native run-visionos --no-packager",
     "windows": "react-native run-windows --no-packager"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "yoctocolors": "^2.0.0"
   },
   "peerDependencies": {
-    "@callstack/react-native-visionos": "0.73",
+    "@callstack/react-native-visionos": "0.73 - 0.74",
     "@expo/config-plugins": ">=5.0",
     "react": "17.0.1 - 18.2",
     "react-native": "0.66 - 0.74 || >=0.75.0-0 <0.75.0",

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -348,6 +348,12 @@ async function getProfile(v, coreOnly) {
     }
 
     default: {
+      const manifest = /** @type {Manifest} */ (readJSONFile("package.json"));
+      const visionos = manifest.defaultPlatformPackages?.["visionos"];
+      if (!visionos) {
+        throw new Error("Missing platform package for visionOS");
+      }
+
       const versions = {
         core: fetchPackageInfo(`react-native@^${v}.0-0`),
         macos: coreOnly
@@ -355,7 +361,7 @@ async function getProfile(v, coreOnly) {
           : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
         visionos: coreOnly
           ? Promise.resolve({ version: undefined })
-          : fetchPackageInfo(`@callstack/react-native-visionos@^${v}.0-0`),
+          : fetchPackageInfo(`${visionos}@^${v}.0-0`),
         windows: coreOnly
           ? Promise.resolve({ version: undefined })
           : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
@@ -367,11 +373,10 @@ async function getProfile(v, coreOnly) {
       const getVersion = ({ version }) => version;
       return {
         ...commonDeps,
-        "@callstack/react-native-visionos":
-          await versions.visionos.then(getVersion),
         "react-native": reactNative.version,
         "react-native-macos": await versions.macos.then(getVersion),
         "react-native-windows": await versions.windows.then(getVersion),
+        [visionos]: await versions.visionos.then(getVersion),
       };
     }
   }

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -348,22 +348,30 @@ async function getProfile(v, coreOnly) {
     }
 
     default: {
-      const [reactNative, { version: rnmVersion }, { version: rnwVersion }] =
-        await Promise.all([
-          fetchPackageInfo(`react-native@^${v}.0-0`),
-          coreOnly
-            ? Promise.resolve({ version: undefined })
-            : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
-          coreOnly
-            ? Promise.resolve({ version: undefined })
-            : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
-        ]);
+      const versions = {
+        core: fetchPackageInfo(`react-native@^${v}.0-0`),
+        macos: coreOnly
+          ? Promise.resolve({ version: undefined })
+          : fetchPackageInfo(`react-native-macos@^${v}.0-0`),
+        visionos: coreOnly
+          ? Promise.resolve({ version: undefined })
+          : fetchPackageInfo(`@callstack/react-native-visionos@^${v}.0-0`),
+        windows: coreOnly
+          ? Promise.resolve({ version: undefined })
+          : fetchPackageInfo(`react-native-windows@^${v}.0-0`),
+      };
+      const reactNative = await versions.core;
       const commonDeps = await resolveCommonDependencies(v, reactNative);
+
+      /** @type {(manifest: Manifest) => string | undefined} */
+      const getVersion = ({ version }) => version;
       return {
         ...commonDeps,
+        "@callstack/react-native-visionos":
+          await versions.visionos.then(getVersion),
         "react-native": reactNative.version,
-        "react-native-macos": rnmVersion,
-        "react-native-windows": rnwVersion,
+        "react-native-macos": await versions.macos.then(getVersion),
+        "react-native-windows": await versions.windows.then(getVersion),
       };
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12276,7 +12276,7 @@ __metadata:
     uuid: "npm:^9.0.0"
     yoctocolors: "npm:^2.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": 0.73
+    "@callstack/react-native-visionos": 0.73 - 0.74
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 18.2
     react-native: 0.66 - 0.74 || >=0.75.0-0 <0.75.0


### PR DESCRIPTION
### Description

Declare support for `@callstack/react-native-visionos` 0.74

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.74
yarn remove react-native-macos --all
cd example
pod install --project-directory=visionos
yarn visionos

# In a separate terminal
yarn start
```

### Screenshots

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/9f9881c8-9729-438d-8538-ff891e7b12d2)
