### PR TITLE
refactor(set-react-version): use npm's public registry api

### DIFF
--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -127,8 +127,14 @@ export function fetchPackageInfo(pkg, version) {
         }
       }
     })
-    .then((version) => fetch(registryURL + pkg + "/" + version))
-    .then((res) => res.json())
+    .then((foundVersion) => {
+      if (!foundVersion) {
+        console.warn(`Could not resolve '${pkg}@${version}'`);
+        return undefined;
+      }
+      return fetch(registryURL + pkg + "/" + foundVersion);
+    })
+    .then((res) => res?.json() ?? /** @type {Manifest} */ ({}))
     .then(({ version, dependencies = {}, peerDependencies = {} }) => {
       return { version, dependencies, peerDependencies };
     });

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -129,7 +129,7 @@ export function fetchPackageInfo(pkg, version) {
     })
     .then((foundVersion) => {
       if (!foundVersion) {
-        console.warn(`Could not resolve '${pkg}@${version}'`);
+        console.warn(`No match found for '${pkg}@${version}'`);
         return undefined;
       }
       return fetch(registryURL + pkg + "/" + foundVersion);


### PR DESCRIPTION
### Description

Use npm's public registry api so we don't have to rely on the npm cli.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version 0.71
# `metro-react-native-babel-preset` should be set, not `@react-native/babel-preset`

npm run set-react-version 0.72
# `metro-react-native-babel-preset` should be set, not `@react-native/babel-preset`

npm run set-react-version 0.73
# `@react-native/babel-preset` should be set, not `metro-react-native-babel-preset`
# `@callstack/react-native-vision` should be set

npm run set-react-version 0.74
# Same as 0.73

npm run set-react-version nightly
# neither `react-native-macos` nor `react-native-windows` should be set

npm run set-react-version canary-macos
# `react-native-windows` should not be set

npm run set-react-version canary-windows
# `react-native-macos` should not be set
```