### PR TITLE
fix: declare support for 0.76

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx --package react-native-test-app@latest init
 In this example, we will create a project named "sample" in `sample` with apps
 for all platforms:
 
-```sh
+```
 ✔ What is the name of your test app? … sample
 ? Which platforms do you need test apps for? ›
 Instructions:
@@ -44,8 +44,9 @@ Instructions:
 ◉   Android
 ◉   iOS
 ◉   macOS
+◯   visionOS (Experimental)
 ◉   Windows
-✔ Where should we create the new project?? … sample
+✔ Where should we create the new project? … sample
 ```
 
 Install npm dependencies inside the new project folder:
@@ -100,9 +101,11 @@ in the wiki.
 [react-native-datetimepicker](https://github.com/react-native-datetimepicker/datetimepicker) &bull;
 [react-native-google-signin](https://github.com/react-native-google-signin/google-signin) &bull;
 [react-native-image-editor](https://github.com/callstack/react-native-image-editor) &bull;
+[react-native-keychain](https://github.com/oblador/react-native-keychain) &bull;
 [react-native-masked-view](https://github.com/react-native-masked-view/masked-view) &bull;
 [react-native-menu](https://github.com/react-native-menu/menu) &bull;
 [react-native-netinfo](https://github.com/react-native-netinfo/react-native-netinfo) &bull;
+[react-native-pager-view](https://github.com/callstack/react-native-pager-view) &bull;
 [react-native-segmented-control](https://github.com/react-native-segmented-control/segmented-control) &bull;
 [react-native-webview](https://github.com/react-native-webview/react-native-webview) &bull;
 [realm-js](https://github.com/realm/realm-js) &bull;

--- a/package.json
+++ b/package.json
@@ -97,12 +97,12 @@
     "uuid": "^10.0.0"
   },
   "peerDependencies": {
-    "@callstack/react-native-visionos": "0.73 - 0.75",
+    "@callstack/react-native-visionos": "0.73 - 0.76",
     "@expo/config-plugins": ">=5.0",
     "react": "17.0.1 - 19.0",
-    "react-native": "0.66 - 0.75 || >=0.76.0-0 <0.76.0",
+    "react-native": "0.66 - 0.76 || >=0.77.0-0 <0.77.0",
     "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75",
-    "react-native-windows": "^0.0.0-0 || 0.66 - 0.75"
+    "react-native-windows": "^0.0.0-0 || 0.66 - 0.76"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/scripts/testing/test-matrix.mjs
+++ b/scripts/testing/test-matrix.mjs
@@ -4,7 +4,7 @@
  * Reminder that this script is meant to be runnable without installing
  * dependencies. It can therefore not rely on any external libraries.
  */
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import { URL, fileURLToPath } from "node:url";
 import * as util from "node:util";
@@ -327,8 +327,7 @@ if (platforms.length === 0) {
     })
     .then(() => {
       showBanner(`Reconfigure existing app`);
-      $(
-        PACKAGE_MANAGER,
+      const args = [
         "configure-test-app",
         "-p",
         "android",
@@ -339,8 +338,12 @@ if (platforms.length === 0) {
         "-p",
         "visionos",
         "-p",
-        "windows"
-      );
+        "windows",
+      ];
+      const { status } = spawnSync(PACKAGE_MANAGER, args, { stdio: "inherit" });
+      if (status !== 1) {
+        throw new Error("Expected an error");
+      }
     })
     .then(() => {
       showBanner(green("✔ Pass"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -12446,12 +12446,12 @@ __metadata:
     typescript: "npm:^5.0.0"
     uuid: "npm:^10.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": 0.73 - 0.75
+    "@callstack/react-native-visionos": 0.73 - 0.76
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 19.0
-    react-native: 0.66 - 0.75 || >=0.76.0-0 <0.76.0
+    react-native: 0.66 - 0.76 || >=0.77.0-0 <0.77.0
     react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75
-    react-native-windows: ^0.0.0-0 || 0.66 - 0.75
+    react-native-windows: ^0.0.0-0 || 0.66 - 0.76
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true


### PR DESCRIPTION
### Description

Declare support for 0.76.

For blocking issues, see https://github.com/microsoft/react-native-test-app/issues/2131

Resolves #2131.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [x] visionOS
- [x] Windows

### Test plan

```
npm run test:matrix 0.76
```

### Screenshots

| Configuration | JSC  | Hermes | Fabric | Fabric + Hermes |
| :------------ | :--: | :----: | :----: | :-------------: |
| Android       | n/a  | ![Screenshot-Android-hermes](https://github.com/user-attachments/assets/c71f2746-5f4f-419b-a342-f1e3a8d1e95d) |  n/a   | ![Screenshot-Android-hermes-fabric-concurrent](https://github.com/user-attachments/assets/790fa58a-a9f7-44c3-bfd4-231ae1a0bae9) |
| iOS           | ![Screenshot-iOS](https://github.com/user-attachments/assets/026f3951-b9b1-424f-90f8-f61b10b20169) | ![Screenshot-iOS-hermes](https://github.com/user-attachments/assets/172ba3e6-bf51-412d-8bdc-7dc882b46477) | ![Screenshot-iOS-fabric-concurrent](https://github.com/user-attachments/assets/670b9258-c0b7-4cd8-a020-c5d1930d3c80) | ![Screenshot-iOS-hermes-fabric-concurrent](https://github.com/user-attachments/assets/807e9b77-f2cf-4544-a7ca-c2398335a7d8) |
| visionOS      | ![Screenshot-visionOS](https://github.com/user-attachments/assets/9e9e95e0-c412-4373-bb9c-6318b3a4d633) | n/a | n/a | n/a |
| Windows       | n/a  | ![image](https://github.com/user-attachments/assets/569ff687-2cb4-40b4-b61d-0af8f269bb3a) |  n/a   | ![image](https://github.com/user-attachments/assets/a833f025-a6d1-4a7c-a799-aea05bbc91cc) |