### PR TITLE
refactor(apple): use xcodeproj's built-in plist support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'CFPropertyList'
 gem 'minitest'
 gem 'rubocop', require: false
 gem 'rubocop-minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  CFPropertyList
   minitest
   rubocop
   rubocop-minitest

--- a/ios/entitlements.rb
+++ b/ios/entitlements.rb
@@ -1,4 +1,4 @@
-require('cfpropertylist')
+require('xcodeproj')
 
 require_relative('pod_helpers')
 
@@ -21,9 +21,6 @@ def generate_entitlements!(project_root, target_platform, destination)
 
   entitlements = target_platform == :macos ? DEFAULT_MACOS_ENTITLEMENTS : DEFAULT_IOS_ENTITLEMENTS
 
-  plist = CFPropertyList::List.new
-  plist.value = CFPropertyList.guess(entitlements.merge(user_entitlements || {}))
-  plist.save(File.join(destination, 'App.entitlements'),
-             CFPropertyList::List::FORMAT_XML,
-             { :formatted => true })
+  Xcodeproj::Plist.write_to_path(entitlements.merge(user_entitlements || {}),
+                                 File.join(destination, 'App.entitlements'))
 end

--- a/ios/info_plist.rb
+++ b/ios/info_plist.rb
@@ -1,4 +1,4 @@
-require('cfpropertylist')
+require('xcodeproj')
 
 require_relative('pod_helpers')
 
@@ -9,15 +9,13 @@ def generate_info_plist!(project_root, target_platform, destination)
   infoplist_src = project_path('ReactTestApp/Info.plist', target_platform)
   infoplist_dst = File.join(destination, File.basename(infoplist_src))
 
-  plist = CFPropertyList::List.new(file: infoplist_src)
-  info = CFPropertyList.native_types(plist.value)
+  info = Xcodeproj::Plist.read_from_path(infoplist_src)
 
   resources = resolve_resources(manifest, target_platform)
   register_fonts!(resources, target_platform, info)
   set_macos_properties!(manifest, target_platform, info)
 
-  plist.value = CFPropertyList.guess(info)
-  plist.save(infoplist_dst, CFPropertyList::List::FORMAT_XML, { :formatted => true })
+  Xcodeproj::Plist.write_to_path(info, infoplist_dst)
 end
 
 private

--- a/ios/privacy_manifest.rb
+++ b/ios/privacy_manifest.rb
@@ -1,4 +1,4 @@
-require('cfpropertylist')
+require('xcodeproj')
 
 require_relative('pod_helpers')
 
@@ -51,9 +51,5 @@ def generate_privacy_manifest!(project_root, target_platform, destination)
     end
   end
 
-  plist = CFPropertyList::List.new
-  plist.value = CFPropertyList.guess(privacy)
-  plist.save(File.join(destination, 'PrivacyInfo.xcprivacy'),
-             CFPropertyList::List::FORMAT_XML,
-             { :formatted => true })
+  Xcodeproj::Plist.write_to_path(privacy, File.join(destination, 'PrivacyInfo.xcprivacy'))
 end

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -1,4 +1,3 @@
-require('cfpropertylist')
 require('json')
 require('pathname')
 


### PR DESCRIPTION
### Description

Use xcodeproj's built-in plist support

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a