### PR TITLE
test(ios): fix config test failing on nightlies

### DIFF
--- a/example/test/config.test.mjs
+++ b/example/test/config.test.mjs
@@ -181,12 +181,13 @@ test("react-native config", async (t) => {
       );
       notEqual(config.platforms.ios, undefined);
       match(config.project.ios.sourceDir, regexp(sourceDir));
-      deepEqual(
-        config.project.ios.xcodeProject,
-        fs.existsSync("ios/Pods")
-          ? { name: "Example.xcworkspace", isWorkspace: true }
-          : null
-      );
+
+      if (fs.existsSync("ios/Pods")) {
+        equal(config.project.ios.xcodeProject.name, "Example.xcworkspace");
+        equal(config.project.ios.xcodeProject.isWorkspace, true);
+      } else {
+        equal(config.project.ios.xcodeProject, null);
+      }
     }
   );
 


### PR DESCRIPTION
### Description

An additional field was introduced in latest nightlies, causing a test to fail.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
pod install --project-directory=ios
node --test test/config.test.mjs
```