### PR TITLE
fix(android): set `packageName` to ensure correct app launches

### DIFF
--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -24,26 +24,32 @@ const {
  */
 
 /**
- * Returns the version number of `@react-native-community/cli-platform-ios`.
- * @param {string} reactNativeDir
+ * Returns the version number of a React Native dependency.
+ * @param {string} packageName
  * @returns {number}
  */
-const cliPlatformIOSVersion = (() => {
-  /** @type {number} */
-  let version;
-  /** @type {(reactNativeDir: string) => number} */
-  return (reactNativeDir) => {
-    if (!version) {
-      version = toVersionNumber(
-        getPackageVersion(
-          "@react-native-community/cli-platform-ios",
-          reactNativeDir
-        )
-      );
+const getRNPackageVersion = (() => {
+  const isTesting = "NODE_TEST_CONTEXT" in process.env;
+  /** @type {Record<string, number>} */
+  let versions = {};
+  /** @type {(packageName: string) => number} */
+  return (packageName, fs = nodefs) => {
+    if (isTesting || !versions[packageName]) {
+      const rnDir = path.dirname(require.resolve("react-native/package.json"));
+      const versionString = getPackageVersion(packageName, rnDir, fs);
+      versions[packageName] = toVersionNumber(versionString);
     }
-    return version;
+    return versions[packageName];
   };
 })();
+
+/**
+ * Returns the version number of `@react-native-community/cli-platform-ios`.
+ * @returns {number}
+ */
+function cliPlatformIOSVersion() {
+  return getRNPackageVersion("@react-native-community/cli-platform-ios");
+}
 
 /**
  * Configures Gradle wrapper as necessary before the Android app is built.
@@ -125,6 +131,19 @@ function getAndroidPackageName(sourceDir, fs = nodefs) {
     return undefined;
   }
 
+  const rncliAndroidVersion = getRNPackageVersion(
+    "@react-native-community/cli-platform-android",
+    fs
+  );
+  if (rncliAndroidVersion < v(12, 3, 7)) {
+    // TODO: This block can be removed when we drop support for 0.72
+    return undefined;
+  }
+  if (rncliAndroidVersion >= v(13, 0, 0) && rncliAndroidVersion < v(13, 6, 9)) {
+    // TODO: This block can be removed when we drop support for 0.73
+    return undefined;
+  }
+
   /** @type {{ android?: { package?: string }}} */
   const manifest = readJSONFile(manifestPath, fs);
   return manifest.android?.package;
@@ -152,8 +171,7 @@ function androidManifestPath(sourceDir) {
  * @returns {string | undefined}
  */
 function iosProjectPath() {
-  const rnDir = path.dirname(require.resolve("react-native/package.json"));
-  const needsProjectPath = cliPlatformIOSVersion(rnDir) < v(8, 0, 0);
+  const needsProjectPath = cliPlatformIOSVersion() < v(8, 0, 0);
   if (needsProjectPath) {
     // `sourceDir` and `podfile` detection was fixed in
     // @react-native-community/cli-platform-ios v5.0.2 (see
@@ -181,7 +199,11 @@ function windowsProjectPath(solutionFile, fs = nodefs) {
  * @returns {Partial<ProjectParams>}
  */
 function configureProjects({ android, ios, windows }, fs = nodefs) {
-  const reactNativeConfig = findNearest("react-native.config.js");
+  const reactNativeConfig = findNearest(
+    "react-native.config.js",
+    undefined,
+    fs
+  );
   if (!reactNativeConfig) {
     throw new Error("Failed to find `react-native.config.js`");
   }
@@ -203,8 +225,7 @@ function configureProjects({ android, ios, windows }, fs = nodefs) {
   if (ios) {
     // `ios.sourceDir` was added in 8.0.0
     // https://github.com/react-native-community/cli/commit/25eec7c695f09aea0ace7c0b591844fe8828ccc5
-    const rnDir = path.dirname(require.resolve("react-native/package.json"));
-    if (cliPlatformIOSVersion(rnDir) >= v(8, 0, 0)) {
+    if (cliPlatformIOSVersion() >= v(8, 0, 0)) {
       config.ios = ios;
     }
     const project = iosProjectPath();
@@ -228,3 +249,4 @@ function configureProjects({ android, ios, windows }, fs = nodefs) {
 
 exports.cliPlatformIOSVersion = cliPlatformIOSVersion;
 exports.configureProjects = configureProjects;
+exports.internalForTestingPurposesOnly = { getAndroidPackageName };

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -318,7 +318,7 @@ export const getConfig = (() => {
               if (toVersionNumber(targetVersion) < v(0, 73, 0)) {
                 return props.replace(
                   /gradle-[.0-9]*-bin\.zip/,
-                  "gradle-7.6.3-bin.zip"
+                  "gradle-7.6.4-bin.zip"
                 );
               }
               return props;

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -228,9 +228,8 @@ export const getConfig = (() => {
       }
 
       const require = createRequire(import.meta.url);
-      const rnDir = path.dirname(require.resolve("react-native/package.json"));
       const projectPathFlag =
-        flatten && cliPlatformIOSVersion(rnDir) < v(8, 0, 0)
+        flatten && cliPlatformIOSVersion() < v(8, 0, 0)
           ? " --project-path ."
           : "";
       const templateDir =

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -40,12 +40,6 @@ export type ConfigureParams = {
   init: boolean;
 };
 
-export type ProjectConfig = {
-  android?: { sourceDir: string; packageName?: string };
-  ios?: { sourceDir: string };
-  windows?: { sourceDir: string; solutionFile: string };
-};
-
 export type ProjectParams = {
   android: {
     sourceDir: string;
@@ -61,6 +55,12 @@ export type ProjectParams = {
     solutionFile: string;
     project: { projectFile: string };
   };
+};
+
+export type ProjectConfig = {
+  android?: Pick<ProjectParams["android"], "sourceDir" | "packageName">;
+  ios?: Pick<ProjectParams["ios"], "sourceDir">;
+  windows?: Pick<ProjectParams["windows"], "sourceDir" | "solutionFile">;
 };
 
 /*****************

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -41,7 +41,7 @@ export type ConfigureParams = {
 };
 
 export type ProjectConfig = {
-  android?: { sourceDir: string };
+  android?: { sourceDir: string; packageName?: string };
   ios?: { sourceDir: string };
   windows?: { sourceDir: string; solutionFile: string };
 };
@@ -50,6 +50,7 @@ export type ProjectParams = {
   android: {
     sourceDir: string;
     manifestPath: string;
+    packageName?: string;
   };
   ios: {
     sourceDir?: string;

--- a/test/configure-projects.test.mjs
+++ b/test/configure-projects.test.mjs
@@ -1,0 +1,134 @@
+import { deepEqual, equal } from "node:assert/strict";
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+  configureProjects,
+  internalForTestingPurposesOnly,
+} from "../scripts/configure-projects.js";
+
+describe("configureProjects()", () => {
+  it("returns empty config", () => {
+    deepEqual(configureProjects({}), {});
+  });
+
+  it("returns Android config", () => {
+    const sourceDir = "android";
+
+    deepEqual(configureProjects({ android: { sourceDir } }), {
+      android: {
+        sourceDir,
+        manifestPath: "app/src/main/AndroidManifest.xml",
+        packageName: undefined,
+      },
+    });
+  });
+
+  it("returns Android config with package name", () => {
+    const sourceDir = "android";
+    const packageName = "com.testapp";
+    const project = configureProjects({ android: { sourceDir, packageName } });
+
+    deepEqual(project, {
+      android: {
+        sourceDir,
+        manifestPath: "app/src/main/AndroidManifest.xml",
+        packageName,
+      },
+    });
+  });
+
+  it("returns iOS config", () => {
+    const sourceDir = "ios";
+    const config = { ios: { sourceDir } };
+
+    deepEqual(configureProjects(config), config);
+  });
+
+  it("returns Windows config", () => {
+    const sourceDir = "windows";
+    const solutionFile = "windows/Example.sln";
+    const vcxproj = "..\\node_modules\\.generated\\windows\\ReactApp.vcxproj";
+    const project = configureProjects(
+      { windows: { sourceDir, solutionFile } },
+      {
+        ...nodefs,
+        existsSync: (p) => {
+          return (
+            p === solutionFile ||
+            p.toString().endsWith("react-native.config.js")
+          );
+        },
+        // @ts-expect-error Type 'string' is not assignable to type 'Buffer'
+        readFileSync: (p, options) => {
+          return p === solutionFile ? vcxproj : nodefs.readFileSync(p, options);
+        },
+      }
+    );
+
+    deepEqual(project, {
+      windows: {
+        sourceDir,
+        solutionFile: path.relative(sourceDir, solutionFile),
+        project: {
+          projectFile: vcxproj,
+        },
+      },
+    });
+  });
+});
+
+describe("getAndroidPackageName()", () => {
+  const { getAndroidPackageName } = internalForTestingPurposesOnly;
+
+  const packageId = "com.testapp";
+
+  /**
+   * @param {string} cliPlatformAndroidVersion
+   * @returns {typeof nodefs}
+   */
+  function mockfs(cliPlatformAndroidVersion) {
+    const appManifest = "app.json";
+    const cliPlatformAndroidPackageManifest =
+      /@react-native-community[/\\]cli-platform-android[/\\]package.json$/;
+    return {
+      ...nodefs,
+      existsSync: (p) => p === appManifest,
+      // @ts-expect-error Type 'string' is not assignable to type 'Buffer'
+      readFileSync: (p) => {
+        if (p === appManifest) {
+          return JSON.stringify({ android: { package: packageId } });
+        } else if (
+          typeof p === "string" &&
+          cliPlatformAndroidPackageManifest.test(p)
+        ) {
+          return JSON.stringify({
+            name: "@react-native-community/cli-platform-android",
+            version: cliPlatformAndroidVersion,
+          });
+        }
+        throw new Error(`Tried to read '${p}'`);
+      },
+    };
+  }
+
+  it("returns early if app manifest cannot be found", () => {
+    equal(getAndroidPackageName("android"), undefined);
+  });
+
+  it("returns early if `@react-native-community/cli-platform-android` <12.3.7", () => {
+    equal(getAndroidPackageName("android", mockfs("12.3.6")), undefined);
+  });
+
+  it("returns package name if `@react-native-community/cli-platform-android` >=12.3.7 <13.0.0", () => {
+    equal(getAndroidPackageName("android", mockfs("12.3.7")), packageId);
+  });
+
+  it("returns early if `@react-native-community/cli-platform-android` <13.6.9", () => {
+    equal(getAndroidPackageName("android", mockfs("13.6.8")), undefined);
+  });
+
+  it("returns package name `@react-native-community/cli-platform-android` >=13.6.9", () => {
+    equal(getAndroidPackageName("android", mockfs("13.6.9")), packageId);
+  });
+});

--- a/test/configure-projects.test.mjs
+++ b/test/configure-projects.test.mjs
@@ -8,6 +8,8 @@ import {
 } from "../scripts/configure-projects.js";
 
 describe("configureProjects()", () => {
+  const manifestPath = path.join("app", "src", "main", "AndroidManifest.xml");
+
   it("returns empty config", () => {
     deepEqual(configureProjects({}), {});
   });
@@ -18,7 +20,7 @@ describe("configureProjects()", () => {
     deepEqual(configureProjects({ android: { sourceDir } }), {
       android: {
         sourceDir,
-        manifestPath: "app/src/main/AndroidManifest.xml",
+        manifestPath,
         packageName: undefined,
       },
     });
@@ -29,13 +31,7 @@ describe("configureProjects()", () => {
     const packageName = "com.testapp";
     const project = configureProjects({ android: { sourceDir, packageName } });
 
-    deepEqual(project, {
-      android: {
-        sourceDir,
-        manifestPath: "app/src/main/AndroidManifest.xml",
-        packageName,
-      },
-    });
+    deepEqual(project, { android: { sourceDir, manifestPath, packageName } });
   });
 
   it("returns iOS config", () => {


### PR DESCRIPTION
### Description

Set `packageName` to ensure correct app launches. This affects Android devs that have several copies of RNTA installed on their device.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example
node --print 'require("./react-native.config.js")'

# Set `android.package` in `app.json` to something other than `com.microsoft.reacttestapp`
node --print 'require("./react-native.config.js")'
```

In both cases, verify that `packageName` is correctly set.