### PR TITLE
ci: enable npm provenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -656,6 +656,7 @@ jobs:
   release:
     permissions:
       contents: write # create releases (semantic-release)
+      id-token: write # enable use of OIDC for npm provenance (semantic-release)
     needs:
       - review
       - ios


### PR DESCRIPTION
### Description

Details here: https://github.com/semantic-release/npm#npm-provenance

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a