### PR TITLE
fix(android): update list of KSP versions

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -5,7 +5,8 @@ static String getKspVersion(String kotlinVersion) {
     def availableVersions = [
         // Run `scripts/update-ksp-versions.mjs` to update this list
         // update-ksp-versions start
-        "1.9.22-1.0.17",
+        "1.9.23-1.0.20",
+        "1.9.22-1.0.18",
         "1.9.21-1.0.16",
         "1.9.20-1.0.14",
         "1.9.10-1.0.13",


### PR DESCRIPTION
### Description

Update list of KSP versions. Adds support for Kotlin versions 1.9.22 and 1.9.23.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a