### PR TITLE
fix(android): bridgeless mode should be enabled by default on 0.74

### DIFF
--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -275,17 +275,24 @@ ext.isBridgelessEnabled = { project, isNewArchEnabled ->
     if (isNewArchEnabled) {
         def bridgelessEnabled = project.findProperty("react.bridgelessEnabled")
             ?: project.findProperty("bridgelessEnabled")
-        if (bridgelessEnabled == "true") {
+        if (bridgelessEnabled != "false") {
             def version = getPackageVersionNumber("react-native", project.rootDir)
             def isSupported = version == 0 || version >= v(0, 73, 0)
-            if (!isSupported) {
-                logger.warn([
-                    "WARNING: react-native 0.73 or greater is required for",
-                    "Bridgeless Mode — disable `bridgelessEnabled` in your",
-                    "`gradle.properties` or upgrade `react-native`"
-                ].join(" "))
+
+            if (bridgelessEnabled == "true") {
+                if (!isSupported) {
+                    logger.warn([
+                        "WARNING: react-native 0.73 or greater is required for",
+                        "Bridgeless Mode — disable `bridgelessEnabled` in your",
+                        "`gradle.properties` or upgrade `react-native`"
+                    ].join(" "))
+                }
+                return isSupported
             }
-            return isSupported
+
+            // https://github.com/facebook/react-native/commit/fe337f25be65b67dc3d8d99d26a61ffd26985dd8
+            def isEnabledByDefault = version == 0 || version >= v(0, 74, 0)
+            return isSupported && isEnabledByDefault
         }
     }
     return false


### PR DESCRIPTION
### Description

When New Architecture is enabled on 0.74+, bridgeless mode should also be enabled by default.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.74
yarn
cd example
yarn android --extra-params "-PnewArchEnabled=true"

# In a separate terminal
yarn start
```

Verify that bridgeless is enabled.