### PR TITLE
chore(android): remove unused `androidx.swiperefreshlayout:swiperefreshlayout`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -299,7 +299,6 @@ dependencies {
     }
     implementation libraries.androidCoreKotlinExtensions
     implementation libraries.androidRecyclerView
-    implementation libraries.androidSwipeRefreshLayout
     implementation libraries.materialComponents
 
     testImplementation libraries.junit

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -42,7 +42,7 @@ ext {
         // be using AGP 7.2.2 (see `androidPluginVersion` above).
         // Note that even though newer 23.x versions exist, we'll stick to AGP's
         // default. See also
-        // https://developer.android.com/studio/releases/gradle-plugin#compatibility-7-3-0
+        // https://developer.android.com/build/releases/past-releases/agp-7-3-0-release-notes
         ndkVersion = "23.1.7779620"
     }
 

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -67,7 +67,6 @@ ext {
         androidJUnit                : "androidx.test.ext:junit:1.1.5",
         androidJUnitKotlinExtensions: "androidx.test.ext:junit-ktx:1.1.5",
         androidRecyclerView         : "androidx.recyclerview:recyclerview:1.3.2",
-        androidSwipeRefreshLayout   : "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
         junit                       : "junit:junit:4.13.2",
         materialComponents          : "com.google.android.material:material:1.11.0",
         mlKitBarcodeScanning        : "com.google.mlkit:barcode-scanning:17.2.0",


### PR DESCRIPTION
### Description

`androidx.swiperefreshlayout:swiperefreshlayout` has been there since the first version, but never used 😛 

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a