### PR TITLE
fix(android): make sdk versions configurable

### DIFF
--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,9 +1,9 @@
 ext {
     apply(from: "${buildscript.sourceFile.getParent()}/test-app-util.gradle")
 
-    compileSdkVersion = 34
-    minSdkVersion = 23
-    targetSdkVersion = 33
+    compileSdkVersion = rootProject.findProperty("react.compileSdkVersion") ?: 34
+    minSdkVersion = rootProject.findProperty("react.minSdkVersion") ?: 23
+    targetSdkVersion = rootProject.findProperty("react.targetSdkVersion") ?: 33
 
     /**
      * Returns the recommended Gradle plugin version for the specified React Native


### PR DESCRIPTION
### Description

`compileSdkVersion`, `minSdkVersion`, `targetSdkVersion` can be configured in `gradle.properties`:

```
react.compileSdkVersion=34
react.minSdkVersion=23
react.targetSdkVersion=33
```

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

1. In `gradle.properties`, try adding `react.minSdkVersion=24` and build the Android app (this should succeed)
2. In `gradle.properties`, try adding `react.minSdkVersion=99` and build the Android app (this should fail)