### PR TITLE
fix(android): fix type mismatch `DeveloperSettings?` vs `DeveloperSettings`

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -190,10 +190,11 @@ class TestAppReactNativeHost(
         val latch = CountDownLatch(1)
         var packagerIsRunning = false
 
-        val devSettings = reactInstanceManager.devSupportManager.devSettings
-        createDevServerHelper(context, devSettings).isPackagerRunning {
-            packagerIsRunning = it
-            latch.countDown()
+        reactInstanceManager.devSupportManager.devSettings?.let { devSettings ->
+            createDevServerHelper(context, devSettings).isPackagerRunning {
+                packagerIsRunning = it
+                latch.countDown()
+            }
         }
 
         latch.await()


### PR DESCRIPTION
### Description

Fix type mismatch `DeveloperSettings?` vs `DeveloperSettings`

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version nightly
yarn
cd example/android
./gradlew assembleDebug
```