### PR TITLE
ci(android): `arguments` and `build-root-directory` are deprecated

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -22,4 +22,5 @@ runs:
       working-directory: ${{ inputs.project-root }}
     - name: Build
       run: ./gradlew ${{ inputs.arguments }}
+      shell: bash
       working-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -21,12 +21,5 @@ runs:
       shell: bash
       working-directory: ${{ inputs.project-root }}
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-version: wrapper
-        gradle-home-cache-excludes: |
-          caches
-          jdks
-        gradle-home-cache-cleanup: true
-        arguments: ${{ inputs.arguments }}
-        build-root-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}
+      run: ./gradlew ${{ inputs.arguments }}
+      working-directory: ${{ steps.build-root-directory-finder.outputs.build-root-directory }}

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -50,6 +50,15 @@ runs:
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+    - name: Set up Gradle
+      if: ${{ inputs.platform == 'android' || inputs.platform == 'node' }}
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-version: wrapper
+        gradle-home-cache-excludes: |
+          caches
+          jdks
+        gradle-home-cache-cleanup: true
     - name: Set up MSBuild
       if: ${{ inputs.platform == 'windows' }}
       uses: microsoft/setup-msbuild@v2

--- a/windows/project.mjs
+++ b/windows/project.mjs
@@ -327,7 +327,7 @@ export function nugetPackage(id, version) {
  */
 export function parseResources(resources, projectPath, fs = nodefs) {
   if (!Array.isArray(resources)) {
-    if (resources && resources.windows) {
+    if (resources?.windows) {
       return parseResources(resources.windows, projectPath, fs);
     }
     return { assetItems: "", assetItemFilters: "", assetFilters: "" };
@@ -373,7 +373,7 @@ export function getBundleResources(manifestFilePath, fs = nodefs) {
         singleApp,
         appxManifest: projectRelativePath(
           projectPath,
-          (windows && windows.appxManifest) || defaultAppxManifest
+          windows?.appxManifest || defaultAppxManifest
         ),
         packageCertificate: generateCertificateItems(
           windows || {},


### PR DESCRIPTION
### Description

> Warning: This job uses deprecated functionality from the 'gradle/actions/setup-gradle' action. Consult the Job Summary for more details.
> DEPRECATION: Using the action to execute Gradle via the `arguments` parameter is deprecated. See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a