### PR TITLE
fix(apple): fix building with `use_frameworks!`

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1018,7 +1018,9 @@ PODS:
     - React-jsi (= 0.73.6)
     - React-logger (= 0.73.6)
     - React-perflogger (= 0.73.6)
-  - ReactNativeHost (0.4.5):
+  - ReactNativeHost (0.4.6):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -1249,7 +1251,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 9daefa990db62f8874bc9d6e7e504272c6b6c57f
   React-utils: d16c1d2251c088ad817996621947d0ac8167b46c
   ReactCommon: 447281ad2034ea3252bf81a60d1f77d5afb0b636
-  ReactNativeHost: ef266683ed8fa40fe48438b3f2ef0b5e3bb72201
+  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 857244f3a23f2b3157b364fa06cf3e8866deff9c
   RNWWebStorage: bbb916037df754d10075c18dccbcde6019a7e050

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1018,7 +1018,9 @@ PODS:
     - React-jsi (= 0.73.21)
     - React-logger (= 0.73.21)
     - React-perflogger (= 0.73.21)
-  - ReactNativeHost (0.4.5):
+  - ReactNativeHost (0.4.6):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -1250,7 +1252,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 67d62dd13ebf8f54c92324c2d82ce506b9a686cc
   React-utils: 0ed450147a4a523413bd0b7ad47a745c75ca4981
   ReactCommon: 2d2a2b76dcab2951d057057a7d6cd44eb02be15e
-  ReactNativeHost: ef266683ed8fa40fe48438b3f2ef0b5e3bb72201
+  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 9d83e280b173ba2ee053b8135730dff60f9ab674
   RNWWebStorage: bbb916037df754d10075c18dccbcde6019a7e050

--- a/example/visionos/Podfile.lock
+++ b/example/visionos/Podfile.lock
@@ -1067,7 +1067,9 @@ PODS:
     - React-jsi (= 0.73.8)
     - React-logger (= 0.73.8)
     - React-perflogger (= 0.73.8)
-  - ReactNativeHost (0.4.5):
+  - ReactNativeHost (0.4.6):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-cxxreact
     - ReactCommon/turbomodule/core
@@ -1315,7 +1317,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 3e08056206bf8627ba2ce2d31d154cfebf773aa4
   React-utils: 98ae5ad20a6f002f275737d79af4a9ab637f5a1f
   ReactCommon: efed44fdc02eddcef579b2de0c1e109604645210
-  ReactNativeHost: ef266683ed8fa40fe48438b3f2ef0b5e3bb72201
+  ReactNativeHost: 7d8d2bcfaa7c82797a4d652f8c591829728bfad1
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 2ad57492ef72ab9b2c6f6e89ea198cc1999ca20b
   RNWWebStorage: b41688dc4431720c07c7e6c7226520b50e5eccfc
@@ -1324,4 +1326,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: eb94ab00d809e5704d3dc4cc5f9709bd8151afb9
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('./test/test_*.rb').each { |file| require(file) }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.4.5",
+    "@rnx-kit/react-native-host": "^0.4.6",
     "ajv": "^8.0.0",
     "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3373,12 +3373,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.4.5":
-  version: 0.4.5
-  resolution: "@rnx-kit/react-native-host@npm:0.4.5"
+"@rnx-kit/react-native-host@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@rnx-kit/react-native-host@npm:0.4.6"
   peerDependencies:
     react-native: ">=0.66"
-  checksum: 10c0/4ac1871cd56a66fcf9364339e277609ccca08fad36c7659d23092c9a51b322cb71f6d7acd1af5241a46494d3e0a80b8c1ad613399f59156658e76bbabc9f7220
+  checksum: 10c0/0b69a4ae90df23ce5c39176a35c556c7595686df805c1cd93ef1aecacd47713a085d36c833f0f9856803ea56d6456bad97c9f36dbd0ef081826abf4abfcc657d
   languageName: node
   linkType: hard
 
@@ -12147,7 +12147,7 @@ __metadata:
     "@microsoft/eslint-plugin-sdl": "npm:^0.2.0"
     "@react-native-community/cli": "npm:^12.3.0"
     "@rnx-kit/eslint-plugin": "npm:^0.7.0"
-    "@rnx-kit/react-native-host": "npm:^0.4.5"
+    "@rnx-kit/react-native-host": "npm:^0.4.6"
     "@rnx-kit/tsconfig": "npm:^1.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Bump `@rnx-kit/react-native-host` to get build fixes for `use_frameworks!`

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a