### PR TITLE
fix(windows): don't spawn separate process for `autolink-windows`

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -76,15 +76,15 @@ function isMain(url, script = process.argv[1]) {
 
 /**
  * @template T
- * @param {() => T} fn
- * @returns {() => T}
+ * @param {(...args: any[]) => T} fn
+ * @returns {(...args: any[]) => T}
  */
 function memo(fn) {
   /** @type {T} */
   let result;
-  return () => {
+  return (...args) => {
     if (result === undefined) {
-      result = fn();
+      result = fn(...args);
     }
     return result;
   };

--- a/windows/project.mjs
+++ b/windows/project.mjs
@@ -7,6 +7,7 @@ import * as colors from "yoctocolors";
 import {
   findNearest,
   getPackageVersion,
+  memo,
   readJSONFile,
   readTextFile,
   requireTransitive,
@@ -89,6 +90,19 @@ function generateCertificateItems(
   }
   return items.join("\n    ");
 }
+
+/**
+ * Equivalent to invoking `react-native config`.
+ * @param {string} rnWindowsPath
+ */
+export const loadReactNativeConfig = memo((rnWindowsPath) => {
+  /** @type {import("@react-native-community/cli")} */
+  const { loadConfig } = requireTransitive(
+    ["@react-native-community/cli"],
+    rnWindowsPath
+  );
+  return loadConfig();
+});
 
 /**
  * @param {string} message
@@ -196,12 +210,9 @@ function getNuGetDependencies(rnWindowsPath, fs = nodefs) {
     return [];
   }
 
-  /** @type {import("@react-native-community/cli")} */
-  const { loadConfig } = requireTransitive(
-    ["@react-native-community/cli"],
-    rnWindowsPath
+  const dependencies = Object.values(
+    loadReactNativeConfig(rnWindowsPath).dependencies
   );
-  const dependencies = Object.values(loadConfig().dependencies);
 
   const xml = new XMLParser({
     ignoreAttributes: false,


### PR DESCRIPTION
### Description

Don't spawn separate process for `autolink-windows`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
cd example
yarn install-windows-test-app --use-nuget
yarn windows
```

### Screenshots

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/b9657386-1a02-445e-9c40-69175b9adce6)
