### PR TITLE
test: automatically pick latest iPhone simulator

### DIFF
--- a/example/test/specs/wdio.config.js
+++ b/example/test/specs/wdio.config.js
@@ -1,8 +1,52 @@
 // @ts-check
-/**
- * @typedef {import("webdriverio").RemoteOptions["logLevel"]} LogLevel;
- * @typedef {import("webdriverio").RemoteOptions["runner"]} Runner;
- */
+/** @typedef {import("webdriverio").RemoteOptions["logLevel"]} LogLevel */
+/** @typedef {import("webdriverio").RemoteOptions["runner"]} Runner */
+
+function getAvailableSimulators(search = "iPhone") {
+  const { spawnSync } = require("node:child_process");
+  const { error, status, stderr, stdout } = spawnSync(
+    "xcrun",
+    ["simctl", "list", "--json", "devices", search, "available"],
+    { encoding: "utf-8" }
+  );
+  if (status !== 0) {
+    console.error(stderr);
+    throw error ?? new Error("Failed go get available iPhone simulators");
+  }
+
+  const { devices } = JSON.parse(stdout);
+  return Object.keys(devices)
+    .sort()
+    .reduce((filtered, runtime) => {
+      const simulators = devices[runtime];
+      if (simulators.length > 0) {
+        filtered[runtime] = simulators;
+      }
+      return filtered;
+    }, /** @type {Record<string, { name: string }[]>} */ ({}));
+}
+
+const findLatestIPhoneSimulator = (() => {
+  /** @type {[string, string]} */
+  let result;
+  return () => {
+    if (!result) {
+      const devices = getAvailableSimulators();
+      const runtimes = Object.keys(devices);
+      const latestRuntime = runtimes[runtimes.length - 1];
+      const sims = devices[latestRuntime];
+      const simulator = sims.find(({ name }) => name.includes("Pro"));
+      result = [
+        simulator?.name ?? "iPhone 15 Pro",
+        latestRuntime
+          .substring("com.apple.CoreSimulator.SimRuntime.iOS-".length)
+          .replace(/-/g, "."),
+      ];
+    }
+    return result;
+  };
+})();
+
 exports.config = {
   runner: /** @type {Runner} */ ("local"),
   port: 4723,
@@ -27,15 +71,17 @@ exports.config = {
           "appium:automationName": "UiAutomator2",
           ...features,
         };
-      case "ios":
+      case "ios": {
+        const [deviceName, platformVersion] = findLatestIPhoneSimulator();
         return {
           platformName: "iOS",
           "appium:app": "com.microsoft.ReactTestApp",
-          "appium:deviceName": "iPhone 15 Pro",
-          "appium:platformVersion": "17.2",
+          "appium:deviceName": deviceName,
+          "appium:platformVersion": platformVersion,
           "appium:automationName": "XCUITest",
           ...features,
         };
+      }
       default:
         throw new Error(`Unknown platform: ${targetPlatform}`);
     }
@@ -43,4 +89,9 @@ exports.config = {
   logLevel: /** @type {LogLevel} */ ("info"),
   waitforTimeout: 60000,
   specFileRetries: 3,
+};
+
+exports.iosSimulatorName = () => {
+  const [deviceName, platformVersion] = findLatestIPhoneSimulator();
+  return `${deviceName} (${platformVersion})`;
 };

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -28,10 +28,7 @@ const getIOSSimulatorName = memo(() => {
   );
   const { status, stdout } = spawnSync(
     process.argv[0],
-    [
-      "--print",
-      `require("${wdioConfig.pathname}").config.capabilities["appium:deviceName"]`,
-    ],
+    ["--print", `require("${wdioConfig.pathname}").iosSimulatorName()`],
     {
       stdio: ["ignore", "pipe", "inherit"],
       env: { TEST_ARGS: "ios" },


### PR DESCRIPTION
### Description

Automatically pick latest iPhone simulator

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run test:matrix
```