### PR TITLE
fix(android): filter out pure C++ modules from autolinking

### DIFF
--- a/android/autolink.mjs
+++ b/android/autolink.mjs
@@ -82,7 +82,7 @@ export function pickAndroidDependencies({ dependencies }) {
   for (const dependency of Object.values(dependencies)) {
     const { android } = dependency.platforms;
     const projectDir = android?.sourceDir;
-    if (projectDir) {
+    if (projectDir && android?.isPureCxxDependency != true) {
       const name = ":" + cleanDependencyName(dependency.name);
 
       /** @type {AndroidDependencies[string]["configurations"]} */


### PR DESCRIPTION
### Description

See also
https://github.com/facebook/react-native/commit/833c3a2cf5df6b65c6fe75577da2df7c5a085e8d

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a