### PR TITLE
fix(android): ensure generated assets are included

### DIFF
--- a/test-app.gradle
+++ b/test-app.gradle
@@ -132,14 +132,14 @@ ext.applyTestAppModule = { Project project ->
         androidResourceFiles.remove(androidResDir)
     }
 
-    def generatedAssetsDir = file("${buildDir}/generated/rncli/src/main/assets/")
+    def generatedAssetsDir = file("${buildDir}/generated/rnta/src/main/assets/")
     generatedAssetsDir.mkdirs()
 
-    def generatedResDir = file("${buildDir}/generated/rncli/src/main/res/")
+    def generatedResDir = file("${buildDir}/generated/rnta/src/main/res/")
     generatedResDir.mkdirs()
 
     // https://github.com/react-native-community/cli/blob/be880b86cdb3f4ea104cf232b95d11f84613321b/packages/cli-platform-android/native_modules.gradle#L534
-    def generatedSrcDir = file("${buildDir}/generated/rncli/src/main/java/")
+    def generatedSrcDir = file("${buildDir}/generated/rnta/src/main/java/")
     generatedSrcDir.mkdirs()
 
     // https://github.com/facebook/react-native/blob/3dfedbc1aec18a4255e126fde96d5dc7b1271ea7/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.java#L25
@@ -209,6 +209,7 @@ ext.applyTestAppModule = { Project project ->
     android {
         sourceSets {
             main {
+                java.srcDirs += generatedSrcDir
                 assets.srcDirs += generatedAssetsDir
                 res.srcDirs += generatedResDir
                 if (manifest.containsKey("android") && manifest["android"].containsKey("icons")) {


### PR DESCRIPTION
### Description

Ensure generated assets are included. By using our own directory, we also avoid clashes and things will still work even if `generated/rncli/src/main/*` goes away in the future.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example
yarn build:android
yarn android
```