### PR TITLE
test: fix config tests failing on nightlies

### DIFF
--- a/example/test/config.test.mjs
+++ b/example/test/config.test.mjs
@@ -33,7 +33,9 @@ async function getLoadConfig() {
     // https://github.com/react-native-community/cli/pull/1464
     const { default: cli } = await import("@react-native-community/cli");
     return cli.loadConfig.length === 1
-      ? () => cli.loadConfig({}) // >=14.0
+      ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore The signature change of `loadConfig` was introduced in 14.0
+        () => cli.loadConfig({}) // >=14.0
       : cli.loadConfig; // <14.0
   }
 }

--- a/example/test/config.test.mjs
+++ b/example/test/config.test.mjs
@@ -32,7 +32,9 @@ async function getLoadConfig() {
     // `loadConfig` was made public in 7.0:
     // https://github.com/react-native-community/cli/pull/1464
     const { default: cli } = await import("@react-native-community/cli");
-    return cli.loadConfig;
+    return cli.loadConfig.length === 1
+      ? () => cli.loadConfig({}) // >=14.0
+      : cli.loadConfig; // <14.0
   }
 }
 


### PR DESCRIPTION
### Description

Fix config tests failing on nightlies: https://github.com/microsoft/react-native-test-app/actions/runs/10034407989/job/27728887817

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
node --test test/config.test.mjs
```