### PR TITLE
chore: don't perform eol conversion on script files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 *                  text=auto
+*.bat              text eol=crlf
 *.pbxproj          -text
+*.sh               text eol=lf
 /.yarn/releases/*  binary


### PR DESCRIPTION
### Description

Don't perform eol conversion on script files

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a