### PR TITLE
Update project file with correct React Native source directory

### DIFF
--- a/windows/UWP/ReactTestApp.vcxproj
+++ b/windows/UWP/ReactTestApp.vcxproj
@@ -24,6 +24,7 @@
     <ReactAppUniversalDir Condition="'$(ReactAppUniversalDir)'==''">$(ReactAppWinDir)\UWP</ReactAppUniversalDir>
     <ReactAppGeneratedDir Condition="'$(ReactAppGeneratedDir)'==''">$(MSBuildProjectDirectory)\..\..</ReactAppGeneratedDir>
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativeDir>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
   <PropertyGroup Label="Fallback Windows SDK Versions">


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->
I tried to run the test app in the async-storage repo on 0.74 and was facing the following error:
> × Building Solution
× Build failed with message 7:10>C:\new-account-repos\async-storage\packages\default-storage\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\JSI\JsiAbiApi.h(11,10): error C1083: Cannot open include file: 'jsi/jsi.h': No such file or directory [C:\new-account-repos\async-storage\packages\default-storage\windows\ReactNativeAsyncStorage\ReactNativeAsyncStorage.vcxproj]. Check your build configuration.
Command failed with error MSBuildError: 7:10>C:\new-account-repos\async-storage\packages\default-storage\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\JSI\JsiAbiApi.h(11,10): error C1083: Cannot open include file: 'jsi/jsi.h': No such file or directory [C:\new-account-repos\async-storage\packages\default-storage\windows\ReactNativeAsyncStorage\ReactNativeAsyncStorage.vcxproj]

I was getting the error on both the ReactNativeAsyncStorage and ReactTestApp project file. The cause of the error was that the `JSI_SourcePath` variable in both of the projects was not being recognized, due to the `ReactNativeDir` not being defined, which caused the JSI error.
<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [X] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

I was able to apply the fix to the ReactNativeAsyncStorage project file, but could not fix the ReactTestApp project file locally as it was generated from the RNTA package - this is the fix that should resolve the issue. I was able to build the ReactTestApp in the example directory of the repo successfully after making this change.
