### PR TITLE
fix(init): use npm public registry api instead of cli

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -11,6 +11,7 @@ import { cliPlatformIOSVersion } from "./configure-projects.js";
 import {
   getPackageVersion,
   isMain,
+  memo,
   readJSONFile,
   readTextFile,
   toVersionNumber,
@@ -50,16 +51,10 @@ function mergeObjects(lhs, rhs) {
     : sortByKeys(rhs);
 }
 
-const readManifest = (() => {
-  /** @type {Manifest} */
-  let manifest;
-  return () => {
-    if (!manifest) {
-      manifest = readJSONFile(new URL("../package.json", import.meta.url));
-    }
-    return manifest;
-  };
-})();
+/** @type {() => Manifest} */
+const readManifest = memo(() =>
+  readJSONFile(new URL("../package.json", import.meta.url))
+);
 
 /**
  * Prints an error message to the console.

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -9,7 +9,7 @@ import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import { fileURLToPath } from "node:url";
-import { readTextFile } from "./helpers.js";
+import { memo, readTextFile } from "./helpers.js";
 import { setReactVersion } from "./set-react-version.mjs";
 import { $, test } from "./test-e2e.mjs";
 
@@ -23,36 +23,30 @@ const TAG = "┃";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 
-const getIOSSimulatorName = (() => {
-  let deviceName = "";
-  return () => {
-    if (!deviceName) {
-      const wdioConfig = new URL(
-        "../example/test/specs/wdio.config.js",
-        import.meta.url
-      );
-      const { status, stdout } = spawnSync(
-        process.argv[0],
-        [
-          "--print",
-          `require("${wdioConfig.pathname}").config.capabilities["appium:deviceName"]`,
-        ],
-        {
-          stdio: ["ignore", "pipe", "inherit"],
-          env: { TEST_ARGS: "ios" },
-          encoding: "utf-8",
-        }
-      );
-      if (status !== 0) {
-        throw new Error(
-          "An error occurred while trying to evaluate 'wdio.config.js'"
-        );
-      }
-      deviceName = stdout.trim();
+const getIOSSimulatorName = memo(() => {
+  const wdioConfig = new URL(
+    "../example/test/specs/wdio.config.js",
+    import.meta.url
+  );
+  const { status, stdout } = spawnSync(
+    process.argv[0],
+    [
+      "--print",
+      `require("${wdioConfig.pathname}").config.capabilities["appium:deviceName"]`,
+    ],
+    {
+      stdio: ["ignore", "pipe", "inherit"],
+      env: { TEST_ARGS: "ios" },
+      encoding: "utf-8",
     }
-    return deviceName;
-  };
-})();
+  );
+  if (status !== 0) {
+    throw new Error(
+      "An error occurred while trying to evaluate 'wdio.config.js'"
+    );
+  }
+  return stdout.trim();
+});
 
 function log(message = "", tag = TAG) {
   console.log(tag, message);

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -1,7 +1,29 @@
 // @ts-check
 import { deepEqual, equal } from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as os from "node:os";
 import { describe, it } from "node:test";
-import { npm } from "../scripts/helpers.js";
+
+/**
+ * Invokes `npm` on the command line.
+ * @param {...string} args
+ */
+function npm(...args) {
+  switch (os.platform()) {
+    case "win32": {
+      return spawnSync(
+        "cmd.exe",
+        ["/d", "/s", "/c", `"npm ${args.join(" ")}"`],
+        {
+          encoding: "utf-8",
+          windowsVerbatimArguments: true,
+        }
+      );
+    }
+    default:
+      return spawnSync("npm", args, { encoding: "utf-8" });
+  }
+}
 
 describe("npm pack", () => {
   // Ensure we include all files regardless of future changes in `npm-packlist`.


### PR DESCRIPTION
### Description

Use npm public registry api instead of spawning separate `npm` processes.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
% yarn init-test-app --destination pr1961 --name TestApp -p android -p ios -p macos -p windows
Using 0.73.6 because the current project uses it (use --version to specify another version)

% yarn init-test-app --destination pr1961 --name TestApp -p android -p ios -p macos -p windows --version 0.74
Downloading react-native-0.74.0-rc.7.tgz...
[!] react-native-macos@0.74 cannot be added because it does not exist or is unsupported
[!] react-native-windows@0.74 cannot be added because it does not exist or is unsupported

% yarn init-test-app --destination pr1961 --name TestApp -p android -p ios -p macos -p windows --version 0.74.0-rc.6
Downloading react-native-0.74.0-rc.6.tgz...
[!] react-native-macos@0.74 cannot be added because it does not exist or is unsupported
[!] react-native-windows@0.74 cannot be added because it does not exist or is unsupported

% cd ..
% ./react-native-test-app/scripts/init.mjs --destination pr1961 --name TestApp -p android -p ios -p macos -p windows
No version was specified; fetching available versions...
Using 0.73 because it supports all specified platforms (use --version to specify another version)
Downloading react-native-0.73.6.tgz...
%
```