### PR TITLE
chore(windows): fix `set-react-version` not parsing Fabric canary builds

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -147,6 +147,7 @@ function inferReactNativeVersion({ name, version, dependencies }) {
     11: "^0.72.0-0",
     12: "^0.73.0-0",
     13: "^0.74.0-0",
+    14: "^0.75.0-0",
   }[m[1]];
   if (!v) {
     throw new Error(`Unsupported '${cliPackage}' version: ${cliVersion}`);
@@ -175,6 +176,7 @@ export function fetchPackageInfo(pkg) {
         const result = JSON.parse(json);
         if (result.error) {
           if (result.error.code === "E404") {
+            console.warn(`Could not resolve '${pkg}'`);
             resolve({
               version: undefined,
               dependencies: {},
@@ -209,7 +211,13 @@ export function fetchPackageInfo(pkg) {
  */
 function fetchReactNativeWindowsCanaryInfoViaNuGet() {
   return new Promise((resolve) => {
-    const pattern = /Microsoft\.ReactNative\.Cxx ([-.\d]*canary[-.\d]*)/;
+    // Example output:
+    //
+    //     Microsoft.ReactNative.Cxx 0.0.0-canary.798-Fabric
+    //     Microsoft.ReactNative.Cxx 0.0.0-canary.797-Fabric
+    //     Microsoft.ReactNative.Cxx 0.0.0-canary.798
+    //     Microsoft.ReactNative.Cxx 0.0.0-canary.797
+    const pattern = /Microsoft\.ReactNative\.Cxx ([-.\d]*canary[.\d]*)/;
 
     let isResolved = false;
     const list = spawn(process.env["NUGET_EXE"] || "nuget.exe", [

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -253,9 +253,11 @@ function fetchReactNativeWindowsCanaryInfoViaNuGet() {
                     typeof version === "string" &&
                     version.startsWith("0.0.0")
                   ) {
-                    const v = version.replace("-Fabric", "");
-                    resolve("react-native-windows@" + v);
-                    return;
+                    const m = version.match(/(0\.0\.0-[.a-z0-9]+)/);
+                    if (m) {
+                      resolve("react-native-windows@" + m[1]);
+                      return;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
### Description

Fix `set-react-version` not parsing Fabric canary builds correctly

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

This can be run on any platform:

```sh
$ NUGET=1 npm run set-react-version canary-windows

> react-native-test-app@0.0.1-dev set-react-version
> node scripts/set-react-version.mjs canary-windows

{
  '@react-native-community/cli': '13.6.0',
  '@react-native-community/cli-platform-android': '13.6.0',
  '@react-native-community/cli-platform-ios': '13.6.0',
  '@react-native/babel-preset': '0.75.0-nightly-20240221-a1171f79f',
  '@react-native/metro-config': '0.75.0-nightly-20240221-a1171f79f',
  'metro-react-native-babel-preset': undefined,
  react: '18.2.0',
  'react-native': '0.75.0-nightly-20240221-a1171f79f',
  'react-native-macos': undefined,
  'react-native-windows': '0.0.0-canary.798'
}
```