### PR TITLE
fix: `configure` throws when `package.json` is missing

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -649,6 +649,12 @@ export function configure(params, fs = nodefs) {
 
   writeAllFiles(files, packagePath).then(() => {
     const packageManifest = path.join(packagePath, "package.json");
+    if (!fs.existsSync(packageManifest)) {
+      // We cannot assume that the app itself is an npm package. Some libraries
+      // have an 'example' folder inside the package.
+      return;
+    }
+
     const newPackageManifest = updatePackageManifest(packageManifest, config);
     fs.writeFile(
       packageManifest,


### PR DESCRIPTION
### Description

`configure` throws when `package.json` is missing

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
git clone https://github.com/react-native-async-storage/async-storage.git
cd async-storage
yarn
cd packages/default-storage/example
yarn configure-test-app -p android -p ios -f
```