### PR TITLE
refactor(apple): move `generate_*` functions to separate files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,14 +25,12 @@ Metrics/MethodLength:
 
 Metrics/CyclomaticComplexity:
   AllowedMethods:
-    - generate_info_plist!
     - make_project!
     - react_native_pods
     - use_test_app_internal!
 
 Metrics/PerceivedComplexity:
   AllowedMethods:
-    - generate_info_plist!
     - make_project!
     - react_native_pods
     - use_test_app_internal!

--- a/ios/assets_catalog.rb
+++ b/ios/assets_catalog.rb
@@ -1,0 +1,46 @@
+require('json')
+
+require_relative('pod_helpers')
+
+def generate_assets_catalog!(project_root, target_platform, destination)
+  xcassets_src = project_path('ReactTestApp/Assets.xcassets', target_platform)
+  xcassets_dst = File.join(destination, File.basename(xcassets_src))
+  FileUtils.rm_rf(xcassets_dst)
+  FileUtils.cp_r(xcassets_src, destination)
+
+  icons = platform_config('icons', project_root, target_platform)
+  primary_icon = icons && icons['primaryIcon']
+  return if primary_icon.nil?
+
+  template = JSON.parse(File.read(File.join(xcassets_src, 'AppIcon.appiconset', 'Contents.json')))
+  app_manifest_dir = File.dirname(find_file('app.json', project_root))
+
+  app_icons = (icons['alternateIcons'] || {}).merge({ 'AppIcon' => primary_icon })
+  app_icons.each do |icon_set_name, app_icon|
+    app_icon_set = File.join(xcassets_dst, "#{icon_set_name}.appiconset")
+    FileUtils.mkdir_p(app_icon_set)
+
+    icon = File.join(app_manifest_dir, app_icon['filename'])
+    extname = File.extname(icon)
+    basename = File.basename(icon, extname)
+
+    images = []
+
+    template['images'].each do |image|
+      scale, size = image.values_at('scale', 'size')
+      width, height = size.split('x')
+      filename = "#{basename}-#{height}@#{scale}#{extname}"
+      images << { 'filename' => filename }.merge(image)
+      fork do
+        output = File.join(app_icon_set, filename)
+        scale = scale.split('x')[0].to_f
+        height = height.to_f * scale
+        width = width.to_f * scale
+        `sips --resampleHeightWidth #{height} #{width} --out "#{output}" "#{icon}"`
+      end
+    end
+
+    contents = JSON.pretty_generate({ 'images' => images, 'info' => template['info'] })
+    File.write(File.join(app_icon_set, 'Contents.json'), contents)
+  end
+end

--- a/ios/info_plist.rb
+++ b/ios/info_plist.rb
@@ -1,0 +1,46 @@
+require('cfpropertylist')
+
+require_relative('pod_helpers')
+
+def generate_info_plist!(project_root, target_platform, destination)
+  manifest = app_manifest(project_root)
+  return if manifest.nil?
+
+  infoplist_src = project_path('ReactTestApp/Info.plist', target_platform)
+  infoplist_dst = File.join(destination, File.basename(infoplist_src))
+
+  plist = CFPropertyList::List.new(file: infoplist_src)
+  info = CFPropertyList.native_types(plist.value)
+
+  resources = resolve_resources(manifest, target_platform)
+  register_fonts!(resources, target_platform, info)
+
+  if target_platform == :macos
+    config = manifest[target_platform.to_s]
+    unless config.nil?
+      category = config['applicationCategoryType']
+      info['LSApplicationCategoryType'] = category unless category.nil?
+      copyright = config['humanReadableCopyright']
+      info['NSHumanReadableCopyright'] = copyright unless copyright.nil?
+    end
+  end
+
+  plist.value = CFPropertyList.guess(info)
+  plist.save(infoplist_dst, CFPropertyList::List::FORMAT_XML, { :formatted => true })
+end
+
+private
+
+def register_fonts!(resources, target_platform, info)
+  font_files = %w[.otf .ttf]
+  fonts = []
+  resources&.each do |filename|
+    fonts << File.basename(filename) if font_files.include?(File.extname(filename))
+  end
+  return if fonts.empty?
+
+  # https://developer.apple.com/documentation/bundleresources/information_property_list/atsapplicationfontspath
+  info['ATSApplicationFontsPath'] = '.' if target_platform == :macos
+  # https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app
+  info['UIAppFonts'] = fonts unless target_platform == :macos
+end

--- a/ios/info_plist.rb
+++ b/ios/info_plist.rb
@@ -14,16 +14,7 @@ def generate_info_plist!(project_root, target_platform, destination)
 
   resources = resolve_resources(manifest, target_platform)
   register_fonts!(resources, target_platform, info)
-
-  if target_platform == :macos
-    config = manifest[target_platform.to_s]
-    unless config.nil?
-      category = config['applicationCategoryType']
-      info['LSApplicationCategoryType'] = category unless category.nil?
-      copyright = config['humanReadableCopyright']
-      info['NSHumanReadableCopyright'] = copyright unless copyright.nil?
-    end
-  end
+  set_macos_properties!(manifest, target_platform, info)
 
   plist.value = CFPropertyList.guess(info)
   plist.save(infoplist_dst, CFPropertyList::List::FORMAT_XML, { :formatted => true })
@@ -43,4 +34,17 @@ def register_fonts!(resources, target_platform, info)
   info['ATSApplicationFontsPath'] = '.' if target_platform == :macos
   # https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app
   info['UIAppFonts'] = fonts unless target_platform == :macos
+end
+
+def set_macos_properties!(manifest, target_platform, info)
+  return unless target_platform == :macos
+
+  config = manifest[target_platform.to_s]
+  return if config.nil?
+
+  category = config['applicationCategoryType']
+  info['LSApplicationCategoryType'] = category unless category.nil?
+
+  copyright = config['humanReadableCopyright']
+  info['NSHumanReadableCopyright'] = copyright unless copyright.nil?
 end

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -58,6 +58,10 @@ def platform_config(key, project_root, target_platform)
   config[key] if !config.nil? && !config.empty?
 end
 
+def project_path(file, target_platform)
+  File.expand_path(file, File.join(__dir__, '..', target_platform.to_s))
+end
+
 def resolve_module(request, start_dir = Pod::Config.instance.installation_root)
   @module_cache ||= {}
   return @module_cache[request] if @module_cache.key?(request)
@@ -76,6 +80,13 @@ def resolve_module_uncached(request, start_dir)
   raise "Cannot find module '#{request}'" if package_json.nil?
 
   package_json.dirname
+end
+
+def resolve_resources(manifest, target_platform)
+  resources = manifest['resources']
+  return if !resources || resources.empty?
+
+  resources.instance_of?(Array) ? resources : resources[target_platform.to_s]
 end
 
 def supports_new_architecture?(react_native_version)

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -144,6 +144,8 @@ describe("npm pack", () => {
       "ios/ReactTestAppTests/ReactTestAppTests.swift",
       "ios/ReactTestAppUITests/Info.plist",
       "ios/ReactTestAppUITests/ReactTestAppUITests.swift",
+      "ios/assets_catalog.rb",
+      "ios/info_plist.rb",
       "ios/pod_helpers.rb",
       "ios/privacy_manifest.rb",
       "ios/test_app.rb",


### PR DESCRIPTION
### Description

Move `generate_*` functions to separate files

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a