### PR TITLE
fix(windows): fix NuGet downloading 0.64 instead of canary builds

### DIFF
--- a/windows/UWP/ReactTestApp.vcxproj
+++ b/windows/UWP/ReactTestApp.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)ExperimentalFeatures.props')" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -181,10 +181,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectRootDir)\app.json" />
-    <None Include="packages.config" Condition="$(ReactNativeWindowsVersionNumber)>=68000" />
+    <None Include="packages.config" Condition="$(ReactNativeWindowsVersionNumber)==0 OR $(ReactNativeWindowsVersionNumber)>=68000" />
     <None Include="PropertySheet.props" />
   </ItemGroup>
-  <ItemGroup Condition="$(ReactNativeWindowsVersionNumber)>=68000">
+  <ItemGroup Condition="$(ReactNativeWindowsVersionNumber)==0 OR $(ReactNativeWindowsVersionNumber)>=68000">
     <PackageReference Include="nlohmann.json" Version="3.11.2" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
@@ -203,12 +203,12 @@
     <ReactNativeWindowsVersion Condition="'$(ReactNativeWindowsVersion)'==''">$(ReactNativeWindowsNpmVersion)</ReactNativeWindowsVersion>
   </PropertyGroup>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
-    <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)'=='true'" />
-    <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
-    <Import Project="$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets" Condition="$(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\Microsoft.ReactNative.Cxx.$(ReactNativeWindowsVersion)\build\native\Microsoft.ReactNative.Cxx.targets')" />
+    <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)'=='true'" />
+    <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+    <Import Project="$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets" Condition="$(ReactNativeWindowsVersionNumber)&gt;0 AND $(ReactNativeWindowsVersionNumber)&lt;68000 AND Exists('$(SolutionDir)packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" />
     <!-- ReactTestApp additional targets -->
   </ImportGroup>
 </Project>

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -306,17 +306,20 @@ export function generateSolution(destPath, options, fs = nodefs) {
       : fs.existsSync(nugetConfigPath0_64)
         ? nugetConfigPath0_64
         : null;
-    const nugetConfigDestPath = path.join(destPath, "NuGet.Config");
-    if (nugetConfigPath && !fs.existsSync(nugetConfigDestPath)) {
-      copyTasks.push(
-        writeTextFile(
-          nugetConfigDestPath,
-          mustache.render(readTextFile(nugetConfigPath, fs), {
-            nuGetADOFeed: info.version.startsWith("0.0.0-"),
-          }),
-          fs.promises
-        )
-      );
+    if (nugetConfigPath) {
+      const nugetConfigDest = path.join(destPath, "NuGet.Config");
+      const nugetConfigCopy = path.join(projectFilesDestPath, "NuGet.Config");
+      if (fs.existsSync(nugetConfigDest)) {
+        copyTasks.push(fs.promises.cp(nugetConfigDest, nugetConfigCopy));
+      } else {
+        const template = readTextFile(nugetConfigPath, fs);
+        const nuGetADOFeed = info.version.startsWith("0.0.0-");
+        const nugetConfig = mustache.render(template, { nuGetADOFeed });
+        copyTasks.push(
+          writeTextFile(nugetConfigDest, nugetConfig, fs.promises),
+          writeTextFile(nugetConfigCopy, nugetConfig, fs.promises)
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Description

We need a copy of `NuGet.Config` under the generated Windows project for VS to be able to download canary builds.

Requires https://github.com/microsoft/rnx-kit/pull/3039

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version canary-windows
yarn
# Apply changes from https://github.com/microsoft/rnx-kit/pull/3039
cd example
yarn install-windows-test-app --use-nuget
yarn ci:windows
```