### PR TITLE
fix(android): fix loading of core modules on 0.75 + New Arch

### DIFF
--- a/android/app/src/main/jni/ComponentsRegistry.cpp
+++ b/android/app/src/main/jni/ComponentsRegistry.cpp
@@ -1,5 +1,7 @@
 #include "ComponentsRegistry.h"
 
+#if !__has_include(<DefaultTurboModuleManagerDelegate.h>)
+
 #include "AutolinkingCompat.h"
 
 #if __has_include(<react/fabric/CoreComponentsRegistry.h>)  // >= 0.71
@@ -61,3 +63,5 @@ ComponentsRegistry::initHybrid(facebook::jni::alias_ref<jclass>, ComponentFactor
 
     return makeCxxInstance(delegate);
 }
+
+#endif  // !__has_include(<DefaultTurboModuleManagerDelegate.h>)

--- a/android/app/src/main/jni/TurboModuleManagerDelegate.cpp
+++ b/android/app/src/main/jni/TurboModuleManagerDelegate.cpp
@@ -1,5 +1,7 @@
 #include "TurboModuleManagerDelegate.h"
 
+#if !__has_include(<DefaultTurboModuleManagerDelegate.h>)
+
 #include <rncore.h>
 
 #include "AutolinkingCompat.h"
@@ -47,3 +49,5 @@ bool TurboModuleManagerDelegate::canCreateTurboModule(StringRef name)
     return getTurboModule(name, nullptr) != nullptr ||
            getTurboModule(name, {.moduleName = name}) != nullptr;
 }
+
+#endif  // !__has_include(<DefaultTurboModuleManagerDelegate.h>)


### PR DESCRIPTION
### Description

Fix loading of core modules on 0.75 + New Arch: https://github.com/facebook/react-native/commit/7facb32f30d17eb27f870dd531d3dc7ebe4532f6

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a