### PR TITLE
fix(android): automatically configure Gradle wrapper

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,8 +18,10 @@ if (autodetectReactNativeVersion || enableNewArchitecture) {
     react {
         reactNativeDir = reactNativePath
         codegenDir = file(
-            findNodeModulesPath("@react-native/codegen", reactNativePath)  // >= 0.72
-                ?: findNodeModulesPath("react-native-codegen", reactNativePath))  // < 0.72
+            reactNativeVersion >= v(0, 72, 0)
+                ? findNodeModulesPath("@react-native/codegen", reactNativePath)
+                : findNodeModulesPath("react-native-codegen", reactNativePath)
+        )
     }
 
     // We don't want the React plugin to bundle.

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -383,22 +383,6 @@ async function getProfile(v, coreOnly) {
 }
 
 /**
- * Sets Gradle Wrapper to specified version.
- * @param {string} version
- */
-function setGradleVersion(version) {
-  const gradleWrapperProperties =
-    "example/android/gradle/wrapper/gradle-wrapper.properties";
-  fs.writeFileSync(
-    gradleWrapperProperties,
-    readTextFile(gradleWrapperProperties).replace(
-      /gradle-[.0-9]*-bin\.zip/,
-      `gradle-${version}-bin.zip`
-    )
-  );
-}
-
-/**
  * Sets specified React Native version.
  * @param {string} version
  * @param {boolean} coreOnly
@@ -466,8 +450,6 @@ if (isMain(import.meta.url)) {
           : toVersionNumber(version);
       if (numVersion >= v(0, 74, 0)) {
         disableJetifier();
-      } else if (numVersion < v(0, 73, 0)) {
-        setGradleVersion("7.6.3");
       }
 
       // `@react-native-webapis/web-storage` is not compatible with codegen 0.71


### PR DESCRIPTION
### Description

Automatically configure Gradle wrapper. To disable this behavior, set `RNTA_CONFIGURE_GRADLE_WRAPPER=0`.

Basically, this is what the script does:

- If 0.74 or greater (including nightlies), set Gradle version to 8.6 if the current version is lower
- If 0.73, set Gradle version to 8.3 if the current version is lower
- If 0.72, set Gradle version to 8.1.1 if the current version is lower
- Else, set Gradle version to 7.6.4 if the current version is <7.5.1 or >=8.0.0

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

1. Switch to 0.71: `npm run set-react-version 0.71 -- --core-only`
2. Verify that `example/android/gradle/wrapper/gradle-wrapper.properties` is unmodified
3. Install npm dependencies: `yarn`
4. Build the Android app: `cd example && yarn android`
5. In a separate terminal, verify that the Gradle version changed to 7.6.4 (in `example/android/gradle/wrapper/gradle-wrapper.properties`)
6. Switch to 0.73: `npm run set-react-version 0.73 -- --core-only`
7. Verify that the Gradle version is still 7.6.4
8. Install npm dependencies: `yarn`
9. Build the Android app: `cd example && yarn android`
10. In a separate terminal, verify that the Gradle version changed to 8.3
11. Switch to 0.72: `npm run set-react-version 0.72 -- --core-only`
12. Verify that the Gradle version is still 8.3
13. Install npm dependencies: `yarn`
14. Build the Android app: `cd example && yarn android`
15. In a separate terminal, verify that the Gradle version is still 8.3
16. Switch to 0.71: `npm run set-react-version 0.71 -- --core-only`
17. Verify that the Gradle version is still 8.3
18. Install npm dependencies: `yarn`
19. Build the Android app but disable the behavior: `cd example && RNTA_CONFIGURE_GRADLE_WRAPPER=0 yarn android`
20. Verify that the Gradle version is still 8.3