### PR TITLE
chore: clean up TypeScript errors when `module: node16`

### DIFF
--- a/scripts/affected.mjs
+++ b/scripts/affected.mjs
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 
 /**
- * @typedef {import("./types").Match} Match
+ * @typedef {import("./types.js").Match} Match
  */
 
 /**

--- a/scripts/apply-config-plugins.mjs
+++ b/scripts/apply-config-plugins.mjs
@@ -7,7 +7,7 @@ import { parseArgs } from "node:util";
 import { findFile } from "./helpers.js";
 
 /**
- * @typedef {import("./config-plugins/types").ProjectInfo["platforms"]} Platforms
+ * @typedef {import("./config-plugins/types.js").ProjectInfo["platforms"]} Platforms
  * @param {string} projectRoot
  * @param {string[]} platforms
  */

--- a/scripts/config-plugins/apply.mjs
+++ b/scripts/config-plugins/apply.mjs
@@ -6,7 +6,7 @@ import { withInternal } from "./plugins/withInternal.mjs";
 
 /**
  * Applies config plugins.
- * @param {import("./types").ProjectInfo} projectInfo
+ * @param {import("./types.js").ProjectInfo} projectInfo
  * @returns {Promise<Awaited<ReturnType<typeof compileModsAsync>> | undefined>}
  */
 export async function applyConfigPlugins({ appJsonPath, ...info }) {

--- a/scripts/config-plugins/plugins/withInternal.mjs
+++ b/scripts/config-plugins/plugins/withInternal.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * @typedef {import("../types").ProjectInfo} ProjectInfo
+ * @typedef {import("../types.js").ProjectInfo} ProjectInfo
  * @typedef {Omit<ProjectInfo, "appJsonPath">} Internals
  */
 /**

--- a/scripts/config-plugins/provider.mjs
+++ b/scripts/config-plugins/provider.mjs
@@ -14,7 +14,7 @@ export function makeNullProvider(defaultRead = {}) {
 /**
  * Creates a mod modifier that just changes `getFilePath()`.
  * @param {string} actualProjectDir
- * @returns {import("./types").CustomModProvider}
+ * @returns {import("./types.js").CustomModProvider}
  */
 export function makeFilePathModifier(actualProjectDir) {
   return function (original, file) {

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -17,8 +17,8 @@ const {
 } = require("./helpers");
 
 /**
- * @typedef {import("./types").ProjectConfig} ProjectConfig
- * @typedef {import("./types").ProjectParams} ProjectParams
+ * @typedef {import("./types.js").ProjectConfig} ProjectConfig
+ * @typedef {import("./types.js").ProjectParams} ProjectParams
  */
 
 /**

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -30,13 +30,13 @@ import {
 } from "./template.mjs";
 
 /**
- * @typedef {import("./types").Configuration} Configuration
- * @typedef {import("./types").ConfigureParams} ConfigureParams
- * @typedef {import("./types").FileCopy} FileCopy
- * @typedef {Required<import("./types").Manifest>} Manifest
- * @typedef {import("./types").PlatformConfiguration} PlatformConfiguration
- * @typedef {import("./types").PlatformPackage} PlatformPackage
- * @typedef {import("./types").Platform} Platform
+ * @typedef {import("./types.js").Configuration} Configuration
+ * @typedef {import("./types.js").ConfigureParams} ConfigureParams
+ * @typedef {import("./types.js").FileCopy} FileCopy
+ * @typedef {Required<import("./types.js").Manifest>} Manifest
+ * @typedef {import("./types.js").PlatformConfiguration} PlatformConfiguration
+ * @typedef {import("./types.js").PlatformPackage} PlatformPackage
+ * @typedef {import("./types.js").Platform} Platform
  */
 
 /**

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -6,7 +6,7 @@ import { generateSchema } from "./schema.mjs";
 
 /**
  * @typedef {import("ajv").SchemaObject} SchemaObject
- * @typedef {import("./types").Language} Language
+ * @typedef {import("./types.js").Language} Language
  */
 const thisScript = fileURLToPath(import.meta.url);
 

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -6,7 +6,7 @@ import { URL, fileURLToPath } from "node:url";
 import { isMain } from "./helpers.js";
 import { generateSchema } from "./schema.mjs";
 
-/** @typedef {import("./types").Docs} Docs */
+/** @typedef {import("./types.js").Docs} Docs */
 
 /** @type {(str: string) => string} */
 const stripCarriageReturn =

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -103,7 +103,7 @@ const getInstalledVersion = memo(() => {
  *   - Currently installed `react-native` version
  *   - Latest version from npm
  *
- * @param {import("./types").Platform[]} platforms
+ * @param {import("./types.js").Platform[]} platforms
  * @returns {Promise<string>}
  */
 async function getVersion(platforms) {
@@ -161,7 +161,7 @@ async function getVersion(platforms) {
 
 /**
  * Returns the React Native version and path to the template.
- * @param {import("./types").Platform[]} platforms
+ * @param {import("./types.js").Platform[]} platforms
  * @returns {Promise<[string] | [string, string]>}
  */
 async function fetchTemplate(platforms) {
@@ -236,7 +236,7 @@ function main() {
          * @type {{
          *   name?: string;
          *   packagePath?: string;
-         *   platforms?: import("./types").Platform[];
+         *   platforms?: import("./types.js").Platform[];
          * }}
          */
         const { name, packagePath, platforms } = await prompts([

--- a/scripts/parseargs.mjs
+++ b/scripts/parseargs.mjs
@@ -4,11 +4,11 @@ import * as path from "node:path";
 import * as util from "node:util";
 
 /**
- * @typedef {import("./types").Options} Options;
+ * @typedef {import("./types.js").Options} Options;
  */
 /**
  * @template {Options} O
- * @typedef {import("./types").Args<O>} Args;
+ * @typedef {import("./types.js").Args<O>} Args;
  */
 
 /**

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -2,7 +2,7 @@
 import { URL, fileURLToPath } from "node:url";
 import { readJSONFile } from "./helpers.js";
 
-/** @typedef {import("./types").Docs} Docs */
+/** @typedef {import("./types.js").Docs} Docs */
 
 /**
  * @param {string} content

--- a/scripts/set-react-version.mjs
+++ b/scripts/set-react-version.mjs
@@ -18,7 +18,7 @@ import {
 } from "./helpers.js";
 
 /**
- * @typedef {import("./types").Manifest} Manifest
+ * @typedef {import("./types.js").Manifest} Manifest
  */
 
 const VALID_TAGS = ["canary-macos", "canary-windows", "nightly"];

--- a/test/android-test-app/gradle.mjs
+++ b/test/android-test-app/gradle.mjs
@@ -28,7 +28,7 @@ function projectPath(name) {
 /**
  * Initializes a React Native project.
  * @param {string} name
- * @param {import("../../scripts/types").ConfigureParams["platforms"]} platforms
+ * @param {import("../../scripts/types.js").ConfigureParams["platforms"]} platforms
  * @param {Record<string, string | string[]>=} setupFiles
  */
 async function makeProject(name, platforms, setupFiles = {}) {
@@ -115,7 +115,7 @@ function runGradle(cwd, ...args) {
 /**
  * Initializes a new React Native project and runs Gradle.
  * @param {string} name
- * @param {import("../../scripts/types").ConfigureParams["platforms"]} platforms
+ * @param {import("../../scripts/types.js").ConfigureParams["platforms"]} platforms
  * @param {Record<string, string | string[]>=} setupFiles
  */
 export async function runGradleWithProject(name, platforms, setupFiles = {}) {

--- a/test/configure/gatherConfig.test.mjs
+++ b/test/configure/gatherConfig.test.mjs
@@ -14,8 +14,8 @@ describe("gatherConfig()", () => {
    * File content should not be normalized because they should only contain
    * forward-slashes.
    *
-   * @param {import("../../scripts/types").ConfigureParams} params
-   * @returns {import("../../scripts/types").Configuration}
+   * @param {import("../../scripts/types.js").ConfigureParams} params
+   * @returns {import("../../scripts/types.js").Configuration}
    */
   function gatherConfig(params) {
     /** @type {(p: string) => string} */

--- a/test/configure/getConfig.test.mjs
+++ b/test/configure/getConfig.test.mjs
@@ -15,8 +15,8 @@ describe("getConfig()", () => {
 
   /**
    * Gets the list of dependencies from specified config.
-   * @param {import("../../scripts/types").Platform} platform
-   * @param {import("../../scripts/types").ConfigureParams} params
+   * @param {import("../../scripts/types.js").Platform} platform
+   * @param {import("../../scripts/types.js").ConfigureParams} params
    * @returns {string[] | undefined}
    */
   function getDependencies(platform, { targetVersion }) {

--- a/test/configure/mockParams.mjs
+++ b/test/configure/mockParams.mjs
@@ -3,8 +3,8 @@
 
 /**
  * Returns mock parameters.
- * @param {Partial<import("../../scripts/types").ConfigureParams>} [overrides]
- * @returns {import("../../scripts/types").ConfigureParams}
+ * @param {Partial<import("../../scripts/types.js").ConfigureParams>} [overrides]
+ * @returns {import("../../scripts/types.js").ConfigureParams}
  */
 export function mockParams(overrides) {
   return {

--- a/test/configure/reactNativeConfig.test.mjs
+++ b/test/configure/reactNativeConfig.test.mjs
@@ -5,7 +5,7 @@ import { reactNativeConfig as reactNativeConfigActual } from "../../scripts/conf
 import { mockParams } from "./mockParams.mjs";
 
 describe("reactNativeConfig()", () => {
-  /** @type {(params: import("../../scripts/types").ConfigureParams) => string} */
+  /** @type {(params: import("../../scripts/types.js").ConfigureParams) => string} */
   const reactNativeConfig = (params) => {
     const config = reactNativeConfigActual(params);
     if (typeof config !== "string") {

--- a/windows/project.mjs
+++ b/windows/project.mjs
@@ -17,12 +17,12 @@ import {
 import { fileURLToPath } from "node:url";
 
 /**
- * @typedef {import("../scripts/types").AppManifest} AppManifest
- * @typedef {import("../scripts/types").AppxBundle} AppxBundle
- * @typedef {import("../scripts/types").AssetItems} AssetItems;
- * @typedef {import("../scripts/types").Assets} Assets;
- * @typedef {import("../scripts/types").MSBuildProjectOptions} MSBuildProjectOptions;
- * @typedef {import("../scripts/types").ProjectInfo} ProjectInfo;
+ * @typedef {import("../scripts/types.js").AppManifest} AppManifest
+ * @typedef {import("../scripts/types.js").AppxBundle} AppxBundle
+ * @typedef {import("../scripts/types.js").AssetItems} AssetItems;
+ * @typedef {import("../scripts/types.js").Assets} Assets;
+ * @typedef {import("../scripts/types.js").MSBuildProjectOptions} MSBuildProjectOptions;
+ * @typedef {import("../scripts/types.js").ProjectInfo} ProjectInfo;
  */
 
 const uniqueFilterIdentifier = "e48dc53e-40b1-40cb-970a-f89935452892";

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -19,7 +19,7 @@ import { configureForUWP } from "./uwp.mjs";
 import { configureForWin32 } from "./win32.mjs";
 
 /**
- * @typedef {import("../scripts/types").MSBuildProjectOptions} MSBuildProjectOptions;
+ * @typedef {import("../scripts/types.js").MSBuildProjectOptions} MSBuildProjectOptions;
  */
 
 const templateView = {
@@ -182,7 +182,7 @@ export function generateSolution(destPath, options, fs = nodefs) {
     .map((project) => toProjectEntry(project, destPath))
     .join(os.EOL);
 
-  /** @type {import("mustache")} */
+  /** @type {typeof import("mustache")} */
   const mustache = requireTransitive(
     ["@react-native-windows/cli", "mustache"],
     rnWindowsPath

--- a/windows/uwp.mjs
+++ b/windows/uwp.mjs
@@ -2,7 +2,7 @@
 import * as path from "node:path";
 import { importTargets, nugetPackage } from "./project.mjs";
 
-/** @type {import("../scripts/types").MSBuildProjectConfigurator} */
+/** @type {import("../scripts/types.js").MSBuildProjectConfigurator} */
 export function configureForUWP(
   {
     bundle,
@@ -15,7 +15,7 @@ export function configureForUWP(
   },
   { useNuGet }
 ) {
-  /** @type {import("../scripts/types").MSBuildProjectParams["projectFiles"]} */
+  /** @type {import("../scripts/types.js").MSBuildProjectParams["projectFiles"]} */
   const projectFiles = [
     ["Assets"],
     ["AutolinkedNativeModules.g.cpp"],

--- a/windows/win32.mjs
+++ b/windows/win32.mjs
@@ -2,7 +2,7 @@
 import * as path from "node:path";
 import { importTargets } from "./project.mjs";
 
-/** @type {import("../scripts/types").MSBuildProjectConfigurator} */
+/** @type {import("../scripts/types.js").MSBuildProjectConfigurator} */
 export function configureForWin32(
   { bundle, nugetDependencies, versionNumber },
   _options


### PR DESCRIPTION
### Description

Clean up TypeScript errors when `module: node16`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Change both `module` and `moduleResolution` to `Node16` (or simply remove them since that's what `@rnx-kit/tsconfig/tsconfig.esm.json` defaults to):

```diff
diff --git a/tsconfig.esm.json b/tsconfig.esm.json
index b229154..d8132f3 100644
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "@rnx-kit/tsconfig/tsconfig.esm.json",
   "compilerOptions": {
-    "module": "ES2022",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noEmit": true
   },
   "include": [
```

Run `yarn lint:js`. There will be some errors left, most notable related to ajv, cliui, mustache, and webdriverio. I will fix them separately if I get around to investigating the root cause.