### PR TITLE
chore: make `release-notes.mjs` output announcement template

### DIFF
--- a/android/autolink.mjs
+++ b/android/autolink.mjs
@@ -13,8 +13,7 @@ import {
 
 /**
  * @typedef {import("@react-native-community/cli-types").Config} Config
- * @typedef {import("../scripts/types.js").AndroidDependency} AndroidDependency
- * @typedef {Record<string, AndroidDependency>} AndroidDependencies
+ * @typedef {import("../scripts/types.js").AndroidDependencies} AndroidDependencies
  */
 
 /**

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -67,11 +67,7 @@ function main(lastRelease, nextRelease) {
 
     buffers.push(Buffer.from("]"));
 
-    const output = Buffer.concat(buffers)
-      .toString()
-      .trim()
-      .split("\n")
-      .join(",");
+    const output = Buffer.concat(buffers).toString().trim().replace(/\n/g, ",");
     const commits = JSON.parse(output);
     if (commits.length === 0) {
       return;
@@ -86,6 +82,7 @@ function main(lastRelease, nextRelease) {
       },
       cwd: process.cwd(),
     };
+
     /** @type {Promise<string>} */
     const releaseNotes = generateNotes({}, context);
     releaseNotes

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -31,6 +31,8 @@ export type AndroidDependency = {
   configurations: string[];
 };
 
+export type AndroidDependencies = Record<string, AndroidDependency>;
+
 /*****************
  * configure.mjs *
  *****************/
@@ -260,6 +262,10 @@ export type Docs = {
 export type Manifest = Partial<{
   name: string;
   version: string;
+  repository: {
+    type: "git";
+    url: string;
+  };
   dependencies: Record<string, string>;
   peerDependencies: Record<string, string>;
   devDependencies: Record<string, string | undefined>;


### PR DESCRIPTION
### Description

Make `release-notes.mjs` output announcement template

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
node scripts/release-notes.mjs 3.7.0 3.8.0
```