### PR TITLE
fix(android): allow for disabling bridgeless

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -210,7 +210,7 @@ android {
 
             !enableNewArchitecture
                 ? "src/old-arch/java"
-                : enableBridgeless
+                : reactNativeVersion >= v(0, 73, 0)
                     ? "src/new-arch-0.73/java"
                     : "src/new-arch/java",
 


### PR DESCRIPTION
### Description

This PR fixes disabling bridgeless on RN `>= 0.74` where it is enabled by default (and therefore needs to be explicitly disabled now). Found during integration of `react-native-test-app` into `@callstack/repack`: https://github.com/callstack/repack/pull/629

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

- [x] - verified bridgeless can be disabled on android on 0.74
- [x] - `yarn test:matrix 0.74` passes

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
