### PR TITLE
chore(visionos): reintroduce no-packager for visionos

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "macos": "react-native run-macos --no-packager --scheme Example",
     "set-react-version": "yarn workspace react-native-test-app set-react-version",
     "start": "react-native start",
-    "visionos": "react-native run-visionos",
+    "visionos": "react-native run-visionos --no-packager",
     "windows": "react-native run-windows --no-packager"
   },
   "dependencies": {

--- a/example/visionos/Podfile.lock
+++ b/example/visionos/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.73.7)
-  - FBReactNativeSpec (0.73.7):
+  - FBLazyVector (0.73.8)
+  - FBReactNativeSpec (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.7)
-    - RCTTypeSafety (= 0.73.7)
-    - React-Core (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - ReactCommon/turbomodule/core (= 0.73.7)
+    - RCTRequired (= 0.73.8)
+    - RCTTypeSafety (= 0.73.8)
+    - React-Core (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - ReactCommon/turbomodule/core (= 0.73.8)
   - fmt (9.1.0)
   - glog (0.3.5)
   - libevent (2.1.12.1)
@@ -31,28 +31,28 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTRequired (0.73.7)
-  - RCTTypeSafety (0.73.7):
-    - FBLazyVector (= 0.73.7)
-    - RCTRequired (= 0.73.7)
-    - React-Core (= 0.73.7)
-  - React (0.73.7):
-    - React-Core (= 0.73.7)
-    - React-Core/DevSupport (= 0.73.7)
-    - React-Core/RCTWebSocket (= 0.73.7)
-    - React-RCTActionSheet (= 0.73.7)
-    - React-RCTAnimation (= 0.73.7)
-    - React-RCTBlob (= 0.73.7)
-    - React-RCTImage (= 0.73.7)
-    - React-RCTLinking (= 0.73.7)
-    - React-RCTNetwork (= 0.73.7)
-    - React-RCTSettings (= 0.73.7)
-    - React-RCTText (= 0.73.7)
-    - React-RCTVibration (= 0.73.7)
-    - React-RCTWindowManager (= 0.73.7)
-    - React-RCTXR (= 0.73.7)
-  - React-callinvoker (0.73.7)
-  - React-Codegen (0.73.7):
+  - RCTRequired (0.73.8)
+  - RCTTypeSafety (0.73.8):
+    - FBLazyVector (= 0.73.8)
+    - RCTRequired (= 0.73.8)
+    - React-Core (= 0.73.8)
+  - React (0.73.8):
+    - React-Core (= 0.73.8)
+    - React-Core/DevSupport (= 0.73.8)
+    - React-Core/RCTWebSocket (= 0.73.8)
+    - React-RCTActionSheet (= 0.73.8)
+    - React-RCTAnimation (= 0.73.8)
+    - React-RCTBlob (= 0.73.8)
+    - React-RCTImage (= 0.73.8)
+    - React-RCTLinking (= 0.73.8)
+    - React-RCTNetwork (= 0.73.8)
+    - React-RCTSettings (= 0.73.8)
+    - React-RCTText (= 0.73.8)
+    - React-RCTVibration (= 0.73.8)
+    - React-RCTWindowManager (= 0.73.8)
+    - React-RCTXR (= 0.73.8)
+  - React-callinvoker (0.73.8)
+  - React-Codegen (0.73.8):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -67,10 +67,10 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.7):
+  - React-Core (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.7)
+    - React-Core/Default (= 0.73.8)
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -80,47 +80,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.7):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0.1)
-    - Yoga
-  - React-Core/Default (0.73.7):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0.1)
-    - Yoga
-  - React-Core/DevSupport (0.73.7):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.7)
-    - React-Core/RCTWebSocket (= 0.73.7)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.73.7)
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.7):
+  - React-Core/CoreModulesHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -133,7 +93,34 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.7):
+  - React-Core/Default (0.73.8):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0.1)
+    - Yoga
+  - React-Core/DevSupport (0.73.8):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.8)
+    - React-Core/RCTWebSocket (= 0.73.8)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.73.8)
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -146,7 +133,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.7):
+  - React-Core/RCTAnimationHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -159,7 +146,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.7):
+  - React-Core/RCTBlobHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -172,7 +159,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.7):
+  - React-Core/RCTImageHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -185,7 +172,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.7):
+  - React-Core/RCTLinkingHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -198,7 +185,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.7):
+  - React-Core/RCTNetworkHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -211,7 +198,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.7):
+  - React-Core/RCTSettingsHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -224,7 +211,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.7):
+  - React-Core/RCTTextHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -237,20 +224,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.7):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.7)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0.1)
-    - Yoga
-  - React-Core/RCTWindowManagerHeaders (0.73.7):
+  - React-Core/RCTVibrationHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -263,7 +237,20 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-Core/RCTXRHeaders (0.73.7):
+  - React-Core/RCTWebSocket (0.73.8):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.8)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0.1)
+    - Yoga
+  - React-Core/RCTWindowManagerHeaders (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -276,32 +263,45 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0.1)
     - Yoga
-  - React-CoreModules (0.73.7):
+  - React-Core/RCTXRHeaders (0.73.8):
+    - glog
     - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.7)
+    - React-Core/Default
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0.1)
+    - Yoga
+  - React-CoreModules (0.73.8):
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTTypeSafety (= 0.73.8)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.7)
-    - React-jsi (= 0.73.7)
+    - React-Core/CoreModulesHeaders (= 0.73.8)
+    - React-jsi (= 0.73.8)
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.7)
+    - React-RCTImage (= 0.73.8)
     - ReactCommon
     - SocketRocket (= 0.7.0.1)
-  - React-cxxreact (0.73.7):
+  - React-cxxreact (0.73.8):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.7)
-    - React-debug (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - React-jsinspector (= 0.73.7)
-    - React-logger (= 0.73.7)
-    - React-perflogger (= 0.73.7)
-    - React-runtimeexecutor (= 0.73.7)
-  - React-debug (0.73.7)
-  - React-Fabric (0.73.7):
+    - React-callinvoker (= 0.73.8)
+    - React-debug (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - React-jsinspector (= 0.73.8)
+    - React-logger (= 0.73.8)
+    - React-perflogger (= 0.73.8)
+    - React-runtimeexecutor (= 0.73.8)
+  - React-debug (0.73.8)
+  - React-Fabric (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -311,20 +311,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.7)
-    - React-Fabric/attributedstring (= 0.73.7)
-    - React-Fabric/componentregistry (= 0.73.7)
-    - React-Fabric/componentregistrynative (= 0.73.7)
-    - React-Fabric/components (= 0.73.7)
-    - React-Fabric/core (= 0.73.7)
-    - React-Fabric/imagemanager (= 0.73.7)
-    - React-Fabric/leakchecker (= 0.73.7)
-    - React-Fabric/mounting (= 0.73.7)
-    - React-Fabric/scheduler (= 0.73.7)
-    - React-Fabric/telemetry (= 0.73.7)
-    - React-Fabric/templateprocessor (= 0.73.7)
-    - React-Fabric/textlayoutmanager (= 0.73.7)
-    - React-Fabric/uimanager (= 0.73.7)
+    - React-Fabric/animations (= 0.73.8)
+    - React-Fabric/attributedstring (= 0.73.8)
+    - React-Fabric/componentregistry (= 0.73.8)
+    - React-Fabric/componentregistrynative (= 0.73.8)
+    - React-Fabric/components (= 0.73.8)
+    - React-Fabric/core (= 0.73.8)
+    - React-Fabric/imagemanager (= 0.73.8)
+    - React-Fabric/leakchecker (= 0.73.8)
+    - React-Fabric/mounting (= 0.73.8)
+    - React-Fabric/scheduler (= 0.73.8)
+    - React-Fabric/telemetry (= 0.73.8)
+    - React-Fabric/templateprocessor (= 0.73.8)
+    - React-Fabric/textlayoutmanager (= 0.73.8)
+    - React-Fabric/uimanager (= 0.73.8)
     - React-graphics
     - React-jsc
     - React-jsi
@@ -334,26 +334,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.7):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.7):
+  - React-Fabric/animations (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -372,7 +353,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.7):
+  - React-Fabric/attributedstring (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -391,7 +372,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.7):
+  - React-Fabric/componentregistry (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -410,37 +391,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.7):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.7)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.7)
-    - React-Fabric/components/modal (= 0.73.7)
-    - React-Fabric/components/rncore (= 0.73.7)
-    - React-Fabric/components/root (= 0.73.7)
-    - React-Fabric/components/safeareaview (= 0.73.7)
-    - React-Fabric/components/scrollview (= 0.73.7)
-    - React-Fabric/components/text (= 0.73.7)
-    - React-Fabric/components/textinput (= 0.73.7)
-    - React-Fabric/components/unimplementedview (= 0.73.7)
-    - React-Fabric/components/view (= 0.73.7)
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.7):
+  - React-Fabric/componentregistrynative (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -459,7 +410,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.7):
+  - React-Fabric/components (0.73.8):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.73.8)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.8)
+    - React-Fabric/components/modal (= 0.73.8)
+    - React-Fabric/components/rncore (= 0.73.8)
+    - React-Fabric/components/root (= 0.73.8)
+    - React-Fabric/components/safeareaview (= 0.73.8)
+    - React-Fabric/components/scrollview (= 0.73.8)
+    - React-Fabric/components/text (= 0.73.8)
+    - React-Fabric/components/textinput (= 0.73.8)
+    - React-Fabric/components/unimplementedview (= 0.73.8)
+    - React-Fabric/components/view (= 0.73.8)
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -478,7 +459,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.7):
+  - React-Fabric/components/legacyviewmanagerinterop (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -497,7 +478,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.7):
+  - React-Fabric/components/modal (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -516,7 +497,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.7):
+  - React-Fabric/components/rncore (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -535,7 +516,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.7):
+  - React-Fabric/components/root (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -554,7 +535,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.7):
+  - React-Fabric/components/safeareaview (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -573,7 +554,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.7):
+  - React-Fabric/components/scrollview (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -592,7 +573,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.7):
+  - React-Fabric/components/text (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -611,7 +592,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.7):
+  - React-Fabric/components/textinput (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -630,7 +611,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.7):
+  - React-Fabric/components/unimplementedview (0.73.8):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -650,7 +650,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.7):
+  - React-Fabric/core (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -669,7 +669,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.7):
+  - React-Fabric/imagemanager (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -688,7 +688,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.7):
+  - React-Fabric/leakchecker (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -707,7 +707,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.7):
+  - React-Fabric/mounting (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -726,7 +726,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.7):
+  - React-Fabric/scheduler (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -745,7 +745,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.7):
+  - React-Fabric/telemetry (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -764,7 +764,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.7):
+  - React-Fabric/templateprocessor (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -783,7 +783,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.7):
+  - React-Fabric/textlayoutmanager (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -803,7 +803,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.7):
+  - React-Fabric/uimanager (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -822,30 +822,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.7):
+  - React-FabricImage (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.7)
-    - RCTTypeSafety (= 0.73.7)
+    - RCTRequired (= 0.73.8)
+    - RCTTypeSafety (= 0.73.8)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.73.7)
+    - React-jsiexecutor (= 0.73.8)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.7):
+  - React-graphics (0.73.8):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.7)
+    - React-Core/Default (= 0.73.8)
     - React-utils
-  - React-ImageManager (0.73.7):
+  - React-ImageManager (0.73.8):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -854,38 +854,38 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.73.7):
-    - React-jsc/Fabric (= 0.73.7)
-    - React-jsi (= 0.73.7)
-  - React-jsc/Fabric (0.73.7):
-    - React-jsi (= 0.73.7)
-  - React-jserrorhandler (0.73.7):
+  - React-jsc (0.73.8):
+    - React-jsc/Fabric (= 0.73.8)
+    - React-jsi (= 0.73.8)
+  - React-jsc/Fabric (0.73.8):
+    - React-jsi (= 0.73.8)
+  - React-jserrorhandler (0.73.8):
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.7):
+  - React-jsi (0.73.8):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.7):
+  - React-jsiexecutor (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - React-perflogger (= 0.73.7)
-  - React-jsinspector (0.73.7)
-  - React-logger (0.73.7):
+    - React-cxxreact (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - React-perflogger (= 0.73.8)
+  - React-jsinspector (0.73.8)
+  - React-logger (0.73.8):
     - glog
-  - React-Mapbuffer (0.73.7):
+  - React-Mapbuffer (0.73.8):
     - glog
     - React-debug
-  - React-nativeconfig (0.73.7)
-  - React-NativeModulesApple (0.73.7):
+  - React-nativeconfig (0.73.8)
+  - React-NativeModulesApple (0.73.8):
     - glog
     - React-callinvoker
     - React-Core
@@ -895,10 +895,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.7)
-  - React-RCTActionSheet (0.73.7):
-    - React-Core/RCTActionSheetHeaders (= 0.73.7)
-  - React-RCTAnimation (0.73.7):
+  - React-perflogger (0.73.8)
+  - React-RCTActionSheet (0.73.8):
+    - React-Core/RCTActionSheetHeaders (= 0.73.8)
+  - React-RCTAnimation (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -906,7 +906,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.7):
+  - React-RCTAppDelegate (0.73.8):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -920,7 +920,7 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon
-  - React-RCTBlob (0.73.7):
+  - React-RCTBlob (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTBlobHeaders
@@ -929,7 +929,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.7):
+  - React-RCTFabric (0.73.8):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-Core
@@ -947,7 +947,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.7):
+  - React-RCTImage (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -956,14 +956,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.7):
+  - React-RCTLinking (0.73.8):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.7)
-    - React-jsi (= 0.73.7)
+    - React-Core/RCTLinkingHeaders (= 0.73.8)
+    - React-jsi (= 0.73.8)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.7)
-  - React-RCTNetwork (0.73.7):
+    - ReactCommon/turbomodule/core (= 0.73.8)
+  - React-RCTNetwork (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -971,7 +971,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.7):
+  - React-RCTSettings (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -979,21 +979,21 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSwiftExtensions (0.73.7):
+  - React-RCTSwiftExtensions (0.73.8):
     - React-Core
     - React-RCTWindowManager
     - React-RCTXR
-  - React-RCTText (0.73.7):
-    - React-Core/RCTTextHeaders (= 0.73.7)
+  - React-RCTText (0.73.8):
+    - React-Core/RCTTextHeaders (= 0.73.8)
     - Yoga
-  - React-RCTVibration (0.73.7):
+  - React-RCTVibration (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTWindowManager (0.73.7):
+  - React-RCTWindowManager (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1001,7 +1001,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTXR (0.73.7):
+  - React-RCTXR (0.73.8):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1009,15 +1009,15 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.7):
+  - React-rendererdebug (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - React-rncore (0.73.7)
-  - React-runtimeexecutor (0.73.7):
-    - React-jsi (= 0.73.7)
-  - React-runtimescheduler (0.73.7):
+  - React-rncore (0.73.8)
+  - React-runtimeexecutor (0.73.8):
+    - React-jsi (= 0.73.8)
+  - React-runtimescheduler (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-callinvoker
@@ -1028,45 +1028,45 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.7):
+  - React-utils (0.73.8):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - ReactCommon (0.73.7):
-    - React-logger (= 0.73.7)
-    - ReactCommon/turbomodule (= 0.73.7)
-  - ReactCommon/turbomodule (0.73.7):
+  - ReactCommon (0.73.8):
+    - React-logger (= 0.73.8)
+    - ReactCommon/turbomodule (= 0.73.8)
+  - ReactCommon/turbomodule (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.7)
-    - React-cxxreact (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - React-logger (= 0.73.7)
-    - React-perflogger (= 0.73.7)
-    - ReactCommon/turbomodule/bridging (= 0.73.7)
-    - ReactCommon/turbomodule/core (= 0.73.7)
-  - ReactCommon/turbomodule/bridging (0.73.7):
+    - React-callinvoker (= 0.73.8)
+    - React-cxxreact (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - React-logger (= 0.73.8)
+    - React-perflogger (= 0.73.8)
+    - ReactCommon/turbomodule/bridging (= 0.73.8)
+    - ReactCommon/turbomodule/core (= 0.73.8)
+  - ReactCommon/turbomodule/bridging (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.7)
-    - React-cxxreact (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - React-logger (= 0.73.7)
-    - React-perflogger (= 0.73.7)
-  - ReactCommon/turbomodule/core (0.73.7):
+    - React-callinvoker (= 0.73.8)
+    - React-cxxreact (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - React-logger (= 0.73.8)
+    - React-perflogger (= 0.73.8)
+  - ReactCommon/turbomodule/core (0.73.8):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.7)
-    - React-cxxreact (= 0.73.7)
-    - React-jsi (= 0.73.7)
-    - React-logger (= 0.73.7)
-    - React-perflogger (= 0.73.7)
+    - React-callinvoker (= 0.73.8)
+    - React-cxxreact (= 0.73.8)
+    - React-jsi (= 0.73.8)
+    - React-logger (= 0.73.8)
+    - React-perflogger (= 0.73.8)
   - ReactNativeHost (0.4.5):
     - React-Core
     - React-cxxreact
@@ -1266,62 +1266,62 @@ SPEC CHECKSUMS:
   boost: 8f1e9b214fa11f71081fc8ecd5fad3daf221cf7f
   DoubleConversion: 71bf0761505a44e4dfddc0aa04afa049fdfb63b5
   Example-Tests: 9e95b10878936c581cbe09d784cd5eaa6ca70db8
-  FBLazyVector: d6824d441ac1d34d0edf2107d0332994ab3c69e3
-  FBReactNativeSpec: a4ee3e96e6c7b3eed51bff05c8012e71adbb1f0c
+  FBLazyVector: 3528954d497f5578142ba1bfe9af95b637fd361e
+  FBReactNativeSpec: b55ded6f2be7810b164f6749679831b0feca02f8
   fmt: 5d9ffa7ccba126c08b730252123601d514652320
   glog: 4f05d17aa39a829fee878689fc9a41af587fabba
   libevent: a29e03f67aa3a1c501656baccbff6071a8b40a00
   RCT-Folly: 08b69b8ee3f4c5baf3a18a468b4d5a56276435fa
-  RCTRequired: ce960b518d49702e4432e0abbaf9d692ea4f725f
-  RCTTypeSafety: 342d2dd416cabcb68a4e55dc81fa1e5d2ca0a7b2
-  React: 1a1497ec6134f15715b079b36e798d8369b9a5dd
-  React-callinvoker: 046715cf20233bebd6a2153f179e565a5706aeac
-  React-Codegen: 2d7b3e668c02ee5ccfba33a65ac149b308936b88
-  React-Core: 6e36a6d209ab9e183cb251a0a842c1c58d9e22b0
-  React-CoreModules: 3b39fb2bc0674d30d089f3bb534963a4eac730b3
-  React-cxxreact: 151a9846b941bfd9d30adaa934f34dd2f63e964b
-  React-debug: af55f2c5ba334f971082b382ac2395177b467f09
-  React-Fabric: 8cb774acb56cb17ff4fce737987f0281fbc6189f
-  React-FabricImage: 94ae7878a20c419a4112117935bb66da885f83b8
-  React-graphics: eff7acb654b029e6721425bb010bbaca17bdda9f
-  React-ImageManager: b825f7a04b4d3c43cd67f918fdd98a1ce94bc71f
-  React-jsc: 8d55ed1775b2d899357fa62ef726f67b58b546a1
-  React-jserrorhandler: c07e9c3253f2a060e71370735503d97d603aa5c8
-  React-jsi: e26a9967350c2da3f6f6c5dbd6e1de2deccd3764
-  React-jsiexecutor: e7bc8112b8af18ff7a313fab05c5f867f1d2b036
-  React-jsinspector: 0380fa1d9c857113005ae483d440938225815b4b
-  React-logger: 69a59b002217b73d5e5e809c1e8626bca7e9a4fd
-  React-Mapbuffer: daf728388c020723b466f76e725c33e6e67330e1
-  React-nativeconfig: 1ca5aeb84b74f5ce3ea4f3fa6961cff1d92da0b0
-  React-NativeModulesApple: 3173a3bf8e683d6c0a7a3a60090bfc3997151366
-  React-perflogger: 8a9efd41cc9a18462c2f847bdc6986c486ae51fb
-  React-RCTActionSheet: bd4f10055c382084cad6e2b91c968b835dab6cbc
-  React-RCTAnimation: e5cc969eb923e2a281f829ffb0efc20c8a3329a3
-  React-RCTAppDelegate: e8ca0786d9db06ff2b5a41c405d8c4f0c15b7c76
-  React-RCTBlob: 347cbed932ae243a8c33dca3d987a910ee1a8b77
-  React-RCTFabric: 897968adb5d6298622c1cf4ee420f184cde4e88c
-  React-RCTImage: 8eff03edc5307f2afbab7934b9a45b44d9b3034b
-  React-RCTLinking: 82b356facc22b57b92aa66e4d072f22f84d57a16
-  React-RCTNetwork: d0d05c269d4847a97d3000fa88229bf9997cf92b
-  React-RCTSettings: 7d12071add1d4d54112108c52dafb990c54d6f20
-  React-RCTSwiftExtensions: 176506cd5b70a7bddeb093da2f26be3e94beb266
-  React-RCTText: fb940ca0d3bf25a1a0c933370db274f5b4d64c5d
-  React-RCTVibration: 9a334391fca27d1f0b5015b35862ebbd8c0cde1c
-  React-RCTWindowManager: 97d40d9f1932a1f6d756403c8c429dc44e0bfbf4
-  React-RCTXR: 371693927d83894454f6d737189844376bb75aea
-  React-rendererdebug: 564aa45023a2070e079963dd29ab63e89525998b
-  React-rncore: 1e928d95ee04e1107b4cf3939a9b928c15e9ba6f
-  React-runtimeexecutor: 0368ff1c0d844ac6478e7e7fc7ce127b9b832653
-  React-runtimescheduler: 770d4d6a77c7445d826264ec53b9d3d9883be421
-  React-utils: 8067608526c1a61546761c1b7677672f216e1607
-  ReactCommon: 0dbf32c98cf01a83e5b4d2c0dd91712a7d666903
+  RCTRequired: e4250e83fd2ccab2ffeb29b484fc30f92a48a887
+  RCTTypeSafety: ffda0c1faf5314c9b7e38b405d4a0ccc0fc303e9
+  React: 84bf2f618aa90c48b2c46e9234bc549e16b2f8cb
+  React-callinvoker: bff9b37849f1832be39351cf4ca52344773351c8
+  React-Codegen: b08ed86689858a14b0c4733c36524d33863decf0
+  React-Core: 8af88dd46a222dca814d7ba956c64a9e61180cc3
+  React-CoreModules: f2194c7f12ee7a721a70837a2af9ecdf27a46b32
+  React-cxxreact: 9f18cadbe55db2fb18b87e6d88ba39d325accbac
+  React-debug: 0a49ff96439f0eb953664def6c97af17415e8163
+  React-Fabric: 57d5c8fb09478da507e3de286d564095bb763403
+  React-FabricImage: ccc1a9552a332f78d3523d02042d1859b80b555e
+  React-graphics: b5a4325458648598949ffe36754ded391aa39e0b
+  React-ImageManager: 4a54171dfccbe608705450b25accbd516bbc9f60
+  React-jsc: 74e4cb7d3728b9862cbe7ada36dc65bdef41277f
+  React-jserrorhandler: adc47a4b2835024f1f16b7ba6b158d1989bb87d1
+  React-jsi: 783251345a6ab6d1740c7d342499edd942f78092
+  React-jsiexecutor: a76d89a04a3a9afd78726d07399af89537e870e2
+  React-jsinspector: b9e3b72a79e0ac805605d3b05844bc7fca2481a7
+  React-logger: b38a95eea49914f02cd8764d48b3def4469b9eae
+  React-Mapbuffer: 95f55d07bb729137f77065c06a331271234f1b55
+  React-nativeconfig: efa01c928b57f2c7adb282ad49dbf35a85f39772
+  React-NativeModulesApple: 5ffa203c4591bb74750a992d45a780a886f6377d
+  React-perflogger: 8cbba16952af4beffd0c45a9e3aca9079de5f53a
+  React-RCTActionSheet: 89b184b611cab9cb0abecc1bcac4ffb896ef55e3
+  React-RCTAnimation: ba344275d1d57926931fe39e506f1de1bd649c23
+  React-RCTAppDelegate: 2c7203f5d619cec31d5503ce32622b32daace636
+  React-RCTBlob: fdd0bd0959184ea030c882909d3aafe33bd46b6d
+  React-RCTFabric: e57b0029e4d1abc8c7a29428c597c91c12f93a0d
+  React-RCTImage: acce25f5e92939874e6269a78592abcaae08e8cd
+  React-RCTLinking: 541904b4e2deafd483134dc9961c5d7e21488d34
+  React-RCTNetwork: cfafe68a8b7936bef0cb0ed72834c09ac3734605
+  React-RCTSettings: 4eac2611cf955c317d11ae62e2f5263f8cfc0788
+  React-RCTSwiftExtensions: a72c9b16f74c5daeb46d2628ea9593d31afef6a3
+  React-RCTText: be241222492c51fd3e1db827c7ed95347067a33e
+  React-RCTVibration: 7a4ef9f99ca0fcd2893af79e630747ca15475645
+  React-RCTWindowManager: 39a943fa44289a5c7c8d71755c9456ffbaa2f37f
+  React-RCTXR: 0528475e88dc7bb12b0ba412d1e9cc5505a2575e
+  React-rendererdebug: 6b70a5235f8bd699e5620714da8a3738fa605c28
+  React-rncore: 5c7868049ac1162756ac63306a343d44bbd6d296
+  React-runtimeexecutor: 9532f8857bad78b48f241b38d264ef6884857878
+  React-runtimescheduler: 3e08056206bf8627ba2ce2d31d154cfebf773aa4
+  React-utils: 98ae5ad20a6f002f275737d79af4a9ab637f5a1f
+  ReactCommon: efed44fdc02eddcef579b2de0c1e109604645210
   ReactNativeHost: ef266683ed8fa40fe48438b3f2ef0b5e3bb72201
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 2ad57492ef72ab9b2c6f6e89ea198cc1999ca20b
   RNWWebStorage: b41688dc4431720c07c7e6c7226520b50e5eccfc
   SocketRocket: 0ba3e799f983d2dfa878777017659ef6c866e5c6
-  Yoga: b8e0a1a7ae3db4e2a966a0cfb009761cdad62914
+  Yoga: 500e2c9fc111319f47dcffec452de1218b968cb4
 
 PODFILE CHECKSUM: eb94ab00d809e5704d3dc4cc5f9709bd8151afb9
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,8 +1846,8 @@ __metadata:
   linkType: hard
 
 "@callstack/react-native-visionos@npm:^0.73.0":
-  version: 0.73.7
-  resolution: "@callstack/react-native-visionos@npm:0.73.7"
+  version: 0.73.8
+  resolution: "@callstack/react-native-visionos@npm:0.73.8"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
     "@react-native-community/cli": "npm:13.5.1"
@@ -1892,7 +1892,7 @@ __metadata:
     react: 18.2.0
   bin:
     react-native-visionos: cli.js
-  checksum: 10c0/da6a1db08a49109ee89da154731f5cd8ff5196381ff8986e7115904291aecc12cca1910a8e5a44ff80c7d42019e2321438df371f6479d9347ce352c3dc5bf983
+  checksum: 10c0/28dfaa2c3648a9c182f10d4bc7ad7b9921a5d03a4aae6dac77341c2ebab57e9d77162d27a79c84ecc3be78cf5af6ff65266e77574d4a3d05d7c257e58ba4b5b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

When testing this PR yesterday https://github.com/microsoft/react-native-test-app/pull/1933 I noticed that the run-visionos command wasn't taking the params. So I went ahead and merged that without the extra param; now Oskar has already taken care of fixing it:

* https://github.com/callstack/react-native-visionos/releases/tag/v0.73.8-visionos
* https://github.com/callstack/react-native-visionos/releases/tag/v0.74.0-rc.1-visionos

so we can re add it.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
Classic test:
* `yarn install`
* `cd example`
* `pod install --project-directory=visionos`
* `yarn visionos` -> the command won't error out and won't start Metro either
* the app runs just fine but you need to start metro on the side
