### PR TITLE
ci(macos): temporarily disable test step due to random failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,8 @@ jobs:
           node --test test/config.test.mjs
         working-directory: example
       - name: Test
-        if: ${{ steps.affected.outputs.macos != '' && github.event_name != 'schedule' }}
+        # Temporarily disabled due to random failures
+        if: false # ${{ steps.affected.outputs.macos != '' && github.event_name != 'schedule' }}
         run: |
           ../scripts/xcodebuild.sh macos/Example.xcworkspace test-without-building
         working-directory: example


### PR DESCRIPTION
### Description

Temporarily disable test step due to random failures:

```
Testing failed:
  ReactTestApp (14119) encountered an error (Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying Error: Crash: ReactTestApp (14119) __55-[RCTDevLoadingView showMessage:color:backgroundColor:]_block_invoke. libsystem_c.dylib: abort() called))

** TEST EXECUTE FAILED **
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a