### PR TITLE
fix(apple): fix `embed-manifest` failing to find `app.json`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,6 @@
           - scripts/embed-manifest/kotlin.mjs
           - scripts/embed-manifest/main.mjs
           - scripts/embed-manifest/validate.mjs
-          - scripts/generate-*.mjs
           - scripts/init.mjs
           - scripts/template.mjs
           - test-app.gradle
@@ -34,7 +33,6 @@
           - scripts/embed-manifest/main.mjs
           - scripts/embed-manifest/swift.mjs
           - scripts/embed-manifest/validate.mjs
-          - scripts/generate-*.mjs
           - scripts/init.mjs
           - scripts/template.mjs
           - scripts/xcodebuild.sh
@@ -63,7 +61,6 @@
           - scripts/embed-manifest/main.mjs
           - scripts/embed-manifest/swift.mjs
           - scripts/embed-manifest/validate.mjs
-          - scripts/generate-*.mjs
           - scripts/init.mjs
           - scripts/template.mjs
           - scripts/xcodebuild.sh
@@ -85,7 +82,6 @@
           - scripts/embed-manifest/main.mjs
           - scripts/embed-manifest/swift.mjs
           - scripts/embed-manifest/validate.mjs
-          - scripts/generate-*.mjs
           - scripts/init.mjs
           - scripts/template.mjs
           - scripts/xcodebuild.sh
@@ -104,7 +100,6 @@
           - scripts/embed-manifest/cpp.mjs
           - scripts/embed-manifest/main.mjs
           - scripts/embed-manifest/validate.mjs
-          - scripts/generate-*.mjs
           - scripts/init.mjs
           - scripts/template.mjs
           - windows/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,13 @@
           - common/**/*
           - example/android/**/*
           - scripts/*.js
-          - test/android-test-app/**/*
+          - scripts/configure.mjs
+          - scripts/embed-manifest/kotlin.mjs
+          - scripts/embed-manifest/main.mjs
+          - scripts/embed-manifest/validate.mjs
+          - scripts/generate-*.mjs
+          - scripts/init.mjs
+          - scripts/template.mjs
           - test-app.gradle
 "platform: iOS":
   - changed-files:
@@ -24,8 +30,14 @@
           - example/ios/**/*
           - ios/**/*
           - scripts/*.js
+          - scripts/configure.mjs
+          - scripts/embed-manifest/main.mjs
+          - scripts/embed-manifest/swift.mjs
+          - scripts/embed-manifest/validate.mjs
+          - scripts/generate-*.mjs
+          - scripts/init.mjs
+          - scripts/template.mjs
           - scripts/xcodebuild.sh
-          - test/*.rb
           - test_app.rb
 "platform: macOS":
   - changed-files:
@@ -47,8 +59,14 @@
           - ios/ReactTestApp/UIViewController+ReactTestApp.{h,m}
           - macos/**/*
           - scripts/*.js
+          - scripts/configure.mjs
+          - scripts/embed-manifest/main.mjs
+          - scripts/embed-manifest/swift.mjs
+          - scripts/embed-manifest/validate.mjs
+          - scripts/generate-*.mjs
+          - scripts/init.mjs
+          - scripts/template.mjs
           - scripts/xcodebuild.sh
-          - test/*.rb
 "platform: visionOS":
   - changed-files:
       - any-glob-to-any-file:
@@ -63,8 +81,14 @@
           - ios/*.rb
           - ios/ReactTestApp/*.{h,m,mm,swift}
           - scripts/*.js
+          - scripts/configure.mjs
+          - scripts/embed-manifest/main.mjs
+          - scripts/embed-manifest/swift.mjs
+          - scripts/embed-manifest/validate.mjs
+          - scripts/generate-*.mjs
+          - scripts/init.mjs
+          - scripts/template.mjs
           - scripts/xcodebuild.sh
-          - test/*.rb
           - visionos/**/*
 "platform: Windows":
   - changed-files:
@@ -76,5 +100,11 @@
           - example/windows/**/*
           - scripts/*.ps1
           - scripts/*.js
-          - test/windows-test-app/**/*
+          - scripts/configure.mjs
+          - scripts/embed-manifest/cpp.mjs
+          - scripts/embed-manifest/main.mjs
+          - scripts/embed-manifest/validate.mjs
+          - scripts/generate-*.mjs
+          - scripts/init.mjs
+          - scripts/template.mjs
           - windows/**/*

--- a/scripts/embed-manifest/swift.mjs
+++ b/scripts/embed-manifest/swift.mjs
@@ -166,14 +166,12 @@ export function generate(json, checksum, fs = nodefs) {
     "",
   ].join("\n");
 
-  const dest = path.join(
-    nodeModulesPath,
-    ".generated",
-    process.env["PLATFORM_FAMILY_NAME"]?.toLowerCase() ?? "ios",
-    "Manifest+Embedded.g.swift"
-  );
+  const projectDir =
+    process.env["PROJECT_DIR"] ??
+    path.join(nodeModulesPath, ".generated", "ios");
+  const dest = path.join(projectDir, "Manifest+Embedded.g.swift");
   fs.promises
-    .mkdir(path.dirname(dest), { recursive: true, mode: 0o755 })
+    .mkdir(projectDir, { recursive: true, mode: 0o755 })
     .then(() => fs.promises.writeFile(dest, code));
   return "app.json -> " + dest;
 }

--- a/scripts/embed-manifest/swift.mjs
+++ b/scripts/embed-manifest/swift.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import * as nodefs from "node:fs";
 import * as path from "node:path";
-import { findFile, isMain } from "../helpers.js";
+import { isMain } from "../helpers.js";
 import { main, warn } from "./main.mjs";
 
 const INDENT = "    ";
@@ -136,14 +136,6 @@ function components(components, level) {
  * @returns {string}
  */
 export function generate(json, checksum, fs = nodefs) {
-  const nodeModulesPath = findFile("node_modules", PODS_ROOT, fs);
-  if (!nodeModulesPath) {
-    console.error(
-      "Failed to find 'node_modules' — make sure you've installed npm dependencies"
-    );
-    return "";
-  }
-
   const code = [
     "import Foundation",
     "",

--- a/scripts/embed-manifest/swift.mjs
+++ b/scripts/embed-manifest/swift.mjs
@@ -5,6 +5,8 @@ import { findFile, isMain } from "../helpers.js";
 import { main, warn } from "./main.mjs";
 
 const INDENT = "    ";
+const SRCROOT =
+  process.env["PODS_ROOT"] || process.env["SRCROOT"] || process.cwd();
 
 /**
  * @param {unknown} s
@@ -134,8 +136,7 @@ function components(components, level) {
  * @returns {string}
  */
 export function generate(json, checksum, fs = nodefs) {
-  const srcRoot = process.env["SRCROOT"] || process.cwd();
-  const nodeModulesPath = findFile("node_modules", srcRoot, fs);
+  const nodeModulesPath = findFile("node_modules", SRCROOT, fs);
   if (!nodeModulesPath) {
     console.error(
       "Failed to find 'node_modules' — make sure you've installed npm dependencies"
@@ -168,7 +169,7 @@ export function generate(json, checksum, fs = nodefs) {
   const dest = path.join(
     nodeModulesPath,
     ".generated",
-    path.basename(srcRoot),
+    process.env["PLATFORM_FAMILY_NAME"]?.toLowerCase() ?? "ios",
     "Manifest+Embedded.g.swift"
   );
   fs.promises
@@ -178,5 +179,5 @@ export function generate(json, checksum, fs = nodefs) {
 }
 
 if (!process.argv[1] || isMain(import.meta.url)) {
-  process.exitCode = main(generate);
+  process.exitCode = main(generate, SRCROOT);
 }

--- a/scripts/embed-manifest/swift.mjs
+++ b/scripts/embed-manifest/swift.mjs
@@ -5,8 +5,8 @@ import { findFile, isMain } from "../helpers.js";
 import { main, warn } from "./main.mjs";
 
 const INDENT = "    ";
-const SRCROOT =
-  process.env["PODS_ROOT"] || process.env["SRCROOT"] || process.cwd();
+const SRCROOT = process.env["SRCROOT"] || process.cwd();
+const PODS_ROOT = process.env["PODS_ROOT"] || SRCROOT;
 
 /**
  * @param {unknown} s
@@ -136,7 +136,7 @@ function components(components, level) {
  * @returns {string}
  */
 export function generate(json, checksum, fs = nodefs) {
-  const nodeModulesPath = findFile("node_modules", SRCROOT, fs);
+  const nodeModulesPath = findFile("node_modules", PODS_ROOT, fs);
   if (!nodeModulesPath) {
     console.error(
       "Failed to find 'node_modules' — make sure you've installed npm dependencies"
@@ -166,16 +166,13 @@ export function generate(json, checksum, fs = nodefs) {
     "",
   ].join("\n");
 
-  const projectDir =
-    process.env["PROJECT_DIR"] ??
-    path.join(nodeModulesPath, ".generated", "ios");
-  const dest = path.join(projectDir, "Manifest+Embedded.g.swift");
+  const dest = path.join(SRCROOT, "Manifest+Embedded.g.swift");
   fs.promises
-    .mkdir(projectDir, { recursive: true, mode: 0o755 })
+    .mkdir(SRCROOT, { recursive: true, mode: 0o755 })
     .then(() => fs.promises.writeFile(dest, code));
   return "app.json -> " + dest;
 }
 
 if (!process.argv[1] || isMain(import.meta.url)) {
-  process.exitCode = main(generate, SRCROOT);
+  process.exitCode = main(generate, PODS_ROOT);
 }


### PR DESCRIPTION
### Description

Fix `embed-manifest` failing to find `app.json`

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

In https://github.com/react-native-webview/react-native-webview:

1. Bump `react-native-test-app` to 3.7.0
2. Install: `yarn`
3. Copy `rnta/scripts/embed-manifest/swift.mjs` to `webview/node_modules/react-native-test-app/scripts/embed-manifest/swift.mjs`
4. Install Pods: `pod install --project-directory=example/ios`
5. Build: `yarn ios`