### PR TITLE
fix(ios): match deployment target when on 0.76

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -326,10 +326,19 @@ def make_project!(xcodeproj, project_root, target_platform, options)
   app_project.save
 
   config = app_project.build_configurations[0]
+
+  # TODO: Deployment target is bumped in 4.0. We should remove this block then.
+  ios_deployment_target =
+    if rn_version >= v(0, 76, 0)
+      '15.1'
+    else
+      config.resolve_build_setting(IPHONEOS_DEPLOYMENT_TARGET)
+    end
+
   {
     :xcodeproj_path => xcodeproj_dst,
     :platforms => {
-      :ios => config.resolve_build_setting(IPHONEOS_DEPLOYMENT_TARGET),
+      :ios => ios_deployment_target,
       :macos => config.resolve_build_setting(MACOSX_DEPLOYMENT_TARGET),
       :visionos => config.resolve_build_setting(XROS_DEPLOYMENT_TARGET),
     },


### PR DESCRIPTION
### Description

`react-native` bumped iOS deployment target yesterday, breaking our nightly builds. This is a temporary change to bump it when we're on 0.76. Long term, we will match the version in the next major release of RNTA.

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn
cd example
pod install --project-directory=ios
```