### PR TITLE
fix(windows): fix missing images when building with New Arch

### DIFF
--- a/windows/Win32/ReactApp.Package.wapproj
+++ b/windows/Win32/ReactApp.Package.wapproj
@@ -51,26 +51,26 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <Image Include="Images\SplashScreen.scale-200.png" />
-    <Image Include="Images\Square150x150Logo.scale-100.png" />
-    <Image Include="Images\Square150x150Logo.scale-200.png" />
-    <Image Include="Images\Square150x150Logo.scale-400.png" />
-    <Image Include="Images\Square44x44Logo.altform-lightunplated_targetsize-16.png" />
-    <Image Include="Images\Square44x44Logo.altform-lightunplated_targetsize-256.png" />
-    <Image Include="Images\Square44x44Logo.altform-lightunplated_targetsize-48.png" />
-    <Image Include="Images\Square44x44Logo.altform-unplated_targetsize-16.png" />
-    <Image Include="Images\Square44x44Logo.altform-unplated_targetsize-256.png" />
-    <Image Include="Images\Square44x44Logo.altform-unplated_targetsize-48.png" />
-    <Image Include="Images\Square44x44Logo.scale-100.png" />
-    <Image Include="Images\Square44x44Logo.scale-200.png" />
-    <Image Include="Images\Square44x44Logo.scale-400.png" />
-    <Image Include="Images\Square44x44Logo.targetsize-16.png" />
-    <Image Include="Images\Square44x44Logo.targetsize-256.png" />
-    <Image Include="Images\Square44x44Logo.targetsize-48.png" />
-    <Image Include="Images\StoreLogo.scale-100.png" />
-    <Image Include="Images\StoreLogo.scale-200.png" />
-    <Image Include="Images\StoreLogo.scale-400.png" />
-    <Image Include="Images\Wide310x150Logo.scale-200.png" />
+    <Content Include="Images\SplashScreen.scale-200.png" />
+    <Content Include="Images\Square150x150Logo.scale-100.png" />
+    <Content Include="Images\Square150x150Logo.scale-200.png" />
+    <Content Include="Images\Square150x150Logo.scale-400.png" />
+    <Content Include="Images\Square44x44Logo.altform-lightunplated_targetsize-16.png" />
+    <Content Include="Images\Square44x44Logo.altform-lightunplated_targetsize-256.png" />
+    <Content Include="Images\Square44x44Logo.altform-lightunplated_targetsize-48.png" />
+    <Content Include="Images\Square44x44Logo.altform-unplated_targetsize-16.png" />
+    <Content Include="Images\Square44x44Logo.altform-unplated_targetsize-256.png" />
+    <Content Include="Images\Square44x44Logo.altform-unplated_targetsize-48.png" />
+    <Content Include="Images\Square44x44Logo.scale-100.png" />
+    <Content Include="Images\Square44x44Logo.scale-200.png" />
+    <Content Include="Images\Square44x44Logo.scale-400.png" />
+    <Content Include="Images\Square44x44Logo.targetsize-16.png" />
+    <Content Include="Images\Square44x44Logo.targetsize-256.png" />
+    <Content Include="Images\Square44x44Logo.targetsize-48.png" />
+    <Content Include="Images\StoreLogo.scale-100.png" />
+    <Content Include="Images\StoreLogo.scale-200.png" />
+    <Content Include="Images\StoreLogo.scale-400.png" />
+    <Content Include="Images\Wide310x150Logo.scale-200.png" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="ReactApp.vcxproj">


### PR DESCRIPTION
### Description

Somehow, we managed to use `Image` instead of `Content` in the `.wapproj`, causing them to (occasionally?) not be included in the build.

Resolves #2176.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version 0.74
cd example
yarn install-windows-test-app --use-fabric
yarn windows
```

Build should succeed.