### PR TITLE
feat(apple): add app privacy manifest support

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Example-Tests (0.0.1-dev):
     - React
     - ReactTestApp-DevSupport
-  - FBLazyVector (0.73.6)
-  - FBReactNativeSpec (0.73.6):
+  - FBLazyVector (0.73.7)
+  - FBReactNativeSpec (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.6)
-    - RCTTypeSafety (= 0.73.6)
-    - React-Core (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - ReactCommon/turbomodule/core (= 0.73.6)
+    - RCTRequired (= 0.73.7)
+    - RCTTypeSafety (= 0.73.7)
+    - React-Core (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - ReactCommon/turbomodule/core (= 0.73.7)
   - fmt (6.2.1)
   - glog (0.3.5)
   - RCT-Folly (2022.05.16.00):
@@ -30,26 +30,26 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.73.6)
-  - RCTTypeSafety (0.73.6):
-    - FBLazyVector (= 0.73.6)
-    - RCTRequired (= 0.73.6)
-    - React-Core (= 0.73.6)
-  - React (0.73.6):
-    - React-Core (= 0.73.6)
-    - React-Core/DevSupport (= 0.73.6)
-    - React-Core/RCTWebSocket (= 0.73.6)
-    - React-RCTActionSheet (= 0.73.6)
-    - React-RCTAnimation (= 0.73.6)
-    - React-RCTBlob (= 0.73.6)
-    - React-RCTImage (= 0.73.6)
-    - React-RCTLinking (= 0.73.6)
-    - React-RCTNetwork (= 0.73.6)
-    - React-RCTSettings (= 0.73.6)
-    - React-RCTText (= 0.73.6)
-    - React-RCTVibration (= 0.73.6)
-  - React-callinvoker (0.73.6)
-  - React-Codegen (0.73.6):
+  - RCTRequired (0.73.7)
+  - RCTTypeSafety (0.73.7):
+    - FBLazyVector (= 0.73.7)
+    - RCTRequired (= 0.73.7)
+    - React-Core (= 0.73.7)
+  - React (0.73.7):
+    - React-Core (= 0.73.7)
+    - React-Core/DevSupport (= 0.73.7)
+    - React-Core/RCTWebSocket (= 0.73.7)
+    - React-RCTActionSheet (= 0.73.7)
+    - React-RCTAnimation (= 0.73.7)
+    - React-RCTBlob (= 0.73.7)
+    - React-RCTImage (= 0.73.7)
+    - React-RCTLinking (= 0.73.7)
+    - React-RCTNetwork (= 0.73.7)
+    - React-RCTSettings (= 0.73.7)
+    - React-RCTText (= 0.73.7)
+    - React-RCTVibration (= 0.73.7)
+  - React-callinvoker (0.73.7)
+  - React-Codegen (0.73.7):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -64,10 +64,10 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.6):
+  - React-Core (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default (= 0.73.7)
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -77,47 +77,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.6):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/Default (0.73.6):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/DevSupport (0.73.6):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
-    - React-Core/RCTWebSocket (= 0.73.6)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.73.6)
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.6):
+  - React-Core/CoreModulesHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -130,7 +90,34 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.6):
+  - React-Core/Default (0.73.7):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/DevSupport (0.73.7):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.7)
+    - React-Core/RCTWebSocket (= 0.73.7)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.73.7)
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -143,7 +130,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.6):
+  - React-Core/RCTAnimationHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -156,7 +143,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.6):
+  - React-Core/RCTBlobHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -169,7 +156,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.6):
+  - React-Core/RCTImageHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -182,7 +169,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.6):
+  - React-Core/RCTLinkingHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -195,7 +182,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.6):
+  - React-Core/RCTNetworkHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -208,7 +195,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.6):
+  - React-Core/RCTSettingsHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -221,7 +208,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.6):
+  - React-Core/RCTTextHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -234,10 +221,10 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.6):
+  - React-Core/RCTVibrationHeaders (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -247,32 +234,45 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-CoreModules (0.73.6):
+  - React-Core/RCTWebSocket (0.73.7):
+    - glog
     - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.6)
+    - React-Core/Default (= 0.73.7)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-CoreModules (0.73.7):
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTTypeSafety (= 0.73.7)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.6)
-    - React-jsi (= 0.73.6)
+    - React-Core/CoreModulesHeaders (= 0.73.7)
+    - React-jsi (= 0.73.7)
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.6)
+    - React-RCTImage (= 0.73.7)
     - ReactCommon
     - SocketRocket (= 0.6.1)
-  - React-cxxreact (0.73.6):
+  - React-cxxreact (0.73.7):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-debug (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-jsinspector (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-    - React-runtimeexecutor (= 0.73.6)
-  - React-debug (0.73.6)
-  - React-Fabric (0.73.6):
+    - React-callinvoker (= 0.73.7)
+    - React-debug (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - React-jsinspector (= 0.73.7)
+    - React-logger (= 0.73.7)
+    - React-perflogger (= 0.73.7)
+    - React-runtimeexecutor (= 0.73.7)
+  - React-debug (0.73.7)
+  - React-Fabric (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -282,20 +282,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.6)
-    - React-Fabric/attributedstring (= 0.73.6)
-    - React-Fabric/componentregistry (= 0.73.6)
-    - React-Fabric/componentregistrynative (= 0.73.6)
-    - React-Fabric/components (= 0.73.6)
-    - React-Fabric/core (= 0.73.6)
-    - React-Fabric/imagemanager (= 0.73.6)
-    - React-Fabric/leakchecker (= 0.73.6)
-    - React-Fabric/mounting (= 0.73.6)
-    - React-Fabric/scheduler (= 0.73.6)
-    - React-Fabric/telemetry (= 0.73.6)
-    - React-Fabric/templateprocessor (= 0.73.6)
-    - React-Fabric/textlayoutmanager (= 0.73.6)
-    - React-Fabric/uimanager (= 0.73.6)
+    - React-Fabric/animations (= 0.73.7)
+    - React-Fabric/attributedstring (= 0.73.7)
+    - React-Fabric/componentregistry (= 0.73.7)
+    - React-Fabric/componentregistrynative (= 0.73.7)
+    - React-Fabric/components (= 0.73.7)
+    - React-Fabric/core (= 0.73.7)
+    - React-Fabric/imagemanager (= 0.73.7)
+    - React-Fabric/leakchecker (= 0.73.7)
+    - React-Fabric/mounting (= 0.73.7)
+    - React-Fabric/scheduler (= 0.73.7)
+    - React-Fabric/telemetry (= 0.73.7)
+    - React-Fabric/templateprocessor (= 0.73.7)
+    - React-Fabric/textlayoutmanager (= 0.73.7)
+    - React-Fabric/uimanager (= 0.73.7)
     - React-graphics
     - React-jsc
     - React-jsi
@@ -305,26 +305,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.6):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.6):
+  - React-Fabric/animations (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -343,7 +324,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.6):
+  - React-Fabric/attributedstring (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -362,7 +343,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.6):
+  - React-Fabric/componentregistry (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -381,37 +362,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.6):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.6)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.6)
-    - React-Fabric/components/modal (= 0.73.6)
-    - React-Fabric/components/rncore (= 0.73.6)
-    - React-Fabric/components/root (= 0.73.6)
-    - React-Fabric/components/safeareaview (= 0.73.6)
-    - React-Fabric/components/scrollview (= 0.73.6)
-    - React-Fabric/components/text (= 0.73.6)
-    - React-Fabric/components/textinput (= 0.73.6)
-    - React-Fabric/components/unimplementedview (= 0.73.6)
-    - React-Fabric/components/view (= 0.73.6)
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.6):
+  - React-Fabric/componentregistrynative (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -430,7 +381,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.6):
+  - React-Fabric/components (0.73.7):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.73.7)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.7)
+    - React-Fabric/components/modal (= 0.73.7)
+    - React-Fabric/components/rncore (= 0.73.7)
+    - React-Fabric/components/root (= 0.73.7)
+    - React-Fabric/components/safeareaview (= 0.73.7)
+    - React-Fabric/components/scrollview (= 0.73.7)
+    - React-Fabric/components/text (= 0.73.7)
+    - React-Fabric/components/textinput (= 0.73.7)
+    - React-Fabric/components/unimplementedview (= 0.73.7)
+    - React-Fabric/components/view (= 0.73.7)
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -449,7 +430,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.6):
+  - React-Fabric/components/legacyviewmanagerinterop (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -468,7 +449,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.6):
+  - React-Fabric/components/modal (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -487,7 +468,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.6):
+  - React-Fabric/components/rncore (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -506,7 +487,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.6):
+  - React-Fabric/components/root (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -525,7 +506,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.6):
+  - React-Fabric/components/safeareaview (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -544,7 +525,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.6):
+  - React-Fabric/components/scrollview (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -563,7 +544,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.6):
+  - React-Fabric/components/text (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -582,7 +563,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.6):
+  - React-Fabric/components/textinput (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -601,7 +582,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.6):
+  - React-Fabric/components/unimplementedview (0.73.7):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -621,7 +621,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.6):
+  - React-Fabric/core (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -640,7 +640,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.6):
+  - React-Fabric/imagemanager (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -659,7 +659,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.6):
+  - React-Fabric/leakchecker (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -678,7 +678,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.6):
+  - React-Fabric/mounting (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -697,7 +697,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.6):
+  - React-Fabric/scheduler (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -716,7 +716,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.6):
+  - React-Fabric/telemetry (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -735,7 +735,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.6):
+  - React-Fabric/templateprocessor (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -754,7 +754,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.6):
+  - React-Fabric/textlayoutmanager (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -774,7 +774,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.6):
+  - React-Fabric/uimanager (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -793,30 +793,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.6):
+  - React-FabricImage (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.6)
-    - RCTTypeSafety (= 0.73.6)
+    - RCTRequired (= 0.73.7)
+    - RCTTypeSafety (= 0.73.7)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.73.6)
+    - React-jsiexecutor (= 0.73.7)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.6):
+  - React-graphics (0.73.7):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default (= 0.73.7)
     - React-utils
-  - React-ImageManager (0.73.6):
+  - React-ImageManager (0.73.7):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -825,38 +825,38 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.73.6):
-    - React-jsc/Fabric (= 0.73.6)
-    - React-jsi (= 0.73.6)
-  - React-jsc/Fabric (0.73.6):
-    - React-jsi (= 0.73.6)
-  - React-jserrorhandler (0.73.6):
+  - React-jsc (0.73.7):
+    - React-jsc/Fabric (= 0.73.7)
+    - React-jsi (= 0.73.7)
+  - React-jsc/Fabric (0.73.7):
+    - React-jsi (= 0.73.7)
+  - React-jserrorhandler (0.73.7):
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.6):
+  - React-jsi (0.73.7):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.6):
+  - React-jsiexecutor (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - React-jsinspector (0.73.6)
-  - React-logger (0.73.6):
+    - React-cxxreact (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - React-perflogger (= 0.73.7)
+  - React-jsinspector (0.73.7)
+  - React-logger (0.73.7):
     - glog
-  - React-Mapbuffer (0.73.6):
+  - React-Mapbuffer (0.73.7):
     - glog
     - React-debug
-  - React-nativeconfig (0.73.6)
-  - React-NativeModulesApple (0.73.6):
+  - React-nativeconfig (0.73.7)
+  - React-NativeModulesApple (0.73.7):
     - glog
     - React-callinvoker
     - React-Core
@@ -866,10 +866,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.6)
-  - React-RCTActionSheet (0.73.6):
-    - React-Core/RCTActionSheetHeaders (= 0.73.6)
-  - React-RCTAnimation (0.73.6):
+  - React-perflogger (0.73.7)
+  - React-RCTActionSheet (0.73.7):
+    - React-Core/RCTActionSheetHeaders (= 0.73.7)
+  - React-RCTAnimation (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -877,7 +877,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.6):
+  - React-RCTAppDelegate (0.73.7):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -891,7 +891,7 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon
-  - React-RCTBlob (0.73.6):
+  - React-RCTBlob (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTBlobHeaders
@@ -900,7 +900,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.6):
+  - React-RCTFabric (0.73.7):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-Core
@@ -918,7 +918,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.6):
+  - React-RCTImage (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -927,14 +927,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.6):
+  - React-RCTLinking (0.73.7):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.6)
-    - React-jsi (= 0.73.6)
+    - React-Core/RCTLinkingHeaders (= 0.73.7)
+    - React-jsi (= 0.73.7)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.6)
-  - React-RCTNetwork (0.73.6):
+    - ReactCommon/turbomodule/core (= 0.73.7)
+  - React-RCTNetwork (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -942,7 +942,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.6):
+  - React-RCTSettings (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -950,25 +950,25 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.73.6):
-    - React-Core/RCTTextHeaders (= 0.73.6)
+  - React-RCTText (0.73.7):
+    - React-Core/RCTTextHeaders (= 0.73.7)
     - Yoga
-  - React-RCTVibration (0.73.6):
+  - React-RCTVibration (0.73.7):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.6):
+  - React-rendererdebug (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - React-rncore (0.73.6)
-  - React-runtimeexecutor (0.73.6):
-    - React-jsi (= 0.73.6)
-  - React-runtimescheduler (0.73.6):
+  - React-rncore (0.73.7)
+  - React-runtimeexecutor (0.73.7):
+    - React-jsi (= 0.73.7)
+  - React-runtimescheduler (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-callinvoker
@@ -979,46 +979,46 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.6):
+  - React-utils (0.73.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - ReactCommon (0.73.6):
-    - React-logger (= 0.73.6)
-    - ReactCommon/turbomodule (= 0.73.6)
-  - ReactCommon/turbomodule (0.73.6):
+  - ReactCommon (0.73.7):
+    - React-logger (= 0.73.7)
+    - ReactCommon/turbomodule (= 0.73.7)
+  - ReactCommon/turbomodule (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-    - ReactCommon/turbomodule/bridging (= 0.73.6)
-    - ReactCommon/turbomodule/core (= 0.73.6)
-  - ReactCommon/turbomodule/bridging (0.73.6):
+    - React-callinvoker (= 0.73.7)
+    - React-cxxreact (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - React-logger (= 0.73.7)
+    - React-perflogger (= 0.73.7)
+    - ReactCommon/turbomodule/bridging (= 0.73.7)
+    - ReactCommon/turbomodule/core (= 0.73.7)
+  - ReactCommon/turbomodule/bridging (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - ReactCommon/turbomodule/core (0.73.6):
+    - React-callinvoker (= 0.73.7)
+    - React-cxxreact (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - React-logger (= 0.73.7)
+    - React-perflogger (= 0.73.7)
+  - ReactCommon/turbomodule/core (0.73.7):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - ReactNativeHost (0.4.6):
+    - React-callinvoker (= 0.73.7)
+    - React-cxxreact (= 0.73.7)
+    - React-jsi (= 0.73.7)
+    - React-logger (= 0.73.7)
+    - React-perflogger (= 0.73.7)
+  - ReactNativeHost (0.4.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1028,7 +1028,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.2.4):
+  - RNWWebStorage (0.2.5):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1206,57 +1206,57 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   Example-Tests: 9e95b10878936c581cbe09d784cd5eaa6ca70db8
-  FBLazyVector: f64d1e2ea739b4d8f7e4740cde18089cd97fe864
-  FBReactNativeSpec: 133b4c4362bacd8d6527b897ee5e5e3bc90bb075
+  FBLazyVector: 9f533d5a4c75ca77c8ed774aced1a91a0701781e
+  FBReactNativeSpec: 510b1e0756a17ab59ad3d2e34b8960aebd549040
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
-  RCTRequired: ca1d7414aba0b27efcfa2ccd37637edb1ab77d96
-  RCTTypeSafety: 678e344fb976ff98343ca61dc62e151f3a042292
-  React: e296bcebb489deaad87326067204eb74145934ab
-  React-callinvoker: d0b7015973fa6ccb592bb0363f6bc2164238ab8c
-  React-Codegen: 26596f3dc3269bed13220f0609f778fcc93b50dd
-  React-Core: 1d1f8ef65353751bf57d5c6f01a2bf3fbe644df8
-  React-CoreModules: 558228e12cddb9ca00ff7937894cc5104a21be6b
-  React-cxxreact: 92db3068083c5790656277d5f1ef56c615cd1177
-  React-debug: d444db402065cca460d9c5b072caab802a04f729
-  React-Fabric: 433731b157b8f63aa0cac89327ece388ca1748a0
-  React-FabricImage: 01a6990e58926aebbd13ea075cb6e9b70b022840
-  React-graphics: 5500206f7c9a481456365403c9fcf1638de108b7
-  React-ImageManager: df193215ff3cf1a8dad297e554c89c632e42436c
-  React-jsc: 423fa1db16947e4dffb83c72f6fe4248913b0e00
-  React-jserrorhandler: a4d0f541c5852cf031db2f82f51de90be55b1334
-  React-jsi: 730ad8dffa69e4196361e10cddc89fd8a9d32202
-  React-jsiexecutor: e9d8ef2051048ae7d32c7da38c2c0c22cfa3d7f3
-  React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
-  React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
-  React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
-  React-NativeModulesApple: ae99dc0e80c9027f54572c45635449fbdc36e4f1
-  React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2
-  React-RCTActionSheet: 37edf35aeb8e4f30e76c82aab61f12d1b75c04ec
-  React-RCTAnimation: a69de7f3daa8462743094f4736c455e844ea63f7
-  React-RCTAppDelegate: d25d143b0918fb0614201f2b5d56eca1679d8462
-  React-RCTBlob: 4ae95e6ba3508771b8fa0fedb64df07aa561b548
-  React-RCTFabric: d792d7bad2238d67a33dd7ee0f2e32de6eaf669f
-  React-RCTImage: a0bfe87b6908c7b76bd7d74520f40660bd0ad881
-  React-RCTLinking: 5f10be1647952cceddfa1970fdb374087582fc34
-  React-RCTNetwork: a0bc3dd45a2dc7c879c80cebb6f9707b2c8bbed6
-  React-RCTSettings: 28c202b68afa59afb4067510f2c69c5a530fb9e3
-  React-RCTText: 4119d9e53ca5db9502b916e1b146e99798986d21
-  React-RCTVibration: 55bd7c48487eb9a2562f2bd3fdc833274f5b0636
-  React-rendererdebug: 5fa97ba664806cee4700e95aec42dff1b6f8ea36
-  React-rncore: e15b68c32138fded0519efc1b156f9716175954c
-  React-runtimeexecutor: bb328dbe2865f3a550df0240df8e2d8c3aaa4c57
-  React-runtimescheduler: 9daefa990db62f8874bc9d6e7e504272c6b6c57f
-  React-utils: d16c1d2251c088ad817996621947d0ac8167b46c
-  ReactCommon: 447281ad2034ea3252bf81a60d1f77d5afb0b636
-  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
+  RCTRequired: 77f73950d15b8c1a2b48ba5b79020c3003d1c9b5
+  RCTTypeSafety: ede1e2576424d89471ef553b2aed09fbbcc038e3
+  React: 2ddb437e599df2f1bffa9b248de2de4cfa0227f0
+  React-callinvoker: 10fc710367985e525e2d65bcc3a73d536c992aea
+  React-Codegen: 2dacb065d14fa11ef8f102612601489d6b0fad92
+  React-Core: 168a3a52c0fbd238d51e4661f0a05cdaa3469ffa
+  React-CoreModules: 97e5860e7e2d8549a5a357c2e0b115e93f25e5e7
+  React-cxxreact: 0ace137717686e7cd2d2460071f85512d087b4fc
+  React-debug: 2bb2ea6d53636bfdc7cb9009a8e71dd6a96810b5
+  React-Fabric: ba59dc25be3c9ec5aeb8beab7846a0449adbda2c
+  React-FabricImage: a6bd5e120ec960c8c7801d3fa77a09fb1176a57c
+  React-graphics: 860acbbd1398a1c50d2a0b7fd37ca4f1ae5cef5e
+  React-ImageManager: b55d5ffffaaa7678bcb5799f95918cb20924d3a8
+  React-jsc: 319d45acef47e4e4277aa3526da064cc5eded50a
+  React-jserrorhandler: 872045564849dadc0692bf034be4fc77b0f6c3e8
+  React-jsi: 43b763ba124304fe86a9e116c61d18657e3270ab
+  React-jsiexecutor: d62771863a12d955a97833dc927d9e0a9215bdfe
+  React-jsinspector: f356e49aa086380d3a4892708ca173ad31ac69c1
+  React-logger: 7b19bdfb254772a0332d6cd4d66eceb0678b6730
+  React-Mapbuffer: 6f392912435adb8fbf4c3eee0e79a0a0b4e4b717
+  React-nativeconfig: 754233aac2a769578f828093b672b399355582e6
+  React-NativeModulesApple: 7359dd8830ba09d157afcc7088836e69d3f61743
+  React-perflogger: 68ec84e2f858a3e35009aef8866b55893e5e0a1f
+  React-RCTActionSheet: 348c4c729fdfb874f6937abbea90355ecaa6977c
+  React-RCTAnimation: 9fb1232af37d25d03415af2e0b8ab3b585ed856d
+  React-RCTAppDelegate: d1fb6420a43901965710be137f9a775a189c484c
+  React-RCTBlob: bc7324807d33ab0bd20a0c7a24d9aaecafe5f84c
+  React-RCTFabric: 831f45529dfe32c89449105a34aba669bfa32822
+  React-RCTImage: 520fe02462804655e39b6657996e47277e6f0115
+  React-RCTLinking: fb46b9dfea24f4a876163f95769ab279851e0b65
+  React-RCTNetwork: dd4396889c20fa8872d4028a4d08f2d2888e2c7f
+  React-RCTSettings: a7d6fe4b52b98c08b12532a42a18cb12a1667d0a
+  React-RCTText: df7267a4bc092429fcf285238fbe67a89406ff44
+  React-RCTVibration: df03af479dc7ec756e2ca73eb6ce2fa3da6b2888
+  React-rendererdebug: ce0744f4121882c76d7a1b2836b8353246d884f8
+  React-rncore: 4236dd8e470f3a228fab1653234d0d47b6d01e88
+  React-runtimeexecutor: b7f307017d54701cf3a4ae41c7558051e0660658
+  React-runtimescheduler: 1c73bbf078fff6ea4a16e251f244ca01cf8b65c5
+  React-utils: d07d009101c7dabff68b710da5c4a47b7a850d98
+  ReactCommon: 1a139d94a3ab30b7ee77b0654bd24a7ecfc67318
+  ReactNativeHost: 69c76dddefb1a795780b5292dad8817e2097f9cd
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 857244f3a23f2b3157b364fa06cf3e8866deff9c
-  RNWWebStorage: 0663af06cd0cf0e465b87e6144f85e0720ded82e
+  RNWWebStorage: ce8c1b8f1ced2ffd85024a0fac266a62087488a8
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 805bf71192903b20fc14babe48080582fee65a80
+  Yoga: 47d399a73c0c0caa9ff824e5c657eae31215bfee
 
 PODFILE CHECKSUM: c9e179d1d59e47eaa6fef9316a7e039dbb9b0c0b
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1018,7 +1018,7 @@ PODS:
     - React-jsi (= 0.73.24)
     - React-logger (= 0.73.24)
     - React-perflogger (= 0.73.24)
-  - ReactNativeHost (0.4.6):
+  - ReactNativeHost (0.4.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1028,7 +1028,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.2.4):
+  - RNWWebStorage (0.2.5):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1252,10 +1252,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 265991752129c54256f223defa0272509fe81ad7
   React-utils: fad5a988b6e23d8b98a4450408bfcc56d63ac85c
   ReactCommon: 67c1d3a5dafe396de7d497fe224c12217f8b6f49
-  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
+  ReactNativeHost: 69c76dddefb1a795780b5292dad8817e2097f9cd
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 9d83e280b173ba2ee053b8135730dff60f9ab674
-  RNWWebStorage: 0663af06cd0cf0e465b87e6144f85e0720ded82e
+  RNWWebStorage: ce8c1b8f1ced2ffd85024a0fac266a62087488a8
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
   Yoga: 24ddb4963e2a3330df762423f0a9de2096325401
 

--- a/example/visionos/Podfile.lock
+++ b/example/visionos/Podfile.lock
@@ -1067,7 +1067,7 @@ PODS:
     - React-jsi (= 0.73.10)
     - React-logger (= 0.73.10)
     - React-perflogger (= 0.73.10)
-  - ReactNativeHost (0.4.6):
+  - ReactNativeHost (0.4.7):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1077,7 +1077,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.2.4):
+  - RNWWebStorage (0.2.5):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1317,10 +1317,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 3f2a280b446060ac359d32175cf26402b7fd8de0
   React-utils: 940f007d5dad05ec028b873ebfed3bf6ec46c417
   ReactCommon: 0c2cdd6a193b8ce7c05105b66b881c41bf014308
-  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
+  ReactNativeHost: 69c76dddefb1a795780b5292dad8817e2097f9cd
   ReactTestApp-DevSupport: c4abadbb90a8a9903400407e9857c2a2ef0343fb
   ReactTestApp-Resources: 2ad57492ef72ab9b2c6f6e89ea198cc1999ca20b
-  RNWWebStorage: 0663af06cd0cf0e465b87e6144f85e0720ded82e
+  RNWWebStorage: ce8c1b8f1ced2ffd85024a0fac266a62087488a8
   SocketRocket: 0ba3e799f983d2dfa878777017659ef6c866e5c6
   Yoga: a2d1866030ed66b042bdd302fe0541f5b107f3b6
 

--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		191A67842BDFCD5C0094F246 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 191A67832BDFCD5C0094F246 /* PrivacyInfo.xcprivacy */; };
 		192DD201240FCAF5004E9CEB /* Manifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192DD200240FCAF5004E9CEB /* Manifest.swift */; };
 		196C22622490CB7600449D3C /* React+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 196C22602490CB7600449D3C /* React+Compatibility.m */; };
 		196C7215232F1788006556ED /* ReactInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C7214232F1788006556ED /* ReactInstance.swift */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		191A67832BDFCD5C0094F246 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		192DD200240FCAF5004E9CEB /* Manifest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Manifest.swift; sourceTree = "<group>"; };
 		192F052624AD3CC500A48456 /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
 		192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */,
 				19ECD0DB232ED427003D8557 /* Assets.xcassets */,
 				19ECD0E3232ED427003D8557 /* Info.plist */,
+				191A67832BDFCD5C0094F246 /* PrivacyInfo.xcprivacy */,
 				196C7216232F6CD9006556ED /* ReactTestApp.entitlements */,
 				192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */,
 				192F052824AD3CC500A48456 /* ReactTestApp.debug.xcconfig */,
@@ -265,6 +268,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				191A67842BDFCD5C0094F246 /* PrivacyInfo.xcprivacy in Resources */,
 				19ECD0DC232ED427003D8557 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -1,3 +1,15 @@
+require('json')
+
+def app_manifest(project_root)
+  @app_manifest ||= {}
+  return @app_manifest[project_root] if @app_manifest.key?(project_root)
+
+  manifest_path = find_file('app.json', project_root)
+  return if manifest_path.nil?
+
+  @app_manifest[project_root] = JSON.parse(File.read(manifest_path))
+end
+
 def assert(condition, message)
   raise message unless condition
 end
@@ -36,6 +48,14 @@ def new_architecture_enabled?(options, react_native_version)
   supports_new_architecture = supports_new_architecture?(react_native_version)
   supports_new_architecture && ENV.fetch('RCT_NEW_ARCH_ENABLED',
                                          options[:fabric_enabled] || options[:turbomodule_enabled])
+end
+
+def platform_config(key, project_root, target_platform)
+  manifest = app_manifest(project_root)
+  return if manifest.nil?
+
+  config = manifest[target_platform.to_s]
+  config[key] if !config.nil? && !config.empty?
 end
 
 def resolve_module(request, start_dir = Pod::Config.instance.installation_root)

--- a/ios/privacy_manifest.rb
+++ b/ios/privacy_manifest.rb
@@ -1,3 +1,7 @@
+require('cfpropertylist')
+
+require_relative('pod_helpers')
+
 # https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
 PRIVACY_ACCESSED_API_TYPES = 'NSPrivacyAccessedAPITypes'.freeze
 PRIVACY_COLLECTED_DATA_TYPES = 'NSPrivacyCollectedDataTypes'.freeze
@@ -10,3 +14,46 @@ PRIVACY_ACCESSED_API_TYPE_REASONS = 'NSPrivacyAccessedAPITypeReasons'.freeze
 PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP = 'NSPrivacyAccessedAPICategoryFileTimestamp'.freeze
 PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME = 'NSPrivacyAccessedAPICategorySystemBootTime'.freeze
 PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS = 'NSPrivacyAccessedAPICategoryUserDefaults'.freeze
+
+def generate_privacy_manifest!(project_root, target_platform, destination)
+  privacy = {
+    PRIVACY_TRACKING => false,
+    PRIVACY_TRACKING_DOMAINS => [],
+    PRIVACY_COLLECTED_DATA_TYPES => [],
+    PRIVACY_ACCESSED_API_TYPES => [
+      {
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['C617.1'],
+      },
+      {
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['35F9.1'],
+      },
+      {
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['CA92.1'],
+      },
+    ],
+  }
+
+  user_privacy_manifest = platform_config('privacyManifest', project_root, target_platform)
+  unless user_privacy_manifest.nil?
+    tracking = user_privacy_manifest[PRIVACY_TRACKING]
+    privacy[PRIVACY_TRACKING] = tracking unless tracking.nil?
+
+    [
+      PRIVACY_TRACKING_DOMAINS,
+      PRIVACY_COLLECTED_DATA_TYPES,
+      PRIVACY_ACCESSED_API_TYPES,
+    ].each do |field|
+      value = user_privacy_manifest[field]
+      privacy[field] += value if value.is_a? Enumerable
+    end
+  end
+
+  plist = CFPropertyList::List.new
+  plist.value = CFPropertyList.guess(privacy)
+  plist.save(File.join(destination, 'PrivacyInfo.xcprivacy'),
+             CFPropertyList::List::FORMAT_XML,
+             { :formatted => true })
+end

--- a/ios/privacy_manifest.rb
+++ b/ios/privacy_manifest.rb
@@ -1,0 +1,12 @@
+# https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+PRIVACY_ACCESSED_API_TYPES = 'NSPrivacyAccessedAPITypes'.freeze
+PRIVACY_COLLECTED_DATA_TYPES = 'NSPrivacyCollectedDataTypes'.freeze
+PRIVACY_TRACKING = 'NSPrivacyTracking'.freeze
+PRIVACY_TRACKING_DOMAINS = 'NSPrivacyTrackingDomains'.freeze
+
+# https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+PRIVACY_ACCESSED_API_TYPE = 'NSPrivacyAccessedAPIType'.freeze
+PRIVACY_ACCESSED_API_TYPE_REASONS = 'NSPrivacyAccessedAPITypeReasons'.freeze
+PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP = 'NSPrivacyAccessedAPICategoryFileTimestamp'.freeze
+PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME = 'NSPrivacyAccessedAPICategorySystemBootTime'.freeze
+PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS = 'NSPrivacyAccessedAPICategoryUserDefaults'.freeze

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -3,6 +3,7 @@ require('json')
 require('pathname')
 
 require_relative('pod_helpers')
+require_relative('privacy_manifest')
 require_relative('xcode')
 
 def app_manifest(project_root)
@@ -170,21 +171,21 @@ end
 
 def generate_privacy_manifest!(project_root, target_platform, destination)
   privacy = {
-    'NSPrivacyTracking' => false,
-    'NSPrivacyTrackingDomains' => [],
-    'NSPrivacyCollectedDataTypes' => [],
-    'NSPrivacyAccessedAPITypes' => [
+    PRIVACY_TRACKING => false,
+    PRIVACY_TRACKING_DOMAINS => [],
+    PRIVACY_COLLECTED_DATA_TYPES => [],
+    PRIVACY_ACCESSED_API_TYPES => [
       {
-        'NSPrivacyAccessedAPIType' => 'NSPrivacyAccessedAPICategoryFileTimestamp',
-        'NSPrivacyAccessedAPITypeReasons' => ['C617.1'],
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['C617.1'],
       },
       {
-        'NSPrivacyAccessedAPIType' => 'NSPrivacyAccessedAPICategorySystemBootTime',
-        'NSPrivacyAccessedAPITypeReasons' => ['35F9.1'],
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['35F9.1'],
       },
       {
-        'NSPrivacyAccessedAPIType' => 'NSPrivacyAccessedAPICategoryUserDefaults',
-        'NSPrivacyAccessedAPITypeReasons' => ['CA92.1'],
+        PRIVACY_ACCESSED_API_TYPE => PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS,
+        PRIVACY_ACCESSED_API_TYPE_REASONS => ['CA92.1'],
       },
     ],
   }
@@ -193,13 +194,13 @@ def generate_privacy_manifest!(project_root, target_platform, destination)
   config = manifest[target_platform.to_s] unless manifest.nil?
   user_privacy_manifest = config && config['privacyManifest']
   unless user_privacy_manifest.nil?
-    privacy_tracking = user_privacy_manifest['NSPrivacyTracking']
-    privacy['NSPrivacyTracking'] = privacy_tracking unless privacy_tracking.nil?
+    tracking = user_privacy_manifest[PRIVACY_TRACKING]
+    privacy[PRIVACY_TRACKING] = tracking unless tracking.nil?
 
-    %w[
-      NSPrivacyTrackingDomains
-      NSPrivacyCollectedDataTypes
-      NSPrivacyAccessedAPITypes
+    [
+      PRIVACY_TRACKING_DOMAINS,
+      PRIVACY_COLLECTED_DATA_TYPES,
+      PRIVACY_ACCESSED_API_TYPES,
     ].each do |field|
       value = user_privacy_manifest[field]
       privacy[field] += value if value.is_a? Enumerable

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -190,9 +190,7 @@ def generate_privacy_manifest!(project_root, target_platform, destination)
     ],
   }
 
-  manifest = app_manifest(project_root)
-  config = manifest[target_platform.to_s] unless manifest.nil?
-  user_privacy_manifest = config && config['privacyManifest']
+  user_privacy_manifest = platform_config('privacyManifest', project_root, target_platform)
   unless user_privacy_manifest.nil?
     tracking = user_privacy_manifest[PRIVACY_TRACKING]
     privacy[PRIVACY_TRACKING] = tracking unless tracking.nil?

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		191A67882BDFD9E90094F246 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 191A67872BDFD9E90094F246 /* PrivacyInfo.xcprivacy */; };
 		193EF063247A736200BE8C79 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF062247A736200BE8C79 /* AppDelegate.swift */; };
 		193EF065247A736200BE8C79 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193EF064247A736200BE8C79 /* ViewController.swift */; };
 		193EF067247A736300BE8C79 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 193EF066247A736300BE8C79 /* Assets.xcassets */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		191A67872BDFD9E90094F246 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		193EF05F247A736200BE8C79 /* ReactTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReactTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		193EF062247A736200BE8C79 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		193EF064247A736200BE8C79 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -61,7 +63,7 @@
 		19B368BC24B12C24002CCEFF /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
 		19B368BD24B12C24002CCEFF /* ReactTestApp.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.debug.xcconfig; sourceTree = "<group>"; };
 		19B368BE24B12C24002CCEFF /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
-		19C4C89227710D8500157870 /* Manifest+Embedded.g.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Manifest+Embedded.g.swift"; path = "Manifest+Embedded.g.swift"; sourceTree = SOURCE_ROOT; };
+		19C4C89227710D8500157870 /* Manifest+Embedded.g.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Manifest+Embedded.g.swift"; sourceTree = SOURCE_ROOT; };
 		19E0B90C27E9F8FD006FD558 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = ../Localizations/en.lproj/Main.strings; sourceTree = "<group>"; };
 		19E791BF24B08E1400FA6468 /* ReactTestAppTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactTestAppTests.swift; sourceTree = "<group>"; };
 		19E791C224B08E4D00FA6468 /* ReactTestAppUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactTestAppUITests.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				193EF066247A736300BE8C79 /* Assets.xcassets */,
 				193EF068247A736300BE8C79 /* Main.storyboard */,
 				193EF06B247A736300BE8C79 /* Info.plist */,
+				191A67872BDFD9E90094F246 /* PrivacyInfo.xcprivacy */,
 				193EF06C247A736300BE8C79 /* ReactTestApp.entitlements */,
 				19B368BC24B12C24002CCEFF /* ReactTestApp.common.xcconfig */,
 				19B368BD24B12C24002CCEFF /* ReactTestApp.debug.xcconfig */,
@@ -264,6 +267,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				191A67882BDFD9E90094F246 /* PrivacyInfo.xcprivacy in Resources */,
 				193EF067247A736300BE8C79 /* Assets.xcassets in Resources */,
 				193EF06A247A736300BE8C79 /* Main.storyboard in Resources */,
 			);

--- a/schema.json
+++ b/schema.json
@@ -25,7 +25,7 @@
           "type": "string"
         },
         "buildNumber": {
-          "description": "Similar to [`version`](#version), but is not shown to users. This is a required\nkey for App Store.",
+          "description": "Similar to [`version`](#version), but is not shown to users. This is a required key for App Store.",
           "markdownDescription": "Similar to [`version`](#version), but is not shown to users. This is a required\nkey for App Store.\n\nThe equivalent key in `Info.plist` is\n[`CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion).\n\nIntroduced in\n[1.4.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.4.0).",
           "type": "string"
         },
@@ -62,19 +62,24 @@
           ]
         },
         "codeSignEntitlements": {
-          "description": "Specifies the path to a custom\n[Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)\nfile. The path should be relative to `app.json`.",
+          "description": "Specifies the path to a custom [Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements) file. The path should be relative to `app.json`.",
           "markdownDescription": "Specifies the path to a custom\n[Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)\nfile. The path should be relative to `app.json`.\n\nThis is the same as setting `CODE_SIGN_ENTITLEMENTS` in Xcode.\n\nIntroduced in\n[0.9.7](https://github.com/microsoft/react-native-test-app/releases/tag/0.9.7).",
           "type": "string"
         },
         "codeSignIdentity": {
-          "description": "Sets the\n<a href='https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW1'>code\nsigning identity</a> to use when signing code.",
+          "description": "Sets the <a href='https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW1'>code signing identity</a> to use when signing code.",
           "markdownDescription": "Sets the\n<a href='https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW1'>code\nsigning identity</a> to use when signing code.\n\nThis is the same as setting `CODE_SIGN_IDENTITY` in Xcode.\n\nIntroduced in\n[0.9.7](https://github.com/microsoft/react-native-test-app/releases/tag/0.9.7).",
           "type": "string"
         },
         "developmentTeam": {
-          "description": "Sets the\n<a href='https://help.apple.com/xcode/mac/current/#/dev23aab79b4'>development\nteam</a> that the app should be assigned to.",
+          "description": "Sets the <a href='https://help.apple.com/xcode/mac/current/#/dev23aab79b4'>development team</a> that the app should be assigned to.",
           "markdownDescription": "Sets the\n<a href='https://help.apple.com/xcode/mac/current/#/dev23aab79b4'>development\nteam</a> that the app should be assigned to.\n\nThis is the same as setting `DEVELOPMENT_TEAM` in Xcode.\n\nIntroduced in\n[0.9.7](https://github.com/microsoft/react-native-test-app/releases/tag/0.9.7).",
           "type": "string"
+        },
+        "privacyManifest": {
+          "description": "The privacy manifest is a property list that records the information regarding the types of data collected and the required reasons APIs your app or third-party SDK use.",
+          "markdownDescription": "The privacy manifest is a property list that records the information regarding\nthe types of data collected and the required reasons APIs your app or\nthird-party SDK use.\n\n- The types of data collected by your app or third-party SDK must be provided on\n  all platforms.\n- The required reasons APIs your app or third-party SDK uses must be provided on\n  iOS, iPadOS, tvOS, visionOS, and watchOS.\n\nBy default, a `PrivacyInfo.xcprivacy` is always generated with the following\nvalues:\n\n```json\n{\n  \"NSPrivacyTracking\": false,\n  \"NSPrivacyTrackingDomains\": [],\n  \"NSPrivacyCollectedDataTypes\": [],\n  \"NSPrivacyAccessedAPITypes\": [\n    {\n      \"NSPrivacyAccessedAPIType\": \"NSPrivacyAccessedAPICategoryFileTimestamp\",\n      \"NSPrivacyAccessedAPITypeReasons\": [\"C617.1\"]\n    },\n    {\n      \"NSPrivacyAccessedAPIType\": \"NSPrivacyAccessedAPICategorySystemBootTime\",\n      \"NSPrivacyAccessedAPITypeReasons\": [\"35F9.1\"]\n    },\n    {\n      \"NSPrivacyAccessedAPIType\": \"NSPrivacyAccessedAPICategoryUserDefaults\",\n      \"NSPrivacyAccessedAPITypeReasons\": [\"CA92.1\"]\n    }\n  ]\n}\n```\n\nFor more details, read Apple's documentation on\n[Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).",
+          "type": "object"
         }
       }
     },
@@ -120,22 +125,22 @@
           "type": "string"
         },
         "version": {
-          "description": "The app version shown to users. The required format is three period-separated\nintegers, such as 1.3.11.",
+          "description": "The app version shown to users. The required format is three period-separated integers, such as 1.3.11.",
           "markdownDescription": "The app version shown to users. The required format is three period-separated\nintegers, such as 1.3.11.\n\n- **Android**: Equivalent to setting\n  [`versionName`](https://developer.android.com/studio/publish/versioning#appversioning).\n- **iOS**: This is the same as setting\n  [`CFBundleShortVersionString`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)\n  in `Info.plist`.\n- **macOS**: This is the same as setting\n  [`CFBundleShortVersionString`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)\n  in `Info.plist`.\n- **Windows**: Please see [`windows.appxmanifest`](#windows.appxmanifest) for\n  how to use a custom\n  [app package manifest](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest)\n  instead.\n\nIntroduced in\n[1.4.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.4.0).",
           "type": "string"
         },
         "bundleRoot": {
-          "description": "Specifies the root of the bundle file name. E.g., if the bundle file is\n`index.[platform].bundle`, `index` is the bundle root.",
+          "description": "Specifies the root of the bundle file name. E.g., if the bundle file is `index.[platform].bundle`, `index` is the bundle root.",
           "markdownDescription": "Specifies the root of the bundle file name. E.g., if the bundle file is\n`index.[platform].bundle`, `index` is the bundle root.\n\nDefaults to `index` and `main`.\n\nWhen set, the test app will look for the following files on startup:\n\n- `myRoot.[platform].jsbundle`\n- `myRoot.[platform].bundle`\n- `myRoot.native.jsbundle`\n- `myRoot.native.bundle`\n- `myRoot.jsbundle`\n- `myRoot.bundle`\n\nIntroduced in\n[0.9.0](https://github.com/microsoft/react-native-test-app/releases/tag/0.9.0).",
           "type": "string"
         },
         "singleApp": {
-          "description": "In single-app mode, the component with the specified slug gets launched\nautomatically, essentially behaving as a normal app.",
+          "description": "In single-app mode, the component with the specified slug gets launched automatically, essentially behaving as a normal app.",
           "markdownDescription": "In single-app mode, the component with the specified slug gets launched\nautomatically, essentially behaving as a normal app.\n\nDefaults to multi-app mode.\n\nFor more details, see [its dedicated page](Single-app-Mode).\n\nIntroduced in\n[1.3.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.3.0).",
           "type": "string"
         },
         "components": {
-          "description": "All components that should be accessible from the home screen should be declared\nunder this property. Each component must have `appKey` set, i.e. the name that\nyou passed to `AppRegistry.registerComponent`.",
+          "description": "All components that should be accessible from the home screen should be declared under this property. Each component must have `appKey` set, i.e. the name that you passed to `AppRegistry.registerComponent`.",
           "markdownDescription": "All components that should be accessible from the home screen should be declared\nunder this property. Each component must have `appKey` set, i.e. the name that\nyou passed to `AppRegistry.registerComponent`.\n\n```javascript\nAppRegistry.registerComponent(\"Example\", () => Example);\n```\n\nFor each entry, you can declare additional (optional) properties:\n\n```javascript\n{\n  \"components\": [\n    {\n      // The app key passed to `AppRegistry.registerComponent()`\n      \"appKey\": \"Example\",\n\n      // [Optional] Name to be displayed on home screen\n      \"displayName\": \"App\",\n\n      // [Optional] Properties that should be passed to your component\n      \"initialProperties\": {\n        \"concurrentRoot\": false\n      },\n\n      // [Optional] The style in which to present your component.\n      // Valid values are: \"modal\"\n      \"presentationStyle\": \"\",\n\n      // [Optional] URL slug that uniquely identifies this component.\n      // Used for deep linking.\n      \"slug\": \"\"\n    }\n  ]\n}\n```\n\n> [!NOTE]\n>\n> [Concurrent React](https://reactjs.org/blog/2022/03/29/react-v18.html#what-is-concurrent-react)\n> is enabled by default when you enable New Architecture starting with 0.71. If\n> this is undesirable, you can opt out by adding `\"concurrentRoot\": false` to\n> `initialProperties`. This is not recommended, and won't be possible from 0.74\n> on.\n\n<a name='android-adding-fragments' />\n\n#### [Android] Adding Fragments\n\nOn Android, you can add fragments to the home screen by using their fully\nqualified class names, e.g. `com.example.app.MyFragment`, as app key:\n\n```javascript\n\"components\": [\n  {\n    \"appKey\": \"com.example.app.MyFragment\",\n    \"displayName\": \"App\"\n  }\n]\n```\n\nIf you need to get the `ReactNativeHost` instance within `MyFragment`, you can\nrequest it as a service from the context:\n\n```java\n@Override\n@SuppressLint(\"WrongConstant\")\npublic void onAttach(@NonNull Context context) {\n    super.onAttach(context);\n\n    ReactNativeHost reactNativeHost = (ReactNativeHost)\n        context.getSystemService(\"service:reactNativeHostService\");\n    ReactInstanceManager reactInstanceManager =\n        reactNativeHost.getReactInstanceManager();\n}\n```\n\n<a name='ios-macos-adding-view-controllers' />\n\n#### [iOS, macOS] Adding View Controllers\n\nOn iOS/macOS, you can have native view controllers on the home screen by using\ntheir Objective-C names as app key (Swift classes can declare Objective-C names\nwith the\n[`@objc`](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#objc)\nattribute):\n\n```javascript\n\"components\": [\n  {\n    \"appKey\": \"RTAMyViewController\",\n    \"displayName\": \"App\"\n  }\n]\n```\n\nThe view controller must implement an initializer that accepts a\n`ReactNativeHost` instance:\n\n```objc\n@interface MyViewController : UIViewController\n- (nonnull instancetype)initWithHost:(nonnull ReactNativeHost *)host;\n@end\n```\n\nOr in Swift:\n\n```swift\n@objc(MyViewController)\nclass MyViewController: UIViewController {\n    @objc init(host: ReactNativeHost) {\n        // Initialize\n    }\n}\n```",
           "type": "array",
           "items": {
@@ -181,7 +186,7 @@
   "type": "object",
   "properties": {
     "resources": {
-      "description": "Here you should declare all resources that should be bundled with the app. The\nproperty can be a list of paths to resources:",
+      "description": "Here you should declare all resources that should be bundled with the app. The property can be a list of paths to resources:",
       "markdownDescription": "Here you should declare all resources that should be bundled with the app. The\nproperty can be a list of paths to resources:\n\n```javascript\n\"resources\": [\n  \"dist/assets\",\n  \"dist/main.jsbundle\"\n]\n```\n\nOr you can declare platform specific resources using platform names as key:\n\n```javascript\n\"resources\": {\n  \"android\": [\n    \"dist/res\",\n    \"dist/main.android.jsbundle\"\n  ],\n  \"ios\": [\n    \"dist/assets\",\n    \"dist/main.ios.jsbundle\"\n  ],\n  \"macos\": [\n    \"dist/assets\",\n    \"dist/main.macos.jsbundle\"\n  ],\n  \"windows\": [\n    \"dist/assets\",\n    \"dist/main.windows.bundle\"\n  ]\n}\n```\n\nA path must be relative to the path of `app.json`, and can point to both a file\nor a directory.",
       "oneOf": [
         {
@@ -235,7 +240,7 @@
           "type": "string"
         },
         "versionCode": {
-          "description": "A positive integer used as an internal version number. Google uses this number\nto determine whether one version is more recent than another. See\n[Version your app](https://developer.android.com/studio/publish/versioning#appversioning)\nfor more on how it is used and how it differs from [`version`](#version).",
+          "description": "A positive integer used as an internal version number. Google uses this number to determine whether one version is more recent than another. See [Version your app](https://developer.android.com/studio/publish/versioning#appversioning) for more on how it is used and how it differs from [`version`](#version).",
           "markdownDescription": "A positive integer used as an internal version number. Google uses this number\nto determine whether one version is more recent than another. See\n[Version your app](https://developer.android.com/studio/publish/versioning#appversioning)\nfor more on how it is used and how it differs from [`version`](#version).\n\nIntroduced in\n[1.4.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.4.0).",
           "type": "number",
           "minimum": 0
@@ -246,7 +251,7 @@
           "type": "string"
         },
         "signingConfigs": {
-          "description": "Use this to set the\n<a href='https://developer.android.com/studio/publish/app-signing'>signing\nconfigurations</a> for the app.",
+          "description": "Use this to set the <a href='https://developer.android.com/studio/publish/app-signing'>signing configurations</a> for the app.",
           "markdownDescription": "Use this to set the\n<a href='https://developer.android.com/studio/publish/app-signing'>signing\nconfigurations</a> for the app.\n\nThe JSON schema follows the Gradle DSL very closely. Below is what one would add\nfor the debug and release flavors:\n\n```javascript\n{\n  \"android\": {\n    \"signingConfigs\": {\n      \"debug\": {                          // optional\n        \"keyAlias\": \"androiddebugkey\",    // defaults to \"androiddebugkey\"\n        \"keyPassword\": \"android\",         // defaults to \"android\n        \"storeFile\": \"debug.keystore\",    // required\n        \"storePassword\": \"android\"        // defaults to \"android\n      },\n      \"release\": {                        // optional\n        \"keyAlias\": \"androiddebugkey\",    // defaults to \"androiddebugkey\"\n        \"keyPassword\": \"android\",         // defaults to \"android\n        \"storeFile\": \"release.keystore\",  // required\n        \"storePassword\": \"android\"        // defaults to \"android\n      }\n    }\n  }\n}\n```\n\nIntroduced in\n[0.11.0](https://github.com/microsoft/react-native-test-app/releases/tag/0.11.0).",
           "type": "object",
           "properties": {
@@ -332,22 +337,22 @@
       "type": "object",
       "properties": {
         "appxManifest": {
-          "description": "Sets the path to your\n<a href='https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest'>app\npackage manifest</a>. If none is set, a default manifest will be provided.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.",
+          "description": "Sets the path to your <a href='https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest'>app package manifest</a>. If none is set, a default manifest will be provided. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.",
           "markdownDescription": "Sets the path to your\n<a href='https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appx-package-manifest'>app\npackage manifest</a>. If none is set, a default manifest will be provided.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in\n[0.5.5](https://github.com/microsoft/react-native-test-app/releases/tag/0.5.5).",
           "type": "string"
         },
         "certificateKeyFile": {
-          "description": "The path to the certificate to use. If specified, it will also enable package\nsigning. Changes to this property will not be automatically be picked up; you\nneed to re-run `npx install-windows-test-app` to update the solution.",
+          "description": "The path to the certificate to use. If specified, it will also enable package signing. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.",
           "markdownDescription": "The path to the certificate to use. If specified, it will also enable package\nsigning. Changes to this property will not be automatically be picked up; you\nneed to re-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in\n[1.1.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.1.0).",
           "type": "string"
         },
         "certificatePassword": {
-          "description": "The password for the private key in the certificate. Leave unset if no password.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.",
+          "description": "The password for the private key in the certificate. Leave unset if no password. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.",
           "markdownDescription": "The password for the private key in the certificate. Leave unset if no password.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in\n[1.1.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.1.0).",
           "type": "string"
         },
         "certificateThumbprint": {
-          "description": "This value must match the thumbprint in the signing certificate, or be unset.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.",
+          "description": "This value must match the thumbprint in the signing certificate, or be unset. Changes to this property will not be automatically be picked up; you need to re-run `npx install-windows-test-app` to update the solution.",
           "markdownDescription": "This value must match the thumbprint in the signing certificate, or be unset.\nChanges to this property will not be automatically be picked up; you need to\nre-run `npx install-windows-test-app` to update the solution.\n\nIntroduced in\n[1.1.0](https://github.com/microsoft/react-native-test-app/releases/tag/1.1.0).",
           "type": "string"
         }

--- a/scripts/docs/ios.privacyManifest.md
+++ b/scripts/docs/ios.privacyManifest.md
@@ -1,0 +1,36 @@
+The privacy manifest is a property list that records the information regarding
+the types of data collected and the required reasons APIs your app or
+third-party SDK use.
+
+- The types of data collected by your app or third-party SDK must be provided on
+  all platforms.
+- The required reasons APIs your app or third-party SDK uses must be provided on
+  iOS, iPadOS, tvOS, visionOS, and watchOS.
+
+By default, a `PrivacyInfo.xcprivacy` is always generated with the following
+values:
+
+```json
+{
+  "NSPrivacyTracking": false,
+  "NSPrivacyTrackingDomains": [],
+  "NSPrivacyCollectedDataTypes": [],
+  "NSPrivacyAccessedAPITypes": [
+    {
+      "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
+      "NSPrivacyAccessedAPITypeReasons": ["C617.1"]
+    },
+    {
+      "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
+      "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+    },
+    {
+      "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+      "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+    }
+  ]
+}
+```
+
+For more details, read Apple's documentation on
+[Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -38,6 +38,7 @@ export async function readDocumentation() {
     "ios.icons",
     "ios.icons.primaryIcon",
     "ios.icons.alternateIcons",
+    "ios.privacyManifest",
     "macos.applicationCategoryType",
     "macos.humanReadableCopyright",
     "windows.appxManifest",

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -47,11 +47,13 @@ export async function readDocumentation() {
     "windows.certificateThumbprint",
   ];
 
-  for (const name of keys) {
-    const filename = path.join(docsDir, name + ".md");
-    const md = await fs.readFile(filename, { encoding: "utf-8" });
-    docs[name] = stripCarriageReturn(md).trim();
-  }
+  await Promise.all(
+    keys.map(async (name) => {
+      const filename = path.join(docsDir, name + ".md");
+      const md = await fs.readFile(filename, { encoding: "utf-8" });
+      docs[name] = stripCarriageReturn(md).trim();
+    })
+  );
 
   return docs;
 }

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -10,7 +10,8 @@ import { readJSONFile } from "./helpers.js";
  */
 function extractBrief(content = "") {
   const endBrief = content.indexOf("\n\n");
-  return endBrief > 0 ? content.substring(0, endBrief) : content;
+  const brief = endBrief > 0 ? content.substring(0, endBrief) : content;
+  return brief.replace(/\r?\n/g, " ");
 }
 
 function readManifest() {
@@ -91,6 +92,11 @@ export function generateSchema(docs = {}) {
             description: extractBrief(docs["ios.developmentTeam"]),
             markdownDescription: docs["ios.developmentTeam"],
             type: "string",
+          },
+          privacyManifest: {
+            description: extractBrief(docs["ios.privacyManifest"]),
+            markdownDescription: docs["ios.privacyManifest"],
+            type: "object",
           },
         },
         "exclude-from-codegen": true,

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -208,6 +208,7 @@ export type Docs = {
   "ios.icons": string;
   "ios.icons.primaryIcon": string;
   "ios.icons.alternateIcons": string;
+  "ios.privacyManifest": string;
   "macos.applicationCategoryType": string;
   "macos.humanReadableCopyright": string;
   "windows.appxManifest": string;

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -145,6 +145,7 @@ describe("npm pack", () => {
       "ios/ReactTestAppUITests/Info.plist",
       "ios/ReactTestAppUITests/ReactTestAppUITests.swift",
       "ios/pod_helpers.rb",
+      "ios/privacy_manifest.rb",
       "ios/test_app.rb",
       "ios/use_react_native-0.64.rb",
       "ios/use_react_native-0.68.rb",

--- a/visionos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/visionos/ReactTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		191A67862BDFCD830094F246 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 191A67852BDFCD830094F246 /* PrivacyInfo.xcprivacy */; };
 		192DD201240FCAF5004E9CEB /* Manifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192DD200240FCAF5004E9CEB /* Manifest.swift */; };
 		196C22622490CB7600449D3C /* React+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 196C22602490CB7600449D3C /* React+Compatibility.m */; };
 		196C7215232F1788006556ED /* ReactInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C7214232F1788006556ED /* ReactInstance.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		191A67852BDFCD830094F246 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		192DD200240FCAF5004E9CEB /* Manifest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Manifest.swift; path = ../Shared/Manifest.swift; sourceTree = "<group>"; };
 		192F052624AD3CC500A48456 /* ReactTestApp.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.release.xcconfig; sourceTree = "<group>"; };
 		192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ReactTestApp.common.xcconfig; sourceTree = "<group>"; };
@@ -48,7 +50,7 @@
 		196C7207232EF5DC006556ED /* ReactTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ReactTestApp-Bridging-Header.h"; path = "../Shared/ReactTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		196C7214232F1788006556ED /* ReactInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReactInstance.swift; path = ../Shared/ReactInstance.swift; sourceTree = "<group>"; };
 		196C7216232F6CD9006556ED /* ReactTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReactTestApp.entitlements; sourceTree = "<group>"; };
-		197827F927710D3400AEC655 /* Manifest+Embedded.g.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Manifest+Embedded.g.swift"; path = "Manifest+Embedded.g.swift"; sourceTree = SOURCE_ROOT; };
+		197827F927710D3400AEC655 /* Manifest+Embedded.g.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Manifest+Embedded.g.swift"; sourceTree = SOURCE_ROOT; };
 		1988282224105BCC005057FF /* UIViewController+ReactTestApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+ReactTestApp.h"; path = "../Shared/UIViewController+ReactTestApp.h"; sourceTree = "<group>"; };
 		1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+ReactTestApp.m"; path = "../Shared/UIViewController+ReactTestApp.m"; sourceTree = "<group>"; };
 		19A624A3258C95F000032776 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Session.swift; path = ../Shared/Session.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				1988284424105BEC005057FF /* UIViewController+ReactTestApp.m */,
 				19ECD0DB232ED427003D8557 /* Assets.xcassets */,
 				19ECD0E3232ED427003D8557 /* Info.plist */,
+				191A67852BDFCD830094F246 /* PrivacyInfo.xcprivacy */,
 				196C7216232F6CD9006556ED /* ReactTestApp.entitlements */,
 				192F052724AD3CC500A48456 /* ReactTestApp.common.xcconfig */,
 				192F052824AD3CC500A48456 /* ReactTestApp.debug.xcconfig */,
@@ -261,6 +264,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				191A67862BDFCD830094F246 /* PrivacyInfo.xcprivacy in Resources */,
 				19ECD0DC232ED427003D8557 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### Description

Add app privacy manifest support.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

Modify privacy manifest via `app.json` e.g.:

```diff
diff --git a/example/app.json b/example/app.json
index 3b8992e..6271cdc 100644
--- a/example/app.json
+++ b/example/app.json
@@ -13,6 +13,12 @@
       "presentationStyle": "modal"
     }
   ],
+  "ios": {
+    "privacyManifest": {
+      "NSPrivacyTrackingDomains": ["test"],
+      "NSPrivacyAccessedAPITypes": ["test"]
+    }
+  },
   "resources": {
     "android": [
       "dist/res",
```

Run `pod install` and verify that a privacy manifest is generated with the expected content. You can verify the content either by opening the workspace in Xcode, or by inspecting `node_modules/.generated/<platform>/PrivacyInfo.xcprivacy`.