### PR TITLE
chore(android): bump Android Core and Moshi

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,11 +8,6 @@
       "allowedVersions": "^12.0.0"
     },
     {
-      "groupName": "Android",
-      "matchDatasources": ["maven"],
-      "matchPackagePrefixes": ["com.android."]
-    },
-    {
       "groupName": "Android CameraX",
       "matchDatasources": ["maven"],
       "matchPackagePrefixes": ["androidx.camera"]

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -97,13 +97,13 @@ ext {
         androidAppCompat            : "androidx.appcompat:appcompat:1.6.1",
         androidCamera               : kotlinVersionNumber >= v(1, 8, 0)
                                           ? "androidx.camera:camera-camera2:1.3.0-beta02"
-                                          : "androidx.camera:camera-camera2:1.2.0-beta02",
+                                          : ["androidx.camera", "camera-camera2", "1.2.0-beta02"].join(":"),
         androidCameraMlKitVision    : kotlinVersionNumber >= v(1, 8, 0)
                                           ? "androidx.camera:camera-mlkit-vision:1.3.0-beta02"
-                                          : "androidx.camera:camera-mlkit-vision:1.2.0-beta02",
+                                          : ["androidx.camera", "camera-mlkit-vision", "1.2.0-beta02"].join(":"),
         androidCoreKotlinExtensions : kotlinVersionNumber >= v(1, 8, 0)
-                                          ? "androidx.core:core-ktx:1.10.1"
-                                          : "androidx.core:core-ktx:1.9.0",
+                                          ? "androidx.core:core-ktx:1.12.0"
+                                          : ["androidx.core", "core-ktx", "1.9.0"].join(":"),
         androidEspressoCore         : "androidx.test.espresso:espresso-core:3.5.1",
         androidJUnit                : "androidx.test.ext:junit:1.1.5",
         androidJUnitKotlinExtensions: "androidx.test.ext:junit-ktx:1.1.5",
@@ -114,11 +114,11 @@ ext {
         mlKitBarcodeScanning        : "com.google.mlkit:barcode-scanning:17.2.0",
         mockitoInline               : "org.mockito:mockito-inline:5.2.0",
         moshiKotlin                 : kotlinVersionNumber >= v(1, 8, 0)
-                                          ? "com.squareup.moshi:moshi-kotlin:1.15.0"
-                                          : "com.squareup.moshi:moshi-kotlin:1.14.0",
+                                          ? "com.squareup.moshi:moshi-kotlin:1.15.1"
+                                          : ["com.squareup.moshi", "moshi-kotlin", "1.14.0"].join(":"),
         moshiKotlinCodegen          : kotlinVersionNumber >= v(1, 8, 0)
-                                          ? "com.squareup.moshi:moshi-kotlin-codegen:1.15.0"
-                                          : "com.squareup.moshi:moshi-kotlin-codegen:1.14.0",
+                                          ? "com.squareup.moshi:moshi-kotlin-codegen:1.15.1"
+                                          : ["com.squareup.moshi", "moshi-kotlin-codegen", "1.14.0"].join(":"),
     ]
 
     getReactNativeDependencies = {


### PR DESCRIPTION
### Description

Bump Android Core and Moshi

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a