### PR TITLE
chore(android): bump ktlint to 1.3.0

### DIFF
--- a/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
+++ b/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
@@ -10,12 +10,10 @@ import com.google.android.material.snackbar.Snackbar
 import com.microsoft.reacttestapp.MainActivity
 import com.microsoft.reacttestapp.R
 
-fun MainActivity.canUseCamera(): Boolean {
-    return ContextCompat.checkSelfPermission(
-        this,
-        Manifest.permission.CAMERA
-    ) == PackageManager.PERMISSION_GRANTED
-}
+fun MainActivity.canUseCamera(): Boolean = ContextCompat.checkSelfPermission(
+    this,
+    Manifest.permission.CAMERA
+) == PackageManager.PERMISSION_GRANTED
 
 fun MainActivity.scanForQrCode() {
     when {

--- a/android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -6,11 +6,10 @@ import com.facebook.react.devsupport.InspectorPackagerConnection.BundleStatus
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 
-fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper {
-    return DevServerHelper(
+fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper =
+    DevServerHelper(
         developerSettings,
         context.packageName,
         { BundleStatus() },
         PackagerConnectionSettings(context)
     )
-}

--- a/android/app/src/devserverhelper-0.74/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-0.74/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -5,10 +5,9 @@ import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 
-fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper {
-    return DevServerHelper(
+fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper =
+    DevServerHelper(
         developerSettings,
         context.packageName,
         PackagerConnectionSettings(context)
     )
-}

--- a/android/app/src/devserverhelper-0.75/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-0.75/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -5,10 +5,9 @@ import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 
-fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper {
-    return DevServerHelper(
+fun createDevServerHelper(context: Context, developerSettings: DeveloperSettings): DevServerHelper =
+    DevServerHelper(
         developerSettings,
         context,
         PackagerConnectionSettings(context)
     )
-}

--- a/android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
+++ b/android/app/src/devserverhelper-pre-0.73/java/com/microsoft/reacttestapp/react/DevServerHelperCompat.kt
@@ -9,10 +9,8 @@ import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 fun createDevServerHelper(
     context: Context,
     @Suppress("UNUSED_PARAMETER") developerSettings: DeveloperSettings
-): DevServerHelper {
-    return DevServerHelper(
-        DevInternalSettings(context) {},
-        context.packageName,
-        { BundleStatus() }
-    )
-}
+): DevServerHelper = DevServerHelper(
+    DevInternalSettings(context) {},
+    context.packageName,
+    { BundleStatus() }
+)

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -16,8 +16,8 @@ class ComponentActivity : ReactActivity() {
         private const val COMPONENT_DISPLAY_NAME = "extra:componentDisplayName"
         const val COMPONENT_INITIAL_PROPERTIES = "extra:componentInitialProperties"
 
-        fun newIntent(activity: Activity, component: ComponentViewModel): Intent {
-            return Intent(activity, ComponentActivity::class.java).apply {
+        fun newIntent(activity: Activity, component: ComponentViewModel): Intent =
+            Intent(activity, ComponentActivity::class.java).apply {
                 putExtra(COMPONENT_NAME, component.name)
                 putExtra(COMPONENT_DISPLAY_NAME, component.displayName)
 
@@ -25,14 +25,12 @@ class ComponentActivity : ReactActivity() {
                     putExtra(COMPONENT_INITIAL_PROPERTIES, component.initialProperties)
                 }
             }
-        }
     }
 
     // ReactActivity overrides
 
-    override fun createReactActivityDelegate(): ReactActivityDelegate {
-        return ComponentActivityDelegate(this, mainComponentName)
-    }
+    override fun createReactActivityDelegate(): ReactActivityDelegate =
+        ComponentActivityDelegate(this, mainComponentName)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -82,11 +80,9 @@ class ComponentActivity : ReactActivity() {
 
     // Private
 
-    private fun findClass(name: String): Class<*>? {
-        return try {
-            Class.forName(name)
-        } catch (e: ClassNotFoundException) {
-            null
-        }
+    private fun findClass(name: String): Class<*>? = try {
+        Class.forName(name)
+    } catch (e: ClassNotFoundException) {
+        null
     }
 }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentListAdapter.kt
@@ -30,15 +30,14 @@ class ComponentListAdapter(
 
     override fun getItemCount() = components.size
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ComponentViewHolder {
-        return ComponentViewHolder(
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ComponentViewHolder =
+        ComponentViewHolder(
             layoutInflater.inflate(
                 R.layout.recyclerview_item_component,
                 parent,
                 false
             ) as TextView
         )
-    }
 
     override fun onBindViewHolder(holder: ComponentViewHolder, position: Int) {
         holder.bindTo(components[position])

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -33,11 +33,9 @@ sealed class BundleSource {
     }
 
     object Server : BundleSource() {
-        override fun moveTo(to: BundleSource): Action {
-            return when (to) {
-                Disk -> Action.RESTART
-                Server -> Action.RELOAD
-            }
+        override fun moveTo(to: BundleSource): Action = when (to) {
+            Disk -> Action.RESTART
+            Server -> Action.RELOAD
         }
     }
 }

--- a/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
+++ b/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
@@ -6,9 +6,9 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.BuildConfig
 
-abstract class ReactNativeHostCompat(application: Application) : DefaultReactNativeHost(
-    application
-) {
+abstract class ReactNativeHostCompat(application: Application) :
+    DefaultReactNativeHost(application) {
+
     companion object {
         init {
             try {

--- a/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/fabric/ComponentsRegistry.kt
+++ b/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/fabric/ComponentsRegistry.kt
@@ -9,14 +9,12 @@ import com.facebook.soloader.SoLoader
  * The corresponding C++ implementation is in `android/app/src/main/jni/ComponentsRegistry.cpp`
  */
 @DoNotStrip
-class ComponentsRegistry @DoNotStrip private constructor(
-    componentFactory: ComponentFactory
-) {
+class ComponentsRegistry @DoNotStrip private constructor(componentFactory: ComponentFactory) {
+
     companion object {
         @DoNotStrip
-        fun register(componentFactory: ComponentFactory): ComponentsRegistry {
-            return ComponentsRegistry(componentFactory)
-        }
+        fun register(componentFactory: ComponentFactory): ComponentsRegistry =
+            ComponentsRegistry(componentFactory)
 
         init {
             SoLoader.loadLibrary("fabricjni")

--- a/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
+++ b/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
@@ -32,8 +32,6 @@ class TurboModuleManagerDelegate protected constructor(
         override fun build(
             context: ReactApplicationContext?,
             packages: PackagesList?
-        ): TurboModuleManagerDelegate {
-            return TurboModuleManagerDelegate(context, packages)
-        }
+        ): TurboModuleManagerDelegate = TurboModuleManagerDelegate(context, packages)
     }
 }

--- a/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
+++ b/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
@@ -6,9 +6,9 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.BuildConfig
 
-abstract class ReactNativeHostCompat(application: Application) : DefaultReactNativeHost(
-    application
-) {
+abstract class ReactNativeHostCompat(application: Application) :
+    DefaultReactNativeHost(application) {
+
     companion object {
         init {
             try {

--- a/android/app/src/new-arch/java/com/microsoft/reacttestapp/fabric/ComponentsRegistry.kt
+++ b/android/app/src/new-arch/java/com/microsoft/reacttestapp/fabric/ComponentsRegistry.kt
@@ -9,14 +9,12 @@ import com.facebook.soloader.SoLoader
  * The corresponding C++ implementation is in `android/app/src/main/jni/ComponentsRegistry.cpp`
  */
 @DoNotStrip
-class ComponentsRegistry @DoNotStrip private constructor(
-    componentFactory: ComponentFactory
-) {
+class ComponentsRegistry @DoNotStrip private constructor(componentFactory: ComponentFactory) {
+
     companion object {
         @DoNotStrip
-        fun register(componentFactory: ComponentFactory): ComponentsRegistry {
-            return ComponentsRegistry(componentFactory)
-        }
+        fun register(componentFactory: ComponentFactory): ComponentsRegistry =
+            ComponentsRegistry(componentFactory)
 
         init {
             SoLoader.loadLibrary("fabricjni")

--- a/android/app/src/new-arch/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
+++ b/android/app/src/new-arch/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
@@ -32,8 +32,6 @@ class TurboModuleManagerDelegate protected constructor(
         override fun build(
             context: ReactApplicationContext?,
             packages: PackagesList?
-        ): TurboModuleManagerDelegate {
-            return TurboModuleManagerDelegate(context, packages)
-        }
+        ): TurboModuleManagerDelegate = TurboModuleManagerDelegate(context, packages)
     }
 }

--- a/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -6,15 +6,12 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactRootView
 import com.microsoft.reacttestapp.BuildConfig
 
-class ComponentActivityDelegate(
-    activity: ReactActivity,
-    mainComponentName: String?
-) : ReactActivityDelegate(activity, mainComponentName) {
-    override fun getLaunchOptions(): Bundle? {
-        return plainActivity.intent.extras?.getBundle(
-            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
-        )
-    }
+class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: String?) :
+    ReactActivityDelegate(activity, mainComponentName) {
+
+    override fun getLaunchOptions(): Bundle? = plainActivity.intent.extras?.getBundle(
+        ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+    )
 
     override fun createRootView(): ReactRootView {
         val rootView = super.createRootView()

--- a/android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -6,15 +6,12 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactRootView
 import com.microsoft.reacttestapp.BuildConfig
 
-class ComponentActivityDelegate(
-    activity: ReactActivity,
-    mainComponentName: String?
-) : ReactActivityDelegate(activity, mainComponentName) {
-    override fun getLaunchOptions(): Bundle? {
-        return plainActivity.intent.extras?.getBundle(
-            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
-        )
-    }
+class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: String?) :
+    ReactActivityDelegate(activity, mainComponentName) {
+
+    override fun getLaunchOptions(): Bundle? = plainActivity.intent.extras?.getBundle(
+        ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+    )
 
     override fun isFabricEnabled(): Boolean = BuildConfig.ReactTestApp_useFabric
 

--- a/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -5,15 +5,12 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.microsoft.reacttestapp.BuildConfig
 
-class ComponentActivityDelegate(
-    activity: ReactActivity,
-    mainComponentName: String?
-) : ReactActivityDelegate(activity, mainComponentName) {
-    override fun getLaunchOptions(): Bundle? {
-        return plainActivity.intent.extras?.getBundle(
-            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
-        )
-    }
+class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: String?) :
+    ReactActivityDelegate(activity, mainComponentName) {
+
+    override fun getLaunchOptions(): Bundle? = plainActivity.intent.extras?.getBundle(
+        ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+    )
 
     override fun isFabricEnabled(): Boolean = BuildConfig.ReactTestApp_useFabric
 }

--- a/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -6,15 +6,12 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactRootView
 import com.microsoft.reacttestapp.BuildConfig
 
-class ComponentActivityDelegate(
-    activity: ReactActivity,
-    mainComponentName: String?
-) : ReactActivityDelegate(activity, mainComponentName) {
-    override fun getLaunchOptions(): Bundle? {
-        return plainActivity.intent.extras?.getBundle(
-            ComponentActivity.COMPONENT_INITIAL_PROPERTIES
-        )
-    }
+class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: String?) :
+    ReactActivityDelegate(activity, mainComponentName) {
+
+    override fun getLaunchOptions(): Bundle? = plainActivity.intent.extras?.getBundle(
+        ComponentActivity.COMPONENT_INITIAL_PROPERTIES
+    )
 
     override fun createRootView(): ReactRootView {
         val rootView = super.createRootView()

--- a/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -14,7 +14,10 @@ import com.microsoft.reacttestapp.react.ReactBundleNameProvider
 import com.microsoft.reacttestapp.react.TestAppReactNativeHost
 import com.microsoft.reacttestapp.support.ReactTestAppLifecycleEvents
 
-class TestApp : Application(), ReactApplication {
+class TestApp :
+    Application(),
+    ReactApplication {
+
     val bundleNameProvider: ReactBundleNameProvider
         get() = reactNativeBundleNameProvider
 

--- a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -12,7 +12,10 @@ import com.microsoft.reacttestapp.react.ReactBundleNameProvider
 import com.microsoft.reacttestapp.react.TestAppReactNativeHost
 import com.microsoft.reacttestapp.support.ReactTestAppLifecycleEvents
 
-class TestApp : Application(), ReactApplication {
+class TestApp :
+    Application(),
+    ReactApplication {
+
     val bundleNameProvider: ReactBundleNameProvider
         get() = reactNativeBundleNameProvider
 


### PR DESCRIPTION
### Description

ktlint was bumped to 1.3.0 on GitHub Actions, causing "build failures".

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.