### PR TITLE
fix(android): ensure `SoLoader` is initialized

### DIFF
--- a/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -7,6 +7,7 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.manifest.Manifest
 import com.microsoft.reacttestapp.manifest.ManifestProvider
 import com.microsoft.reacttestapp.react.ReactBundleNameProvider
@@ -36,6 +37,8 @@ class TestApp : Application(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+
+        SoLoader.init(this, false)
 
         reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)
         reactNativeHostInternal =

--- a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
+import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.manifest.Manifest
 import com.microsoft.reacttestapp.manifest.ManifestProvider
 import com.microsoft.reacttestapp.react.ReactBundleNameProvider
@@ -28,6 +29,8 @@ class TestApp : Application(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+
+        SoLoader.init(this, false)
 
         reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)
         reactNativeHostInternal =


### PR DESCRIPTION
### Description

Ensure `SoLoader` is initialized otherwise it may crash when New Arch is enabled on 0.71

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version 0.71 -- --core-only
yarn
cd example
yarn android --extra-params "-PnewArchEnabled=true"

# In a separate terminal
yarn start
```