### PR TITLE
fix(android): `minSdkVersion` was bumped to 24 in latest nightly

### DIFF
--- a/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/react/TestAppReactNativeHost.kt
@@ -15,7 +15,6 @@ import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
-import com.facebook.soloader.SoLoader
 import com.microsoft.reacttestapp.BuildConfig
 import com.microsoft.reacttestapp.MainActivity
 import com.microsoft.reacttestapp.R
@@ -171,10 +170,7 @@ class TestAppReactNativeHost(
         return reactInstanceManager
     }
 
-    override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory {
-        SoLoader.init(application, false)
-        return HermesExecutorFactory()
-    }
+    override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory = HermesExecutorFactory()
 
     override fun getJSMainModuleName() = "index"
 

--- a/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -41,6 +41,7 @@ class TestApp :
     override fun onCreate() {
         super.onCreate()
 
+        @Suppress("DEPRECATION")
         SoLoader.init(this, false)
 
         reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)

--- a/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt
@@ -33,6 +33,7 @@ class TestApp :
     override fun onCreate() {
         super.onCreate()
 
+        @Suppress("DEPRECATION")
         SoLoader.init(this, false)
 
         reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,10 +1,6 @@
 ext {
     apply(from: "${buildscript.sourceFile.getParent()}/test-app-util.gradle")
 
-    compileSdkVersion = rootProject.findProperty("react.compileSdkVersion") ?: 34
-    minSdkVersion = rootProject.findProperty("react.minSdkVersion") ?: 23
-    targetSdkVersion = rootProject.findProperty("react.targetSdkVersion") ?: 33
-
     /**
      * Returns the recommended Gradle plugin version for the specified React Native
      * version.
@@ -21,7 +17,22 @@ ext {
         }
     }
 
+    // TODO: Bump `minSdkVersion` to 24 in 4.0
+    def getDefaultMinSdkVersion = { reactNativeVersion ->
+        if (reactNativeVersion >= v(0, 76, 0)) {
+            return 24
+        } else {
+            return 23
+        }
+    }
+
     reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
+
+    compileSdkVersion = rootProject.findProperty("react.compileSdkVersion") ?: 34
+    minSdkVersion = rootProject.findProperty("react.minSdkVersion")
+                        ?: getDefaultMinSdkVersion(reactNativeVersion)
+    targetSdkVersion = rootProject.findProperty("react.targetSdkVersion") ?: 33
+
     autodetectReactNativeVersion = reactNativeVersion == 0 || reactNativeVersion >= v(0, 71, 0)
     enableNewArchitecture = isNewArchitectureEnabled(project)
     enableBridgeless = isBridgelessEnabled(project, enableNewArchitecture)

--- a/android/test-app-util.gradle
+++ b/android/test-app-util.gradle
@@ -151,7 +151,7 @@ ext.getApplicationId = {
 
 ext.getArchitectures = { project ->
     def archs = project.findProperty("react.nativeArchitectures")
-        ?: project.findProperty("reactNativeArchitectures")
+                    ?: project.findProperty("reactNativeArchitectures")
     return archs != null
         ? archs.split(",")
         : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -284,7 +284,7 @@ ext.getVersionName = {
 ext.isBridgelessEnabled = { project, isNewArchEnabled ->
     if (isNewArchEnabled) {
         def bridgelessEnabled = project.findProperty("react.bridgelessEnabled")
-            ?: project.findProperty("bridgelessEnabled")
+                                    ?: project.findProperty("bridgelessEnabled")
         if (bridgelessEnabled != "false") {
             def version = getPackageVersionNumber("react-native", project.rootDir)
             def isSupported = version == 0 || version >= v(0, 73, 0)
@@ -314,7 +314,7 @@ ext.isFabricEnabled = { project ->
 
 ext.isNewArchitectureEnabled = { project ->
     def newArchEnabled = project.findProperty("react.newArchEnabled")
-        ?: project.findProperty("newArchEnabled")
+                             ?: project.findProperty("newArchEnabled")
     if (newArchEnabled == "true") {
         def version = getPackageVersionNumber("react-native", project.rootDir)
         def isSupported = version == 0 || version >= v(0, 71, 0)


### PR DESCRIPTION
### Description

`minSdkVersion` was bumped to 24 in latest nightly

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/10414421019/job/28843339489

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
yarn android
```

### Screenshots

![Screenshot_1723797568](https://github.com/user-attachments/assets/82450978-9ad2-4b87-b6b8-42b7bcc444e0)