### PR TITLE
fix(android): initialize SoLoader with merged libraries on 0.76

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -249,11 +249,15 @@ android {
                         ? "src/devserverhelper-0.73/java"
                         : "src/devserverhelper-pre-0.73/java",
 
-            // TODO: Remove this block when we drop support for 0.72
-            // https://github.com/facebook/react-native/commit/c3f672cef7d4f287d3d729d33650f917ed132a0c
-            reactNativeVersion > 0 && reactNativeVersion < v(0, 73, 0)
-                ? "src/reactapplication-pre-0.73/java"
-                : "src/reactapplication-0.73/java",
+            // TODO: Remove this block when we drop support for 0.75
+            // https://github.com/react-native-community/template/commit/f738a366b194dd21d4d2bc14c9215b630714dd70
+            reactNativeVersion >= v(0, 76, 0)
+                ? "src/reactapplication-0.76/java"
+                // TODO: Remove this block when we drop support for 0.72
+                // https://github.com/facebook/react-native/commit/c3f672cef7d4f287d3d729d33650f917ed132a0c
+                : reactNativeVersion < v(0, 73, 0)
+                    ? "src/reactapplication-pre-0.73/java"
+                    : "src/reactapplication-0.73/java",
         ]
     }
 

--- a/android/app/src/reactapplication-0.76/java/com/microsoft/reacttestapp/TestApp.kt
+++ b/android/app/src/reactapplication-0.76/java/com/microsoft/reacttestapp/TestApp.kt
@@ -1,0 +1,69 @@
+package com.microsoft.reacttestapp
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.soloader.OpenSourceMergedSoMapping
+import com.facebook.soloader.SoLoader
+import com.microsoft.reacttestapp.manifest.Manifest
+import com.microsoft.reacttestapp.manifest.ManifestProvider
+import com.microsoft.reacttestapp.react.ReactBundleNameProvider
+import com.microsoft.reacttestapp.react.TestAppReactNativeHost
+import com.microsoft.reacttestapp.support.ReactTestAppLifecycleEvents
+
+class TestApp :
+    Application(),
+    ReactApplication {
+
+    val bundleNameProvider: ReactBundleNameProvider
+        get() = reactNativeBundleNameProvider
+
+    val manifest: Manifest by lazy {
+        ManifestProvider.manifest()
+    }
+
+    override val reactHost: ReactHost
+        get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+    override val reactNativeHost: TestAppReactNativeHost
+        get() = reactNativeHostInternal
+
+    private lateinit var reactNativeBundleNameProvider: ReactBundleNameProvider
+    private lateinit var reactNativeHostInternal: TestAppReactNativeHost
+
+    fun reloadJSFromServer(activity: Activity, bundleURL: String) {
+        reactNativeHostInternal.reloadJSFromServer(activity, bundleURL)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        SoLoader.init(this, OpenSourceMergedSoMapping)
+
+        reactNativeBundleNameProvider = ReactBundleNameProvider(this, manifest.bundleRoot)
+        reactNativeHostInternal =
+            TestAppReactNativeHost(this, reactNativeBundleNameProvider)
+
+        val eventConsumers = PackageList(this).packages
+            .filter { it is ReactTestAppLifecycleEvents }
+            .map { it as ReactTestAppLifecycleEvents }
+
+        eventConsumers.forEach { it.onTestAppInitialized() }
+
+        reactNativeHostInternal.init(
+            beforeReactNativeInit = {
+                eventConsumers.forEach { it.onTestAppWillInitializeReactNative() }
+            },
+            afterReactNativeInit = {
+                eventConsumers.forEach { it.onTestAppDidInitializeReactNative() }
+            }
+        )
+    }
+}
+
+val Context.testApp: TestApp
+    get() = applicationContext as TestApp

--- a/test/pack.test.ts
+++ b/test/pack.test.ts
@@ -95,6 +95,7 @@ describe("npm pack", () => {
       "android/app/src/reactactivitydelegate-0.75/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactactivitydelegate-pre-0.72/java/com/microsoft/reacttestapp/component/ComponentActivityDelegate.kt",
       "android/app/src/reactapplication-0.73/java/com/microsoft/reacttestapp/TestApp.kt",
+      "android/app/src/reactapplication-0.76/java/com/microsoft/reacttestapp/TestApp.kt",
       "android/app/src/reactapplication-pre-0.73/java/com/microsoft/reacttestapp/TestApp.kt",
       "android/app/src/reactinstanceeventlistener-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt",
       "android/app/src/reactinstanceeventlistener-pre-0.68/java/com/microsoft/reacttestapp/compat/ReactInstanceEventListener.kt",


### PR DESCRIPTION
### Description

This needs to merge whenever https://github.com/reactwg/react-native-releases/issues/486 gets resolved (likely with 0.76-rc.1)

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.76 -- --core-only
cd example
yarn android

# In a separate terminal
yarn start
```