### PR TITLE
fix(macos): add `applicationCategoryType` and `humanReadableCopyright`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/PerceivedComplexity:
   AllowedMethods:
+    - generate_info_plist!
     - make_project!
     - react_native_pods
     - use_test_app_internal!

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -153,6 +153,16 @@ def generate_info_plist!(project_root, target_platform, destination)
     info['UIAppFonts'] = fonts unless target_platform == :macos
   end
 
+  if target_platform == :macos
+    config = manifest[target_platform.to_s]
+    unless config.nil?
+      category = config['applicationCategoryType']
+      info['LSApplicationCategoryType'] = category unless category.nil?
+      copyright = config['humanReadableCopyright']
+      info['NSHumanReadableCopyright'] = copyright unless copyright.nil?
+    end
+  end
+
   plist.value = CFPropertyList.guess(info)
   plist.save(infoplist_dst, CFPropertyList::List::FORMAT_XML, { :formatted => true })
 end

--- a/schema.json
+++ b/schema.json
@@ -296,6 +296,16 @@
       ],
       "type": "object",
       "properties": {
+        "applicationCategoryType": {
+          "description": "The category that best describes the app for the App Store.",
+          "markdownDescription": "The category that best describes the app for the App Store.\n\nThe equivalent key in `Info.plist` is\n[`LSApplicationCategoryType`](https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype).",
+          "type": "string"
+        },
+        "humanReadableCopyright": {
+          "description": "A human-readable copyright notice for the bundle.",
+          "markdownDescription": "A human-readable copyright notice for the bundle.\n\nThe equivalent key in `Info.plist` is\n[`NSHumanReadableCopyright`](https://developer.apple.com/documentation/bundleresources/information_property_list/nshumanreadablecopyright).",
+          "type": "string"
+        },
         "reactNativePath": {
           "description": "Sets a custom path to React Native for macOS. Useful for when `require(\"react-native-macos\")` does not return the desired path.",
           "type": "string"

--- a/scripts/docs/macos.applicationCategoryType.md
+++ b/scripts/docs/macos.applicationCategoryType.md
@@ -1,0 +1,4 @@
+The category that best describes the app for the App Store.
+
+The equivalent key in `Info.plist` is
+[`LSApplicationCategoryType`](https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype).

--- a/scripts/docs/macos.humanReadableCopyright.md
+++ b/scripts/docs/macos.humanReadableCopyright.md
@@ -1,0 +1,4 @@
+A human-readable copyright notice for the bundle.
+
+The equivalent key in `Info.plist` is
+[`NSHumanReadableCopyright`](https://developer.apple.com/documentation/bundleresources/information_property_list/nshumanreadablecopyright).

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -32,6 +32,8 @@ export async function readDocumentation() {
     "ios.icons",
     "ios.icons.primaryIcon",
     "ios.icons.alternateIcons",
+    "macos.applicationCategoryType",
+    "macos.humanReadableCopyright",
     "windows.appxManifest",
     "windows.certificateKeyFile",
     "windows.certificatePassword",

--- a/scripts/schema.js
+++ b/scripts/schema.js
@@ -274,6 +274,16 @@ function generateSchema(docs = {}) {
         allOf: [{ $ref: "#/$defs/apple" }],
         type: "object",
         properties: {
+          applicationCategoryType: {
+            description: extractBrief(docs["macos.applicationCategoryType"]),
+            markdownDescription: docs["macos.applicationCategoryType"],
+            type: "string",
+          },
+          humanReadableCopyright: {
+            description: extractBrief(docs["macos.humanReadableCopyright"]),
+            markdownDescription: docs["macos.humanReadableCopyright"],
+            type: "string",
+          },
           reactNativePath: {
             description: `Sets a custom path to React Native for macOS. Useful for when \`require("${defaultPlatformPackages.macos}")\` does not return the desired path.`,
             type: "string",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -208,6 +208,8 @@ export type Docs = {
   "ios.icons": string;
   "ios.icons.primaryIcon": string;
   "ios.icons.alternateIcons": string;
+  "macos.applicationCategoryType": string;
+  "macos.humanReadableCopyright": string;
   "windows.appxManifest": string;
   "windows.certificateKeyFile": string;
   "windows.certificatePassword": string;


### PR DESCRIPTION
### Description

Add `applicationCategoryType` and `humanReadableCopyright` to the app manifest.

Resolves #1026.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

1. Set `applicationCategoryType` and `humanReadableCopyright`:
    ```diff
    diff --git a/example/app.json b/example/app.json
    index 3b8992e..177a32b 100644
    --- a/example/app.json
    +++ b/example/app.json
    @@ -13,6 +13,10 @@
           "presentationStyle": "modal"
         }
       ],
    +  "macos": {
    +    "applicationCategoryType": "public.app-category.business",
    +    "humanReadableCopyright": "Private"
    +  },
       "resources": {
         "android": [
           "dist/res",
    ```
2. Run `pod install --project-directory=macos`
3. Verify that the values are set in `node_modules/.generated/macos/Info.plist`