### PR TITLE
feat: add `visionos` entry to `app.json` template

### DIFF
--- a/scripts/template.mjs
+++ b/scripts/template.mjs
@@ -36,6 +36,7 @@ export function appManifest(name) {
       android: ["dist/res", "dist/main.android.jsbundle"],
       ios: ["dist/assets", "dist/main.ios.jsbundle"],
       macos: ["dist/assets", "dist/main.macos.jsbundle"],
+      visionos: ["dist/assets", "dist/main.visionos.jsbundle"],
       windows: ["dist/assets", "dist/main.windows.bundle"],
     },
   });


### PR DESCRIPTION
### Description

Default `app.json` was missing `visionos` inside `resources`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

New projects should contain correct `app.json`.
