### PR TITLE
chore: migrate `schema.js` to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "scripts/embed-manifest",
     "scripts/init.mjs",
     "scripts/parseargs.mjs",
+    "scripts/schema.mjs",
     "scripts/template.mjs",
     "test-app.gradle",
     "test_app.rb",

--- a/scripts/affected.mjs
+++ b/scripts/affected.mjs
@@ -1,6 +1,4 @@
-#!/usr/bin/env node
 // @ts-check
-
 import yaml from "js-yaml";
 import { Minimatch } from "minimatch";
 import { spawnSync } from "node:child_process";

--- a/scripts/copy-yarnrc.mjs
+++ b/scripts/copy-yarnrc.mjs
@@ -1,6 +1,4 @@
-#!/usr/bin/env node
 // @ts-check
-
 import yaml from "js-yaml";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/scripts/embed-manifest/validate.mjs
+++ b/scripts/embed-manifest/validate.mjs
@@ -2,7 +2,7 @@
 import Ajv from "ajv";
 import * as nodefs from "node:fs";
 import { readJSONFile } from "../helpers.js";
-import { generateSchema } from "../schema.js";
+import { generateSchema } from "../schema.mjs";
 
 const APP_JSON = "app.json";
 

--- a/scripts/generate-manifest-docs.mjs
+++ b/scripts/generate-manifest-docs.mjs
@@ -1,9 +1,7 @@
-#!/usr/bin/env node
 // @ts-check
-
 import * as path from "node:path";
 import { readDocumentation } from "./generate-schema.mjs";
-import { generateSchema } from "./schema.js";
+import { generateSchema } from "./schema.mjs";
 
 async function generateManifestDocs() {
   const docs = await readDocumentation();

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -1,10 +1,8 @@
-#!/usr/bin/env node
 // @ts-check
-
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { generateSchema } from "./schema.js";
+import { generateSchema } from "./schema.mjs";
 
 /**
  * @typedef {import("ajv").SchemaObject} SchemaObject

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -1,6 +1,8 @@
-/**
- * @typedef {import("./types").Docs} Docs
- */
+// @ts-check
+import { URL, fileURLToPath } from "node:url";
+import { readJSONFile } from "./helpers.js";
+
+/** @typedef {import("./types").Docs} Docs */
 
 /**
  * @param {string} content
@@ -11,12 +13,17 @@ function extractBrief(content = "") {
   return endBrief > 0 ? content.substring(0, endBrief) : content;
 }
 
+function readManifest() {
+  const manifest = fileURLToPath(new URL("../package.json", import.meta.url));
+  return /** @type {import("../package.json")} */ (readJSONFile(manifest));
+}
+
 /**
  * @param {Partial<Docs>=} docs App manifest documentation
  * @returns {import("ajv").SchemaObject}
  */
-function generateSchema(docs = {}) {
-  const { defaultPlatformPackages } = require("../package.json");
+export function generateSchema(docs = {}) {
+  const { defaultPlatformPackages } = readManifest();
   return {
     $defs: {
       appIconSet: {
@@ -330,5 +337,3 @@ function generateSchema(docs = {}) {
     },
   };
 }
-
-exports.generateSchema = generateSchema;

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // @ts-check
 
 /**

--- a/scripts/template.mjs
+++ b/scripts/template.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Joins all specified lines into a single string.
  * @param {...string} lines

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // @ts-check
 
 /**

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // @ts-check
 
 /**

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -194,7 +194,7 @@ describe("npm pack", () => {
       "scripts/helpers.js",
       "scripts/init.mjs",
       "scripts/parseargs.mjs",
-      "scripts/schema.js",
+      "scripts/schema.mjs",
       "scripts/template.mjs",
       "test-app.gradle",
       "test_app.rb",


### PR DESCRIPTION
### Description

Migrate `schema.js` to ESM

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a