### PR TITLE
fix(android) Be more explicit about which gradle plugin to include

### DIFF
--- a/test-app.gradle
+++ b/test-app.gradle
@@ -67,9 +67,12 @@ ext.applyTestAppSettings = { DefaultSettings settings ->
     settings.project(":support")
         .projectDir = file("${testAppDir}/android/support")
 
+    def reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
+
     def reactNativeGradlePlugin =
-        findNodeModulesPath("@react-native/gradle-plugin", reactNativeDir)  // >= 0.72
-            ?: findNodeModulesPath("react-native-gradle-plugin", reactNativeDir)  // < 0.72
+        reactNativeVersion >= v(0, 72, 0)
+            ? findNodeModulesPath("@react-native/gradle-plugin", reactNativeDir)
+            : findNodeModulesPath("react-native-gradle-plugin", reactNativeDir)
     if (reactNativeGradlePlugin != null) {
         settings.includeBuild(reactNativeGradlePlugin)
     }


### PR DESCRIPTION
The previous approach could fail in a monorepo where both modules could exist in a hoisted node_modules

### Description

I discovered an issue with selecting which version of the react native module to include.

The current code checks if `@react-native/gradle-plugin` exists (RN >= 0.72) and usesit if it does.

This logic fails in a monorepo situation where both libraries could exist for different packages.

This change explicitly checks the react native version and loas the appropriate library.

This is on the path to helping me solve #1932

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

I'm currently testing this against my code base. Easiest way to reproduce

* Create a yarn workspace
* Create to react-native-test-apps inside
* One on 0.73 and on one 0.70
* Make sure you can build both
