### PR TITLE
Yg update layout direction

### DIFF
--- a/windows/Win32/Main.cpp
+++ b/windows/Win32/Main.cpp
@@ -50,9 +50,12 @@ namespace
 
         auto hwnd = winrt::Microsoft::UI::GetWindowFromWindowId(window.Id());
         auto scaleFactor = ScaleFactor(hwnd);
+        winrt::Microsoft::ReactNative::LayoutConstraints constraints;
         winrt::Size size{window.ClientSize().Width / scaleFactor,
                          window.ClientSize().Height / scaleFactor};
-        rootView.Arrange({size, size, winrt::LayoutDirection::Undefined}, {0, 0});
+        constraints.MinimumSize = constraints.MaximumSize = size;
+        IsIconic(hwnd) ? constraints.LayoutDirection = winrt::LayoutDirection::Undefined : winrt::LayoutDirection::LeftToRight;
+        rootView.Arrange(constraints, {0, 0});
     }
 
     winrt::ReactViewOptions MakeReactViewOptions(ReactApp::Component const &component)

--- a/windows/Win32/Main.cpp
+++ b/windows/Win32/Main.cpp
@@ -54,7 +54,7 @@ namespace
         winrt::Size size{window.ClientSize().Width / scaleFactor,
                          window.ClientSize().Height / scaleFactor};
         constraints.MinimumSize = constraints.MaximumSize = size;
-        IsIconic(hwnd) ? constraints.LayoutDirection = winrt::LayoutDirection::Undefined : winrt::LayoutDirection::LeftToRight;
+        constraints.LayoutDirection = winrt::LayoutDirection::LeftToRight;
         rootView.Arrange(constraints, {0, 0});
     }
 


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

In `Main.cpp`, currently the call to `ReactNativeIsland::Arrange()` is being passed an 'undefined' `layoutDirection`. This change modifies the `constraints` object so that the `layoutDirection` is not undefined.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->
When trying to launch an example fabric app in this async-storage [branch](https://github.com/Yajur-Grover/async-storage/tree/yg-fabric-windows-upgrade), I got the following error:

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
