### PR TITLE
fix(android): fix bundle being loaded twice in bridgeless mode

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -77,7 +77,6 @@ class TestAppReactNativeHost(
         reactInstanceManager.addReactInstanceEventListener(reactInstanceListener)
 
         beforeReactNativeInit()
-        reactInstanceManager.createReactContextInBackground()
     }
 
     fun addReactInstanceEventListener(listener: ReactInstanceEventListener) {
@@ -160,16 +159,10 @@ class TestAppReactNativeHost(
             }
         )
         devSupportManager.addCustomDevOption(bundleOption) {
-            when (source) {
-                BundleSource.Disk -> {
-                    reactInstanceManager.currentReactContext?.currentActivity?.let {
-                        reload(it, BundleSource.Server)
-                    }
-                }
-                BundleSource.Server -> {
-                    reactInstanceManager.currentReactContext?.currentActivity?.let {
-                        reload(it, BundleSource.Disk)
-                    }
+            reactInstanceManager.currentReactContext?.currentActivity?.let {
+                when (source) {
+                    BundleSource.Disk -> reload(it, BundleSource.Server)
+                    BundleSource.Server -> reload(it, BundleSource.Disk)
                 }
             }
         }


### PR DESCRIPTION
### Description

Fix bundle being loaded twice in bridgeless mode.

Resolves #2109.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.74 -- --core-only
yarn clean
yarn
cd example
yarn android --extra-params "-PnewArchEnabled=true -PbridgelessEnabled=true"
```

### Screenshots

| 0.66 | 0.74 + bridgeless |
| :-: | :-: |
| ![Screenshot_1721027528](https://github.com/user-attachments/assets/76306747-81ad-4c5e-8d57-46ebbaa4dd83) | ![Screenshot_1721027946](https://github.com/user-attachments/assets/806b54de-c0cb-40e7-bd13-16612802684e) |
