### PR TITLE
fix(android): fix loading last/single component on startup

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -112,10 +112,10 @@ android {
         versionName project.ext.getVersionName()
 
         def singleApp = getSingleAppMode()
-        buildConfigField "String", "ReactTestApp_singleApp", singleApp ? "\"${singleApp}\"" : "null"
+        buildConfigField "String", "REACTAPP_SINGLE_APP", singleApp ? "\"${singleApp}\"" : "null"
 
-        buildConfigField "boolean", "ReactTestApp_useFabric", enableNewArchitecture.toString()
-        buildConfigField "boolean", "ReactTestApp_useBridgeless", enableBridgeless.toString()
+        buildConfigField "boolean", "REACTAPP_USE_FABRIC", enableNewArchitecture.toString()
+        buildConfigField "boolean", "REACTAPP_USE_BRIDGELESS", enableBridgeless.toString()
 
         manifestPlaceholders = [
             rntaEnableCamera: project.ext.react.enableCamera ? "1000000" : "1"

--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -12,13 +12,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.systeminfo.ReactNativeVersion
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 import com.google.android.material.appbar.MaterialToolbar
 import com.microsoft.reacttestapp.camera.canUseCamera
 import com.microsoft.reacttestapp.camera.scanForQrCode
-import com.microsoft.reacttestapp.compat.ReactInstanceEventListener
 import com.microsoft.reacttestapp.component.ComponentActivity
 import com.microsoft.reacttestapp.component.ComponentBottomSheetDialogFragment
 import com.microsoft.reacttestapp.component.ComponentListAdapter

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentActivity.kt
@@ -36,7 +36,7 @@ class ComponentActivity : ReactActivity() {
         super.onCreate(savedInstanceState)
 
         @Suppress("SENSELESS_COMPARISON")
-        if (BuildConfig.ReactTestApp_singleApp === null) {
+        if (BuildConfig.REACTAPP_SINGLE_APP === null) {
             supportActionBar?.setHomeButtonEnabled(true)
             supportActionBar?.setDisplayHomeAsUpEnabled(true)
         }

--- a/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/component/ComponentBottomSheetDialogFragment.kt
@@ -37,7 +37,7 @@ class ComponentBottomSheetDialogFragment : BottomSheetDialogFragment() {
     ): View {
         val reactApplication = requireActivity().application as ReactApplication
         return ReactRootView(context).apply {
-            setIsFabric(BuildConfig.ReactTestApp_useFabric)
+            setIsFabric(BuildConfig.REACTAPP_USE_FABRIC)
             startReactApplication(
                 reactApplication.reactNativeHost.reactInstanceManager,
                 requireArguments().getString(NAME),

--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -64,6 +64,10 @@ class TestAppReactNativeHost(
             error("init() can only be called once on startup")
         }
 
+        // When we reference `reactInstanceManager` below, `ReactNativeHost` will start creating a
+        // `ReactInstanceManager` instance.
+        beforeReactNativeInit()
+
         val reactInstanceListener = object : ReactInstanceEventListener {
             override fun onReactContextInitialized(context: ReactContext) {
                 afterReactNativeInit()
@@ -75,8 +79,6 @@ class TestAppReactNativeHost(
         }
 
         reactInstanceManager.addReactInstanceEventListener(reactInstanceListener)
-
-        beforeReactNativeInit()
     }
 
     fun addReactInstanceEventListener(listener: ReactInstanceEventListener) {

--- a/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
+++ b/android/app/src/new-arch-0.73/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
@@ -13,9 +13,9 @@ abstract class ReactNativeHostCompat(application: Application) :
         init {
             try {
                 DefaultNewArchitectureEntryPoint.load(
-                    turboModulesEnabled = BuildConfig.ReactTestApp_useFabric,
-                    fabricEnabled = BuildConfig.ReactTestApp_useFabric,
-                    bridgelessEnabled = BuildConfig.ReactTestApp_useBridgeless
+                    turboModulesEnabled = BuildConfig.REACTAPP_USE_FABRIC,
+                    fabricEnabled = BuildConfig.REACTAPP_USE_FABRIC,
+                    bridgelessEnabled = BuildConfig.REACTAPP_USE_BRIDGELESS
                 )
             } catch (e: UnsatisfiedLinkError) {
                 // Older versions of `DefaultNewArchitectureEntryPoint` is
@@ -25,6 +25,6 @@ abstract class ReactNativeHostCompat(application: Application) :
         }
     }
 
-    override val isNewArchEnabled: Boolean = BuildConfig.ReactTestApp_useFabric
+    override val isNewArchEnabled: Boolean = BuildConfig.REACTAPP_USE_FABRIC
     override val isHermesEnabled: Boolean? = true
 }

--- a/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
+++ b/android/app/src/new-arch/java/com/microsoft/reacttestapp/compat/ReactNativeHostCompat.kt
@@ -13,8 +13,8 @@ abstract class ReactNativeHostCompat(application: Application) :
         init {
             try {
                 DefaultNewArchitectureEntryPoint.load(
-                    turboModulesEnabled = BuildConfig.ReactTestApp_useFabric,
-                    fabricEnabled = BuildConfig.ReactTestApp_useFabric
+                    turboModulesEnabled = BuildConfig.REACTAPP_USE_FABRIC,
+                    fabricEnabled = BuildConfig.REACTAPP_USE_FABRIC
                 )
             } catch (e: UnsatisfiedLinkError) {
                 // Older versions of `DefaultNewArchitectureEntryPoint` is
@@ -24,6 +24,6 @@ abstract class ReactNativeHostCompat(application: Application) :
         }
     }
 
-    override val isNewArchEnabled: Boolean = BuildConfig.ReactTestApp_useFabric
+    override val isNewArchEnabled: Boolean = BuildConfig.REACTAPP_USE_FABRIC
     override val isHermesEnabled: Boolean? = true
 }

--- a/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -15,13 +15,13 @@ class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: Stri
 
     override fun createRootView(): ReactRootView {
         val rootView = super.createRootView()
-        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        rootView.setIsFabric(BuildConfig.REACTAPP_USE_FABRIC)
         return rootView
     }
 
     override fun createRootView(bundle: Bundle?): ReactRootView {
         val rootView = super.createRootView(bundle)
-        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        rootView.setIsFabric(BuildConfig.REACTAPP_USE_FABRIC)
         return rootView
     }
 }

--- a/android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.74/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -13,11 +13,11 @@ class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: Stri
         ComponentActivity.COMPONENT_INITIAL_PROPERTIES
     )
 
-    override fun isFabricEnabled(): Boolean = BuildConfig.ReactTestApp_useFabric
+    override fun isFabricEnabled(): Boolean = BuildConfig.REACTAPP_USE_FABRIC
 
     override fun createRootView(): ReactRootView =
-        ReactRootView(context).apply { setIsFabric(BuildConfig.ReactTestApp_useFabric) }
+        ReactRootView(context).apply { setIsFabric(BuildConfig.REACTAPP_USE_FABRIC) }
 
     override fun createRootView(bundle: Bundle?): ReactRootView =
-        ReactRootView(context).apply { setIsFabric(BuildConfig.ReactTestApp_useFabric) }
+        ReactRootView(context).apply { setIsFabric(BuildConfig.REACTAPP_USE_FABRIC) }
 }

--- a/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -12,5 +12,5 @@ class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: Stri
         ComponentActivity.COMPONENT_INITIAL_PROPERTIES
     )
 
-    override fun isFabricEnabled(): Boolean = BuildConfig.ReactTestApp_useFabric
+    override fun isFabricEnabled(): Boolean = BuildConfig.REACTAPP_USE_FABRIC
 }

--- a/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
+++ b/android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt
@@ -15,7 +15,7 @@ class ComponentActivityDelegate(activity: ReactActivity, mainComponentName: Stri
 
     override fun createRootView(): ReactRootView {
         val rootView = super.createRootView()
-        rootView.setIsFabric(BuildConfig.ReactTestApp_useFabric)
+        rootView.setIsFabric(BuildConfig.REACTAPP_USE_FABRIC)
         return rootView
     }
 }


### PR DESCRIPTION
### Description

Regressed in 3.8.8 (#2120).

Also gets rid of a call to private `getCurrentReactContext()` (see #2119).

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

1. Remove a component in `example/app.json` to trigger this code path
2. Build and run the Android app
3. Verify that the remaining component gets started on startup