### PR TITLE
chore: migrate `wdio.config.js` -> `wdio.config.mjs`

### DIFF
--- a/example/test/specs/app.spec.mjs
+++ b/example/test/specs/app.spec.mjs
@@ -3,7 +3,7 @@ import { equal } from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { remote } from "webdriverio";
 import { findNearest, readTextFile } from "../../../scripts/helpers.js";
-import { config } from "./wdio.config.js";
+import { config } from "./wdio.config.mjs";
 
 /**
  * @typedef {Awaited<ReturnType<typeof import("webdriverio").remote>>} Browser

--- a/example/test/specs/wdio.config.mjs
+++ b/example/test/specs/wdio.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
-const { spawnSync } = require("node:child_process");
-const fs = require("node:fs");
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
 
 /** @typedef {import("webdriverio").RemoteOptions["logLevel"]} LogLevel */
 /** @typedef {import("webdriverio").RemoteOptions["runner"]} Runner */
@@ -111,7 +111,7 @@ const findLatestIPhoneSimulator = (() => {
   };
 })();
 
-exports.config = {
+export const config = {
   runner: /** @type {Runner} */ ("local"),
   port: 4723,
   specs: ["**/*.spec.js"],
@@ -155,7 +155,7 @@ exports.config = {
   specFileRetries: 3,
 };
 
-exports.iosSimulatorName = () => {
+export function iosSimulatorName() {
   const [deviceName, platformVersion] = findLatestIPhoneSimulator();
   return `${deviceName} (${platformVersion})`;
-};
+}

--- a/scripts/test-matrix.mjs
+++ b/scripts/test-matrix.mjs
@@ -23,12 +23,15 @@ const rootDir = fileURLToPath(new URL("..", import.meta.url));
 
 const getIOSSimulatorName = memo(() => {
   const wdioConfig = new URL(
-    "../example/test/specs/wdio.config.js",
+    "../example/test/specs/wdio.config.mjs",
     import.meta.url
   );
   const { status, stdout } = spawnSync(
     process.argv[0],
-    ["--print", `require("${wdioConfig.pathname}").iosSimulatorName()`],
+    [
+      "--eval",
+      `import("${fileURLToPath(wdioConfig)}").then((config) => console.log(config.iosSimulatorName()))`,
+    ],
     {
       stdio: ["ignore", "pipe", "inherit"],
       env: { TEST_ARGS: "ios" },
@@ -37,7 +40,7 @@ const getIOSSimulatorName = memo(() => {
   );
   if (status !== 0) {
     throw new Error(
-      "An error occurred while trying to evaluate 'wdio.config.js'"
+      "An error occurred while trying to evaluate 'wdio.config.mjs'"
     );
   }
   return stdout.trim();


### PR DESCRIPTION
### Description

Migrate `wdio.config.js` -> `wdio.config.mjs`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run test:matrix
```