### PR TITLE
fix(android): use debug signing config for release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -204,7 +204,7 @@ android {
         buildType.signingConfig = signingConfigs[name]
     }
     if (buildTypes.release.signingConfig == null) {
-        logger.warn("Signing config for 'release' build type not found; using default config")
+        logger.warn("Signing config for 'release' build type not found; reusing debug config")
         buildTypes.release.signingConfig = signingConfigs.debug
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,20 +193,19 @@ android {
         pickFirst "lib/x86/libc++_shared.so"
     }
 
-    if (project.ext.signingConfigs.isEmpty()) {
-        logger.warn("Signing config for 'release' build type not found; reusing debug config")
-        buildTypes.release.signingConfig = signingConfigs.debug
-    } else {
-        project.ext.signingConfigs.each { name, config ->
-            def signingConfig = signingConfigs.findByName(name) ?: signingConfigs.create(name)
-            signingConfig.keyAlias = config["keyAlias"]
-            signingConfig.keyPassword = config["keyPassword"]
-            signingConfig.storeFile = config["storeFile"]
-            signingConfig.storePassword = config["storePassword"]
+    project.ext.signingConfigs.each { name, config ->
+        def signingConfig = signingConfigs.findByName(name) ?: signingConfigs.create(name)
+        signingConfig.keyAlias = config["keyAlias"]
+        signingConfig.keyPassword = config["keyPassword"]
+        signingConfig.storeFile = config["storeFile"]
+        signingConfig.storePassword = config["storePassword"]
 
-            def buildType = buildTypes.findByName(name) ?: buildTypes.create(name)
-            buildType.signingConfig = signingConfigs[name]
-        }
+        def buildType = buildTypes.findByName(name) ?: buildTypes.create(name)
+        buildType.signingConfig = signingConfigs[name]
+    }
+    if (buildTypes.release.signingConfig == null) {
+        logger.warn("Signing config for 'release' build type not found; using default config")
+        buildTypes.release.signingConfig = signingConfigs.debug
     }
 
     sourceSets {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,15 +193,20 @@ android {
         pickFirst "lib/x86/libc++_shared.so"
     }
 
-    project.ext.signingConfigs.each { name, config ->
-        def signingConfig = signingConfigs.findByName(name) ?: signingConfigs.create(name)
-        signingConfig.keyAlias = config["keyAlias"]
-        signingConfig.keyPassword = config["keyPassword"]
-        signingConfig.storeFile = config["storeFile"]
-        signingConfig.storePassword = config["storePassword"]
+    if (project.ext.signingConfigs.isEmpty()) {
+        logger.warn("Signing config for 'release' build type not found; reusing debug config")
+        buildTypes.release.signingConfig = signingConfigs.debug
+    } else {
+        project.ext.signingConfigs.each { name, config ->
+            def signingConfig = signingConfigs.findByName(name) ?: signingConfigs.create(name)
+            signingConfig.keyAlias = config["keyAlias"]
+            signingConfig.keyPassword = config["keyPassword"]
+            signingConfig.storeFile = config["storeFile"]
+            signingConfig.storePassword = config["storePassword"]
 
-        def buildType = buildTypes.findByName(name) ?: buildTypes.create(name)
-        buildType.signingConfig = signingConfigs[name]
+            def buildType = buildTypes.findByName(name) ?: buildTypes.create(name)
+            buildType.signingConfig = signingConfigs[name]
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
### Description

Signing config for 'release' build types are unset by default.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example
yarn android --mode Release
```