### PR TITLE
test: use mock objects directly

### DIFF
--- a/test/configure/console.test.ts
+++ b/test/configure/console.test.ts
@@ -1,24 +1,23 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { error, warn } from "../../scripts/configure.mjs";
-import { spy } from "../spy.js";
 
 describe("console", () => {
   it("error() is just a fancy console.error()", (t) => {
-    t.mock.method(console, "error", () => null);
-    t.mock.method(console, "warn", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     error("These tests are seriously lacking Arnold.");
-    equal(spy(console.error).calls.length, 1);
-    equal(spy(console.warn).calls.length, 0);
+    equal(errorMock.mock.calls.length, 1);
+    equal(warnMock.mock.calls.length, 0);
   });
 
   it("warn() is just a fancy console.warn()", (t) => {
-    t.mock.method(console, "error", () => null);
-    t.mock.method(console, "warn", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     warn("These tests are lacking Arnold.");
-    equal(spy(console.error).calls.length, 0);
-    equal(spy(console.warn).calls.length, 1);
+    equal(errorMock.mock.calls.length, 0);
+    equal(warnMock.mock.calls.length, 1);
   });
 });

--- a/test/configure/getAppName.test.ts
+++ b/test/configure/getAppName.test.ts
@@ -2,7 +2,6 @@ import { equal } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { getAppName as getAppNameActual } from "../../scripts/configure.mjs";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("getAppName()", () => {
   const getAppName: typeof getAppNameActual = (p) => getAppNameActual(p, fs);
@@ -10,30 +9,30 @@ describe("getAppName()", () => {
   afterEach(() => setMockFiles());
 
   it("retrieves name from the app manifest", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
     setMockFiles({ "app.json": `{ "name": "Example" }` });
 
     equal(getAppName("."), "Example");
-    equal(spy(console.warn).calls.length, 0);
+    equal(warnMock.mock.calls.length, 0);
   });
 
   it("falls back to 'ReactTestApp' if `name` is missing or empty", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
     setMockFiles({ "app.json": "{}" });
 
     equal(getAppName("."), "ReactTestApp");
-    equal(spy(console.warn).calls.length, 1);
+    equal(warnMock.mock.calls.length, 1);
 
     setMockFiles({ "app.json": `{ name: "" }` });
 
     equal(getAppName("."), "ReactTestApp");
-    equal(spy(console.warn).calls.length, 2);
+    equal(warnMock.mock.calls.length, 2);
   });
 
   it("falls back to 'ReactTestApp' if the app manifest is missing", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     equal(getAppName("."), "ReactTestApp");
-    equal(spy(console.warn).calls.length, 1);
+    equal(warnMock.mock.calls.length, 1);
   });
 });

--- a/test/configure/getPlatformPackage.test.ts
+++ b/test/configure/getPlatformPackage.test.ts
@@ -1,13 +1,12 @@
 import { deepEqual, equal, throws } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { getPlatformPackage } from "../../scripts/configure.mjs";
-import { spy } from "../spy.js";
 
 describe("getPlatformPackage()", () => {
   const name = "react-native-macos";
 
   it("returns dependency when target version is inside range", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     for (const targetVersion of ["0.0.0-canary", "^0.0.0-canary"]) {
       const pkg = getPlatformPackage("macos", targetVersion);
@@ -19,11 +18,11 @@ describe("getPlatformPackage()", () => {
       deepEqual(pkg, { [name]: "^0.73.0" });
     }
 
-    equal(spy(console.warn).calls.length, 0);
+    equal(warnMock.mock.calls.length, 0);
   });
 
   it("returns `undefined` when target version is outside range", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     const versions = ["0.59", "9999.0"];
     for (const targetVersion of versions) {
@@ -31,7 +30,7 @@ describe("getPlatformPackage()", () => {
       equal(pkg, undefined);
     }
 
-    equal(spy(console.warn).calls.length, versions.length);
+    equal(warnMock.mock.calls.length, versions.length);
   });
 
   it("throws if target version is invalid", () => {

--- a/test/configure/isDestructive.test.ts
+++ b/test/configure/isDestructive.test.ts
@@ -2,7 +2,6 @@ import { equal } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { isDestructive as isDestructiveActual } from "../../scripts/configure.mjs";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("isDestructive()", () => {
   /**
@@ -44,7 +43,7 @@ describe("isDestructive()", () => {
   });
 
   it("returns true when there are files to overwrite", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     const config = {
       scripts: {},
@@ -56,16 +55,16 @@ describe("isDestructive()", () => {
     };
 
     equal(isDestructive(".", config), false);
-    equal(spy(console.warn).calls.length, 0);
+    equal(warnMock.mock.calls.length, 0);
 
     setMockFiles({ "metro.config.js": "" });
 
     equal(isDestructive(".", config), true);
-    equal(spy(console.warn).calls.length, 2);
+    equal(warnMock.mock.calls.length, 2);
   });
 
   it("returns true when there are files to remove", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     const config = {
       scripts: {},
@@ -77,16 +76,16 @@ describe("isDestructive()", () => {
     };
 
     equal(isDestructive(".", config), false);
-    equal(spy(console.warn).calls.length, 0);
+    equal(warnMock.mock.calls.length, 0);
 
     setMockFiles({ "Podfile.lock": "" });
 
     equal(isDestructive(".", config), true);
-    equal(spy(console.warn).calls.length, 2);
+    equal(warnMock.mock.calls.length, 2);
   });
 
   it("enumerates all files that need to be modified", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     const config = {
       scripts: {},
@@ -100,7 +99,7 @@ describe("isDestructive()", () => {
     };
 
     equal(isDestructive(".", config), false);
-    equal(spy(console.warn).calls.length, 0);
+    equal(warnMock.mock.calls.length, 0);
 
     setMockFiles({
       "Podfile.lock": "",
@@ -109,7 +108,7 @@ describe("isDestructive()", () => {
     });
 
     equal(isDestructive(".", config), true);
-    equal(spy(console.warn).calls.length, 5);
+    equal(warnMock.mock.calls.length, 5);
     // 2 x "The following files..." + number of files
   });
 });

--- a/test/embed-manifest/validate.test.ts
+++ b/test/embed-manifest/validate.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, it } from "node:test";
 import { validate as validateActual } from "../../scripts/embed-manifest/validate.mjs";
 import { findFile as findFileActual } from "../../scripts/helpers.js";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("validate()", () => {
   const findFile: typeof findFileActual = (file, startDir = undefined) =>
@@ -30,35 +29,35 @@ describe("validate()", () => {
   });
 
   it("handles missing app manifest", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
 
     equal(validate(undefined), 1);
-    equal(spy(console.error).calls.length, 1);
-    deepEqual(spy(console.error).calls[0].arguments, [
+    equal(errorMock.mock.calls.length, 1);
+    deepEqual(errorMock.mock.calls[0].arguments, [
       `Failed to find 'app.json'. Please make sure you're in the right directory.`,
     ]);
   });
 
   it("catches missing root properties", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{ "name": "Example" }`,
     });
 
     equal(validate(findFile("app.json")), 1001);
-    equal(spy(console.error).calls.length, 2);
+    equal(errorMock.mock.calls.length, 2);
     match(
-      spy(console.error).calls[0].arguments[0],
+      errorMock.mock.calls[0].arguments[0],
       /app.json: error: app.json is not a valid app manifest$/
     );
     match(
-      spy(console.error).calls[1].arguments[0],
+      errorMock.mock.calls[1].arguments[0],
       /app.json: error: <root> must have required property 'displayName'$/
     );
   });
 
   it("catches missing component properties", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{
         "name": "Example",
@@ -77,19 +76,19 @@ describe("validate()", () => {
     });
 
     equal(validate(findFile("app.json")), 1001);
-    equal(spy(console.error).calls.length, 2);
+    equal(errorMock.mock.calls.length, 2);
     match(
-      spy(console.error).calls[0].arguments[0],
+      errorMock.mock.calls[0].arguments[0],
       /app.json: error: app.json is not a valid app manifest$/
     );
     match(
-      spy(console.error).calls[1].arguments[0],
+      errorMock.mock.calls[1].arguments[0],
       /app.json: error: \/components\/0 must have required property 'appKey'$/
     );
   });
 
   it("catches invalid values for `presentationStyle`", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{
         "name": "Example",
@@ -104,19 +103,19 @@ describe("validate()", () => {
     });
 
     equal(validate(findFile("app.json")), 1001);
-    equal(spy(console.error).calls.length, 2);
+    equal(errorMock.mock.calls.length, 2);
     match(
-      spy(console.error).calls[0].arguments[0],
+      errorMock.mock.calls[0].arguments[0],
       /app.json: error: app.json is not a valid app manifest$/
     );
     match(
-      spy(console.error).calls[1].arguments[0],
+      errorMock.mock.calls[1].arguments[0],
       /app.json: error: \/components\/0\/presentationStyle must be equal to one of the allowed values$/
     );
   });
 
   it("catches invalid values for resources", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{
         "name": "Example",
@@ -127,21 +126,21 @@ describe("validate()", () => {
 
     equal(validate(findFile("app.json")), 1003);
     match(
-      spy(console.error).calls[0].arguments[0],
+      errorMock.mock.calls[0].arguments[0],
       /app.json: error: app.json is not a valid app manifest$/
     );
     match(
-      spy(console.error).calls[1].arguments[0],
+      errorMock.mock.calls[1].arguments[0],
       /app.json: error: \/resources must be array$/
     );
     match(
-      spy(console.error).calls[2].arguments[0],
+      errorMock.mock.calls[2].arguments[0],
       /app.json: error: \/resources must be object$/
     );
   });
 
   it("catches duplicate resources", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{
         "name": "Example",
@@ -155,18 +154,18 @@ describe("validate()", () => {
 
     equal(validate(findFile("app.json")), 1003);
     match(
-      spy(console.error).calls[0].arguments[0],
+      errorMock.mock.calls[0].arguments[0],
       /app.json: error: app.json is not a valid app manifest$/
     );
     match(
-      spy(console.error).calls[1].arguments[0],
+      errorMock.mock.calls[1].arguments[0],
       /app.json: error: \/resources must NOT have duplicate items/
     );
   });
 
   for (const platform of ["android", "ios", "macos", "windows"]) {
     it(`catches duplicate, ${platform} specific resources`, (t) => {
-      t.mock.method(console, "error", () => null);
+      const errorMock = t.mock.method(console, "error", () => null);
       setMockFiles({
         "app.json": `{
           "name": "Example",
@@ -182,15 +181,15 @@ describe("validate()", () => {
 
       equal(validate(findFile("app.json")), 1003);
       match(
-        spy(console.error).calls[0].arguments[0],
+        errorMock.mock.calls[0].arguments[0],
         /app.json: error: app.json is not a valid app manifest$/
       );
       match(
-        spy(console.error).calls[1].arguments[0],
+        errorMock.mock.calls[1].arguments[0],
         /app.json: error: \/resources must be array$/
       );
       match(
-        spy(console.error).calls[2].arguments[0],
+        errorMock.mock.calls[2].arguments[0],
         new RegExp(
           `app.json: error: /resources/${platform} must NOT have duplicate items`
         )
@@ -199,7 +198,7 @@ describe("validate()", () => {
   }
 
   it("is silent on valid manifests", (t) => {
-    t.mock.method(console, "error", () => null);
+    const errorMock = t.mock.method(console, "error", () => null);
     setMockFiles({
       "app.json": `{
         "name": "Example",
@@ -250,6 +249,6 @@ describe("validate()", () => {
       displayName: "Example",
       name: "Example",
     });
-    equal(spy(console.error).calls.length, 0);
+    equal(errorMock.mock.calls.length, 0);
   });
 });

--- a/test/spy.ts
+++ b/test/spy.ts
@@ -1,7 +1,0 @@
-/* node:coverage disable */
-
-type Mock = { mock: { calls: { arguments: string[] }[] } };
-
-export function spy(obj: unknown): Mock["mock"] {
-  return (obj as Mock).mock;
-}

--- a/test/windows/copyAndReplace.test.ts
+++ b/test/windows/copyAndReplace.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, it } from "node:test";
 import { readTextFile as readTextFileActual } from "../../scripts/helpers.js";
 import { copyAndReplace as copyAndReplaceActual } from "../../windows/test-app.mjs";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("copyAndReplace()", () => {
   const copyAndReplace: typeof copyAndReplaceActual = (src, dst, r) =>
@@ -16,7 +15,7 @@ describe("copyAndReplace()", () => {
 
   // TODO: Skip because `memfs` hasn't implemented `fs.cp` or `fs.promises.cp`
   it.skip("copies files if no modifications are needed", async (t) => {
-    t.mock.method(fs.promises, "cp");
+    const cpMock = t.mock.method(fs.promises, "cp");
     setMockFiles({
       "ReactTestApp.png": "binary",
       "test/.placeholder": "",
@@ -28,12 +27,12 @@ describe("copyAndReplace()", () => {
       undefined
     );
 
-    equal(spy(fs.promises.cp).calls.length, 1);
+    equal(cpMock.mock.calls.length, 1);
     equal(readTextFile("test/ReactTestApp.png"), "binary");
   });
 
   it("replaces file content", async (t) => {
-    t.mock.method(fs.promises, "cp");
+    const cpMock = t.mock.method(fs.promises, "cp");
     setMockFiles({
       "ReactTestApp.png": "binary",
       "test/.placeholder": "",
@@ -43,7 +42,7 @@ describe("copyAndReplace()", () => {
       binary: "text",
     });
 
-    equal(spy(fs.promises.cp).calls.length, 0);
+    equal(cpMock.mock.calls.length, 0);
     equal(readTextFile("test/ReactTestApp.png"), "text");
   });
 

--- a/test/windows/getBundleResources.test.ts
+++ b/test/windows/getBundleResources.test.ts
@@ -3,7 +3,6 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { getBundleResources as getBundleResourcesActual } from "../../windows/project.mjs";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("getBundleResources()", () => {
   const getBundleResources: typeof getBundleResourcesActual = (p) =>
@@ -78,7 +77,7 @@ describe("getBundleResources()", () => {
   });
 
   it("handles missing manifest", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     deepEqual(getBundleResources(""), {
       appName: "ReactTestApp",
@@ -90,13 +89,13 @@ describe("getBundleResources()", () => {
     });
 
     equal(
-      spy(console.warn).calls[0].arguments[1],
+      warnMock.mock.calls[0].arguments[1],
       "Could not find 'app.json' file."
     );
   });
 
   it("handles invalid manifest", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
     setMockFiles({ "app.json": "-" });
 
     deepEqual(getBundleResources("app.json"), {
@@ -109,7 +108,7 @@ describe("getBundleResources()", () => {
     });
 
     match(
-      spy(console.warn).calls[0].arguments[1],
+      warnMock.mock.calls[0].arguments[1],
       /^Could not parse 'app.json':\n/
     );
   });

--- a/test/windows/parseResources.test.ts
+++ b/test/windows/parseResources.test.ts
@@ -2,7 +2,6 @@ import { deepEqual, equal, match } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { parseResources as parseResourcesActual } from "../../windows/project.mjs";
 import { fs, setMockFiles } from "../fs.mock.js";
-import { spy } from "../spy.js";
 
 describe("parseResources()", () => {
   const parseResources: typeof parseResourcesActual = (r, p) =>
@@ -61,16 +60,16 @@ describe("parseResources()", () => {
   });
 
   it("skips missing assets", (t) => {
-    t.mock.method(console, "warn", () => null);
+    const warnMock = t.mock.method(console, "warn", () => null);
 
     deepEqual(parseResources(["dist/assets", "dist/main.bundle"], "."), empty);
 
     equal(
-      spy(console.warn).calls[0].arguments[1],
+      warnMock.mock.calls[0].arguments[1],
       "Resource not found: dist/assets"
     );
     equal(
-      spy(console.warn).calls[1].arguments[1],
+      warnMock.mock.calls[1].arguments[1],
       "Resource not found: dist/main.bundle"
     );
   });


### PR DESCRIPTION
### Description

`t.mock.method` returns the mock object so we don't need to the helper function.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a