### PR TITLE
test: re-enable `test-app-util.gradle` tests

### DIFF
--- a/test/android-test-app/gradle.mjs
+++ b/test/android-test-app/gradle.mjs
@@ -106,8 +106,11 @@ export function removeProject(name) {
  * @returns
  */
 function runGradle(cwd, ...args) {
-  const gradlew = os.platform() === "win32" ? "gradlew.bat" : "./gradlew";
-  return spawnSync(gradlew, args, { cwd, encoding: "utf-8" });
+  // As of Node 20.12.2, it is no longer allowed to spawn a process with `.bat`
+  // or `.cmd` without shell (see https://nodejs.org/en/blog/release/v20.12.2).
+  const isWindows = os.platform() === "win32";
+  const gradlew = isWindows ? "gradlew.bat" : "./gradlew";
+  return spawnSync(gradlew, args, { cwd, encoding: "utf-8", shell: isWindows });
 }
 
 /**

--- a/test/android-test-app/test-app-util.test.mjs
+++ b/test/android-test-app/test-app-util.test.mjs
@@ -1,6 +1,5 @@
 // @ts-check
 import { equal, match } from "node:assert/strict";
-import * as os from "node:os";
 import { after, describe, it } from "node:test";
 import { toVersionNumber, v } from "../../scripts/helpers.js";
 import {
@@ -9,9 +8,7 @@ import {
   runGradleWithProject,
 } from "./gradle.mjs";
 
-// TODO: These tests are broken on GitHub Actions (Windows) as of 20240414.1.0
-// https://github.com/actions/runner-images/commit/16c64c111cb6372bf8949332d275b74c87d33075
-describe("test-app-util.gradle", { skip: os.platform() === "win32" }, () => {
+describe("test-app-util.gradle", () => {
   const buildGradle = [
     "buildscript {",
     '    def androidTestAppDir = "node_modules/react-native-test-app/android"',


### PR DESCRIPTION
### Description

Re-enable `test-app-util.gradle` tests

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a