### PR TITLE
fix(android): handle `DevServerHelper` constructor signature change

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -233,15 +233,19 @@ android {
                         ? "src/reactactivitydelegate-0.72/java"
                         : "src/reactactivitydelegate-pre-0.72/java",
 
-            // TODO: Remove this block when we drop support for 0.73
-            // https://github.com/facebook/react-native/commit/cfa02eec50469059542ccbacbc51643b525ad461
-            reactNativeVersion >= v(0, 74, 0)
-                ? "src/devserverhelper-0.74/java"
-                // TODO: Remove this block when we drop support for 0.72
-                // https://github.com/facebook/react-native/commit/da358d0ec7a492edb804b9cdce70e7516ee518ae
-                : reactNativeVersion >= v(0, 73, 0)
-                    ? "src/devserverhelper-0.73/java"
-                    : "src/devserverhelper-pre-0.73/java",
+            // TODO: Remove this block when we drop support for 0.74
+            // https://github.com/facebook/react-native/commit/a1e81185416a53c7c7d0cfc67e40079fd0073e7c
+            reactNativeVersion >= v(0, 75, 0)
+                ? "src/devserverhelper-0.75/java"
+                // TODO: Remove this block when we drop support for 0.73
+                // https://github.com/facebook/react-native/commit/cfa02eec50469059542ccbacbc51643b525ad461
+                : reactNativeVersion >= v(0, 74, 0)
+                    ? "src/devserverhelper-0.74/java"
+                    // TODO: Remove this block when we drop support for 0.72
+                    // https://github.com/facebook/react-native/commit/da358d0ec7a492edb804b9cdce70e7516ee518ae
+                    : reactNativeVersion >= v(0, 73, 0)
+                        ? "src/devserverhelper-0.73/java"
+                        : "src/devserverhelper-pre-0.73/java",
 
             // TODO: Remove this block when we drop support for 0.72
             // https://github.com/facebook/react-native/commit/c3f672cef7d4f287d3d729d33650f917ed132a0c

--- a/android/app/src/devserverhelper-0.75/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-0.75/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -1,0 +1,14 @@
+package com.microsoft.reacttestapp.react
+
+import android.content.Context
+import com.facebook.react.devsupport.DevServerHelper
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+
+fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper {
+    return DevServerHelper(
+        developerSettings,
+        context,
+        PackagerConnectionSettings(context)
+    )
+}

--- a/test/pack.test.mjs
+++ b/test/pack.test.mjs
@@ -40,6 +40,7 @@ describe("npm pack", () => {
       "android/app/src/camera/java/com/microsoft/reacttestapp/camera/QRCodeScannerFragment.kt",
       "android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
       "android/app/src/devserverhelper-0.74/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
+      "android/app/src/devserverhelper-0.75/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
       "android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt",
       "android/app/src/main/AndroidManifest.xml",
       "android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt",


### PR DESCRIPTION
### Description

`DevServerHelper` constructor signature changed again: https://github.com/facebook/react-native/commit/a1e81185416a53c7c7d0cfc67e40079fd0073e7c

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version nightly
yarn clean
yarn
cd example/android
./gradlew assembleDebug
```

Should successfully build.