### PR TITLE
fix(windows): declare support for 0.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react": "17.0.1 - 18.2",
     "react-native": "0.66 - 0.74 || >=0.75.0-0 <0.75.0",
     "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.73",
-    "react-native-windows": "^0.0.0-0 || 0.66 - 0.73"
+    "react-native-windows": "^0.0.0-0 || 0.66 - 0.74"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/test/android-test-app/test-app-util.test.mjs
+++ b/test/android-test-app/test-app-util.test.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { equal, match } from "node:assert/strict";
+import * as os from "node:os";
 import { after, describe, it } from "node:test";
 import { toVersionNumber, v } from "../../scripts/helpers.js";
 import {
@@ -8,7 +9,9 @@ import {
   runGradleWithProject,
 } from "./gradle.mjs";
 
-describe("test-app-util.gradle", () => {
+// TODO: These tests are broken on GitHub Actions (Windows) as of 20240414.1.0
+// https://github.com/actions/runner-images/commit/16c64c111cb6372bf8949332d275b74c87d33075
+describe("test-app-util.gradle", { skip: os.platform() === "win32" }, () => {
   const buildGradle = [
     "buildscript {",
     '    def androidTestAppDir = "node_modules/react-native-test-app/android"',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12208,7 +12208,7 @@ __metadata:
     react: 17.0.1 - 18.2
     react-native: 0.66 - 0.74 || >=0.75.0-0 <0.75.0
     react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.73
-    react-native-windows: ^0.0.0-0 || 0.66 - 0.73
+    react-native-windows: ^0.0.0-0 || 0.66 - 0.74
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true


### PR DESCRIPTION
### Description

Declare support for `react-native-windows` 0.74

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version 0.74
yarn remove react-native-macos --all
cd example
yarn install-windows-test-app
yarn windows

# In a separate terminal
yarn start
```

### Screenshots

![image](https://github.com/microsoft/react-native-test-app/assets/4123478/987b2895-f613-4e0f-bc5f-6d5c77fcb432)
