### PR TITLE
fix(ios): make `new_architecture_enabled?` respect `RCT_NEW_ARCH_ENABLED=0`

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -45,9 +45,9 @@ def find_file(file_name, current_dir)
 end
 
 def new_architecture_enabled?(options, react_native_version)
-  supports_new_architecture = supports_new_architecture?(react_native_version)
-  supports_new_architecture && ENV.fetch('RCT_NEW_ARCH_ENABLED',
-                                         options[:fabric_enabled] || options[:turbomodule_enabled])
+  return false unless supports_new_architecture?(react_native_version)
+  dependent_options_enabled = options[:fabric_enabled] || options[:turbomodule_enabled]
+  ENV.fetch('RCT_NEW_ARCH_ENABLED', dependent_options_enabled ? '1' : '0') != '0'
 end
 
 def platform_config(key, project_root, target_platform)

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -46,6 +46,7 @@ end
 
 def new_architecture_enabled?(options, react_native_version)
   return false unless supports_new_architecture?(react_native_version)
+
   dependent_options_enabled = options[:fabric_enabled] || options[:turbomodule_enabled]
   ENV.fetch('RCT_NEW_ARCH_ENABLED', dependent_options_enabled ? '1' : '0') != '0'
 end

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -76,6 +76,8 @@ class TestPodHelpers < Minitest::Test
 
     refute(new_architecture_enabled?({}, v(0, 70, 999)))
     refute(new_architecture_enabled?({}, available_version))
+    refute(new_architecture_enabled?({ fabric_enabled: true }, available_version))
+    refute(new_architecture_enabled?({ turbomodule_enabled: true }, available_version))
 
     ENV.delete('RCT_NEW_ARCH_ENABLED')
   end

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -71,6 +71,12 @@ class TestPodHelpers < Minitest::Test
     refute(new_architecture_enabled?({}, v(0, 70, 999)))
     assert(new_architecture_enabled?({}, available_version))
 
+    # `RCT_NEW_ARCH_ENABLED` disables everything
+    ENV['RCT_NEW_ARCH_ENABLED'] = '0'
+
+    refute(new_architecture_enabled?({}, v(0, 70, 999)))
+    refute(new_architecture_enabled?({}, available_version))
+
     ENV.delete('RCT_NEW_ARCH_ENABLED')
   end
 


### PR DESCRIPTION
### Description

It seems to me the read of the `RCT_NEW_ARCH_ENABLED` environment variable is broken:

```ruby
RCT_NEW_ARCH_ENABLED=0 ruby -e 'puts ENV.fetch("RCT_NEW_ARCH_ENABLED", false) ? "enabled" : "disabled"'
```

prints

```
enabled
```

I.e. when setting `RCT_NEW_ARCH_ENABLED` to `0`, `new_architecture_enabled?` returns the string `"0"` which is truthy.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

- Run `RCT_NEW_ARCH_ENABLED=0 pod install` and see how the `RCT_NEW_ARCH_ENABLED=1` is incorrectly appended to the "OTHER_CPLUSPLUSFLAGS" on the Xcode project.
- Apply this fix and notice how it isn't anymore after running the command again.
