### PR TITLE
fix(android): don't require camera permission in single app mode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -117,6 +117,10 @@ android {
         buildConfigField "boolean", "ReactTestApp_useFabric", enableNewArchitecture.toString()
         buildConfigField "boolean", "ReactTestApp_useBridgeless", enableBridgeless.toString()
 
+        manifestPlaceholders = [
+            rntaEnableCamera: project.ext.react.enableCamera ? "1000000" : "1"
+        ]
+
         resValue "string", "app_name", project.ext.react.appName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,10 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.microsoft.reacttestapp"
 >
-    <uses-feature android:name="android.hardware.camera.any" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CAMERA" android:maxSdkVersion="${rntaEnableCamera}" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application


### PR DESCRIPTION
### Description

Don't require camera permission in single app mode.

This (ab)uses the `android:maxSdkVersion` property on `uses-permission` to disable the camera permission: https://developer.android.com/guide/topics/manifest/uses-permission-element

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

| Multi-app mode | Single-app mode |
| :-: | :-: |
| ![camera-permission](https://github.com/microsoft/react-native-test-app/assets/4123478/e7d806e5-9f62-46b0-94fd-45be541caf1c) | ![no-permissions](https://github.com/microsoft/react-native-test-app/assets/4123478/e3c09605-a25e-481a-9b35-740d17ea24bd) |