### PR TITLE
fix(windows): `CompositionRootView` was renamed to `ReactNativeIsland`

### DIFF
--- a/windows/Shared/ReactInstance.cpp
+++ b/windows/Shared/ReactInstance.cpp
@@ -140,10 +140,8 @@ ReactInstance::ReactInstance(HWND hwnd,
 
     // By using the MicrosoftCompositionContextHelper here, React Native Windows
     // will use Lifted Visuals for its tree.
-    winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
-        reactNativeHost_.InstanceSettings().Properties(),
-        winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::
-            CreateContext(compositor));
+    winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(
+        reactNativeHost_.InstanceSettings(), compositor);
 }
 #endif  // __has_include(<winrt/Microsoft.UI.Composition.h>)
 

--- a/windows/Win32/Main.cpp
+++ b/windows/Win32/Main.cpp
@@ -8,9 +8,10 @@
 
 namespace winrt
 {
-    using winrt::Microsoft::ReactNative::CompositionRootView;
     using winrt::Microsoft::ReactNative::IJSValueWriter;
+    using winrt::Microsoft::ReactNative::LayoutDirection;
     using winrt::Microsoft::ReactNative::ReactCoreInjection;
+    using winrt::Microsoft::ReactNative::ReactNativeIsland;
     using winrt::Microsoft::ReactNative::ReactViewOptions;
     using winrt::Microsoft::UI::Composition::Compositor;
     using winrt::Microsoft::UI::Content::ContentSizePolicy;
@@ -38,12 +39,12 @@ namespace
         return GetDpiForWindow(hwnd) / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
     }
 
-    void UpdateRootViewSizeToAppWindow(winrt::CompositionRootView const &rootView,
+    void UpdateRootViewSizeToAppWindow(winrt::ReactNativeIsland const &rootView,
                                        winrt::AppWindow const &window)
     {
         // Do not relayout when minimized
-        if (window.Presenter().as<winrt::OverlappedPresenter>().State() ==
-            winrt::OverlappedPresenterState::Minimized) {
+        auto windowState = window.Presenter().as<winrt::OverlappedPresenter>().State();
+        if (windowState == winrt::OverlappedPresenterState::Minimized) {
             return;
         }
 
@@ -51,8 +52,7 @@ namespace
         auto scaleFactor = ScaleFactor(hwnd);
         winrt::Size size{window.ClientSize().Width / scaleFactor,
                          window.ClientSize().Height / scaleFactor};
-        rootView.Arrange(size);
-        rootView.Size(size);
+        rootView.Arrange({size, size, winrt::LayoutDirection::Undefined}, {0, 0});
     }
 
     winrt::ReactViewOptions MakeReactViewOptions(ReactApp::Component const &component)
@@ -138,7 +138,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE /* instance */,
         viewOptions = MakeReactViewOptions(component);
     }
 
-    auto rootView = winrt::CompositionRootView{compositor};
+    auto rootView = winrt::ReactNativeIsland{compositor};
     rootView.ReactViewHost(
         winrt::ReactCoreInjection::MakeViewHost(instance.ReactHost(), viewOptions));
 

--- a/windows/Win32/Package.appxmanifest
+++ b/windows/Win32/Package.appxmanifest
@@ -44,6 +44,7 @@
         DisplayName="ReactApp"
         Description="React Native app"
         BackgroundColor="transparent"
+        Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png"
       >
         <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png" />


### PR DESCRIPTION
### Description

`CompositionRootView` was renamed to `ReactNativeIsland` in https://github.com/microsoft/react-native-windows/commit/af10f995954d1ccc08be931e93afa11bc97e8258

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```sh
yarn clean
npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-fabric
yarn windows
```