### PR TITLE
feat: add :additional_build_settings to options

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -98,6 +98,16 @@ def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
 
+def append_additional_build_settings!(build_settings, settings_to_append)
+  settings_to_append&.each do |setting, value|
+    if build_settings.key?(setting)
+      build_settings[setting] += value
+    else
+      build_settings[setting] = value
+    end
+  end
+end
+
 def use_hermes?(options)
   use_hermes = ENV.fetch('USE_HERMES', nil)
   return use_hermes == '1' unless use_hermes.nil?

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -98,15 +98,9 @@ def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
 
-def append_additional_build_settings!(build_settings, settings_to_append)
+def override_build_settings!(build_settings, settings_to_append)
   settings_to_append&.each do |setting, value|
-    if build_settings.key?(setting)
-      current = build_settings[setting]
-      build_settings[setting] += " #{value}" if current.is_a? String
-      build_settings[setting] += value if current.is_a? Array
-    else
-      build_settings[setting] = value
-    end
+    build_settings[setting] = value
   end
 end
 

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -101,7 +101,9 @@ end
 def append_additional_build_settings!(build_settings, settings_to_append)
   settings_to_append&.each do |setting, value|
     if build_settings.key?(setting)
-      build_settings[setting] += value
+      current = build_settings[setting]
+      build_settings[setting] += " #{value}" if current.is_a? String
+      build_settings[setting] += value if current.is_a? Array
     else
       build_settings[setting] = value
     end

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -259,6 +259,8 @@ def make_project!(xcodeproj, project_root, target_platform, options)
     uitests_build_settings[PRODUCT_BUNDLE_IDENTIFIER] = "#{product_bundle_identifier}UITests"
   end
 
+  append_additional_build_settings!(build_settings, options[:additional_build_settings])
+
   build_settings[PRODUCT_DISPLAY_NAME] = display_name
   build_settings[PRODUCT_VERSION] = version || '1.0'
 

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -259,7 +259,7 @@ def make_project!(xcodeproj, project_root, target_platform, options)
     uitests_build_settings[PRODUCT_BUNDLE_IDENTIFIER] = "#{product_bundle_identifier}UITests"
   end
 
-  append_additional_build_settings!(build_settings, options[:additional_build_settings])
+  override_build_settings!(build_settings, options[:build_setting_overrides])
 
   build_settings[PRODUCT_DISPLAY_NAME] = display_name
   build_settings[PRODUCT_VERSION] = version || '1.0'

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -113,27 +113,31 @@ class TestPodHelpers < Minitest::Test
     assert_equal(1_001_001, v(1, 1, 1))
   end
 
-  def test_append_additional_build_settings
-    build_settings = { 'OTHER_LDFLAGS' => '-l"Pods-TestApp"' }
+  def test_override_build_settings
+    build_settings = { 'OTHER_LDFLAGS' => '-l"Pods-TestApp"', 'ONLY_ACTIVE_ARCH' => 'NO' }
 
-    append_additional_build_settings!(build_settings, {})
+    override_build_settings!(build_settings, {})
 
     assert_equal('-l"Pods-TestApp"', build_settings['OTHER_LDFLAGS'])
 
-    append_additional_build_settings!(build_settings, { 'OTHER_LDFLAGS' => ' -ObjC' })
+    override_build_settings!(build_settings, { 'OTHER_LDFLAGS' => ' -ObjC' })
 
-    assert_equal('-l"Pods-TestApp" -ObjC', build_settings['OTHER_LDFLAGS'])
+    assert_equal(' -ObjC', build_settings['OTHER_LDFLAGS'])
 
     # Test passing a table
     build_settings_arr = { 'OTHER_LDFLAGS' => ['$(inherited)', '-l"Pods-TestApp"'] }
-    append_additional_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => [' -ObjC'] })
+    override_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => [' -ObjC'] })
 
-    assert_equal(['$(inherited)', '-l"Pods-TestApp"', ' -ObjC'],
-                 build_settings_arr['OTHER_LDFLAGS'])
+    assert_equal([' -ObjC'], build_settings_arr['OTHER_LDFLAGS'])
 
     # Test setting a new key
-    append_additional_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
+    override_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
 
     assert_equal('-DDEBUG', build_settings['OTHER_CFLAGS'])
+
+
+    override_build_settings!(build_settings, { 'ONLY_ACTIVE_ARCH' => 'YES' })
+
+    assert_equal('YES', build_settings['ONLY_ACTIVE_ARCH'])
   end
 end

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -134,8 +134,6 @@ class TestPodHelpers < Minitest::Test
     override_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
 
     assert_equal('-DDEBUG', build_settings['OTHER_CFLAGS'])
-
-
     override_build_settings!(build_settings, { 'ONLY_ACTIVE_ARCH' => 'YES' })
 
     assert_equal('YES', build_settings['ONLY_ACTIVE_ARCH'])

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -112,4 +112,27 @@ class TestPodHelpers < Minitest::Test
     assert_equal(1_001_000, v(1, 1, 0))
     assert_equal(1_001_001, v(1, 1, 1))
   end
+
+  def test_append_additional_build_settings
+    build_settings = { 'OTHER_LDFLAGS' => '-l"Pods-TestApp"' }
+
+    append_additional_build_settings!(build_settings, {})
+
+    assert_equal('-l"Pods-TestApp"', build_settings['OTHER_LDFLAGS'])
+
+    append_additional_build_settings!(build_settings, { 'OTHER_LDFLAGS' => ' -ObjC' })
+
+    assert_equal('-l"Pods-TestApp" -ObjC', build_settings['OTHER_LDFLAGS'])
+
+    # Test passing a table
+    build_settings_arr = { 'OTHER_LDFLAGS' => ['$(inherited)', '-l"Pods-TestApp"'] }
+    append_additional_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => [' -ObjC'] })
+
+    assert_equal(['$(inherited)', '-l"Pods-TestApp"', ' -ObjC'], build_settings_arr['OTHER_LDFLAGS'])
+
+    # Test setting a new key
+    append_additional_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
+
+    assert_equal('-DDEBUG', build_settings['OTHER_CFLAGS'])
+  end
 end

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -128,7 +128,8 @@ class TestPodHelpers < Minitest::Test
     build_settings_arr = { 'OTHER_LDFLAGS' => ['$(inherited)', '-l"Pods-TestApp"'] }
     append_additional_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => [' -ObjC'] })
 
-    assert_equal(['$(inherited)', '-l"Pods-TestApp"', ' -ObjC'], build_settings_arr['OTHER_LDFLAGS'])
+    assert_equal(['$(inherited)', '-l"Pods-TestApp"', ' -ObjC'],
+                 build_settings_arr['OTHER_LDFLAGS'])
 
     # Test setting a new key
     append_additional_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

This change allows us to pass additional build settings to the main generated project:

```ruby
options = {
  :app_build_settings => { 
    'LIBRARY_SEARCH_PATHS' => '$(inherited) "../something"',
  }
}


use_test_app! options 
```



### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

Pass additional build setting. 


