### PR TITLE
refactor(apple): use `SCRIPT_OUTPUT_FILE_0` instead of path

### DIFF
--- a/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"$SRCROOT/Manifest+Embedded.g.swift\"\n";
+			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"$SRCROOT/Manifest+Embedded.g.swift\"\n";
+			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/visionos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/visionos/ReactTestApp.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"$SRCROOT/Manifest+Embedded.g.swift\"\n";
+			shellScript = "source .env\nnode -e \"import('react-native-test-app/scripts/embed-manifest/swift.mjs')\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
### Description

Use `SCRIPT_OUTPUT_FILE_0` instead of repeating path

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

CI should pass.