### PR TITLE
test: simplify `npm pack` test

### DIFF
--- a/.yarn/plugins/link-project.cjs
+++ b/.yarn/plugins/link-project.cjs
@@ -26,7 +26,6 @@ module.exports = {
         }
 
         const fs = require("node:fs");
-        const os = require("node:os");
         const path = require("node:path");
 
         /**
@@ -66,7 +65,7 @@ module.exports = {
                 } else {
                   fs.mkdirSync(nodeModulesDir, mkdirOptions);
                 }
-                if (os.platform() === "win32") {
+                if (process.platform === "win32") {
                   fs.symlink(projectRoot, linkPath, "junction", noop);
                 } else {
                   const target = path.relative(nodeModulesDir, projectRoot);

--- a/example/test/config.test.mjs
+++ b/example/test/config.test.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 import { deepEqual, equal, match, notEqual } from "node:assert/strict";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -135,7 +134,7 @@ test("react-native config", async (t) => {
 
   await t.test(
     "contains iOS config (@react-native-community/cli <8.0.0)",
-    { skip: os.platform() === "win32" || cliMajorVersion >= 8 },
+    { skip: process.platform === "win32" || cliMajorVersion >= 8 },
     () => {
       const sourceDir = path.join(exampleRoot, "ios");
       const config = loadConfig();
@@ -164,7 +163,7 @@ test("react-native config", async (t) => {
 
   await t.test(
     "contains iOS config (@react-native-community/cli >=8.0.0)",
-    { skip: os.platform() === "win32" || cliMajorVersion < 8 },
+    { skip: process.platform === "win32" || cliMajorVersion < 8 },
     () => {
       const sourceDir = path.join(exampleRoot, "ios");
       const config = loadConfig();
@@ -189,7 +188,7 @@ test("react-native config", async (t) => {
 
   await t.test(
     "contains Windows config",
-    { skip: os.platform() !== "win32" },
+    { skip: process.platform !== "win32" },
     () => {
       const projectFile = path.join(
         "node_modules",

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -7,7 +7,6 @@
  */
 import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import { fileURLToPath } from "node:url";
 import { memo, readTextFile } from "./helpers.js";
 import { setReactVersion } from "./set-react-version.mjs";
@@ -242,7 +241,7 @@ const { [2]: version } = process.argv;
         buildAndRun("android");
         await test("android", ["hermes", newArch]);
 
-        if (os.platform() === "darwin") {
+        if (process.platform === "darwin") {
           showBanner(`Build iOS [jsc, ${newArch}]`);
 
           configure("ios", config);

--- a/test/android-test-app/gradle.mjs
+++ b/test/android-test-app/gradle.mjs
@@ -3,7 +3,6 @@
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { gatherConfig, writeAllFiles } from "../../scripts/configure.mjs";
@@ -108,7 +107,7 @@ export function removeProject(name) {
 function runGradle(cwd, ...args) {
   // As of Node 20.12.2, it is no longer allowed to spawn a process with `.bat`
   // or `.cmd` without shell (see https://nodejs.org/en/blog/release/v20.12.2).
-  const isWindows = os.platform() === "win32";
+  const isWindows = process.platform === "win32";
   const gradlew = isWindows ? "gradlew.bat" : "./gradlew";
   return spawnSync(gradlew, args, { cwd, encoding: "utf-8", shell: isWindows });
 }

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 import { deepEqual, equal } from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import * as os from "node:os";
 import { describe, it } from "node:test";
 
 /**
@@ -9,20 +8,11 @@ import { describe, it } from "node:test";
  * @param {...string} args
  */
 function npm(...args) {
-  switch (os.platform()) {
-    case "win32": {
-      return spawnSync(
-        "cmd.exe",
-        ["/d", "/s", "/c", `"npm ${args.join(" ")}"`],
-        {
-          encoding: "utf-8",
-          windowsVerbatimArguments: true,
-        }
-      );
-    }
-    default:
-      return spawnSync("npm", args, { encoding: "utf-8" });
-  }
+  return spawnSync("npm", args, {
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+    windowsVerbatimArguments: true,
+  });
 }
 
 describe("npm pack", () => {


### PR DESCRIPTION
### Description

Simplify `npm pack` test. `shell: true` is equivalent to calling `cmd.exe`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a