### PR TITLE
fix(macos): declare support for 0.75

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Pods/
 android/**/build/
 clang-format-diff.py
 coverage/
+example/*/DerivedData/
 example/*/build/
 example/Screenshot-*.png
 local.properties

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -327,19 +327,25 @@ def make_project!(xcodeproj, project_root, target_platform, options)
 
   config = app_project.build_configurations[0]
 
-  # TODO: Deployment target is bumped in 4.0. We should remove this block then.
+  # TODO: Deployment targets are bumped in 4.0. We should remove these blocks then.
   ios_deployment_target =
     if rn_version >= v(0, 76, 0)
       '15.1'
     else
       config.resolve_build_setting(IPHONEOS_DEPLOYMENT_TARGET)
     end
+  macos_deployment_target =
+    if rn_version >= v(0, 75, 0)
+      '11.0'
+    else
+      config.resolve_build_setting(MACOSX_DEPLOYMENT_TARGET)
+    end
 
   {
     :xcodeproj_path => xcodeproj_dst,
     :platforms => {
       :ios => ios_deployment_target,
-      :macos => config.resolve_build_setting(MACOSX_DEPLOYMENT_TARGET),
+      :macos => macos_deployment_target,
       :visionos => config.resolve_build_setting(XROS_DEPLOYMENT_TARGET),
     },
     :react_native_version => rn_version,

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@expo/config-plugins": ">=5.0",
     "react": "17.0.1 - 19.0",
     "react-native": "0.66 - 0.75 || >=0.76.0-0 <0.76.0",
-    "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.74",
+    "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75",
     "react-native-windows": "^0.0.0-0 || 0.66 - 0.75"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12486,7 +12486,7 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 19.0
     react-native: 0.66 - 0.75 || >=0.76.0-0 <0.76.0
-    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.74
+    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75
     react-native-windows: ^0.0.0-0 || 0.66 - 0.75
   peerDependenciesMeta:
     "@callstack/react-native-visionos":


### PR DESCRIPTION
### Description

Declare support for `react-native-macos` 0.75.

Also bumps the repository to 0.75.

Blocked by:
- [x] https://github.com/microsoft/react-native-macos/pull/2182
- [x] https://github.com/microsoft/react-native-macos/issues/2183

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example
pod install --project-directory=macos
yarn macos

# In a separate terminal
yarn start
```

| 0.75.1 | 0.75.2 |
| :----: | :----: |
| ![image](https://github.com/user-attachments/assets/d3694f06-adb5-4bbe-9791-79ab8aa6df08) | <img width="592" alt="image" src="https://github.com/user-attachments/assets/64b59b05-ab15-4ef6-ab63-6c6b9858ab4d"> |
