### PR TITLE
Update layoutDirection in calls to `ReactNativeIsland::Arrange`

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -20,9 +20,11 @@
   },
   "dependencies": {
     "@callstack/react-native-visionos": "^0.75.0",
+    "@react-native-webapis/web-storage": "^0  .3.0",
     "react": "^18.2.0",
     "react-native": "^0.75.0",
-    "react-native-macos": "^0.75.2"
+    "react-native-macos": "^0.75.2",
+    "react-native-windows": "^0.75.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -38,7 +40,6 @@
     "appium-uiautomator2-driver": "^3.0.0",
     "appium-xcuitest-driver": "^7.0.0",
     "react-native-test-app": "workspace:*",
-    "react-native-windows": "^0.75.0",
     "webdriverio": "^9.0.0"
   },
   "eslintConfig": {

--- a/example/package.json
+++ b/example/package.json
@@ -20,11 +20,9 @@
   },
   "dependencies": {
     "@callstack/react-native-visionos": "^0.75.0",
-    "@react-native-webapis/web-storage": "^0.3.0",
     "react": "^18.2.0",
     "react-native": "^0.75.0",
-    "react-native-macos": "^0.75.2",
-    "react-native-windows": "^0.75.0"
+    "react-native-macos": "^0.75.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -40,6 +38,7 @@
     "appium-uiautomator2-driver": "^3.0.0",
     "appium-xcuitest-driver": "^7.0.0",
     "react-native-test-app": "workspace:*",
+    "react-native-windows": "^0.75.0",
     "webdriverio": "^9.0.0"
   },
   "eslintConfig": {

--- a/windows/Win32/Main.cpp
+++ b/windows/Win32/Main.cpp
@@ -50,9 +50,12 @@ namespace
 
         auto hwnd = winrt::Microsoft::UI::GetWindowFromWindowId(window.Id());
         auto scaleFactor = ScaleFactor(hwnd);
+        winrt::Microsoft::ReactNative::LayoutConstraints constraints;
         winrt::Size size{window.ClientSize().Width / scaleFactor,
                          window.ClientSize().Height / scaleFactor};
-        rootView.Arrange({size, size, winrt::LayoutDirection::Undefined}, {0, 0});
+        constraints.MinimumSize = constraints.MaximumSize = size;
+        IsIconic(hwnd) ? constraints.LayoutDirection = winrt::LayoutDirection::Undefined : winrt::LayoutDirection::LeftToRight;
+        rootView.Arrange(constraints, {0, 0});
     }
 
     winrt::ReactViewOptions MakeReactViewOptions(ReactApp::Component const &component)

--- a/windows/Win32/Main.cpp
+++ b/windows/Win32/Main.cpp
@@ -54,7 +54,7 @@ namespace
         winrt::Size size{window.ClientSize().Width / scaleFactor,
                          window.ClientSize().Height / scaleFactor};
         constraints.MinimumSize = constraints.MaximumSize = size;
-        IsIconic(hwnd) ? constraints.LayoutDirection = winrt::LayoutDirection::Undefined : winrt::LayoutDirection::LeftToRight;
+        constraints.LayoutDirection = winrt::LayoutDirection::LeftToRight;
         rootView.Arrange(constraints, {0, 0});
     }
 

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -84,8 +84,7 @@ export function replaceContent(content, replacements) {
  */
 export function toProjectEntry(project, destPath) {
   return [
-    `Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "${
-      project.name
+    `Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "${project.name
     }", "${path.relative(destPath, project.path)}", "${project.guid}"`,
     "\tProjectSection(ProjectDependencies) = postProject",
     `\t\t${templateView.projectGuidUpper} = ${templateView.projectGuidUpper}`,
@@ -198,6 +197,10 @@ export function generateSolution(destPath, options, fs = nodefs) {
           ...templateView,
           name: path.basename(projectFileName, path.extname(projectFileName)),
           useExperimentalNuget: info.useExperimentalNuGet,
+          rnwPathFromProjectRoot: path.relative(
+            path.dirname(projectManifest),
+            rnWindowsPath
+          ),
         })
         // The current version of this template (v0.63.18) assumes that
         // `react-native-windows` is always installed in

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -84,7 +84,8 @@ export function replaceContent(content, replacements) {
  */
 export function toProjectEntry(project, destPath) {
   return [
-    `Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "${project.name
+    `Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "${
+      project.name
     }", "${path.relative(destPath, project.path)}", "${project.guid}"`,
     "\tProjectSection(ProjectDependencies) = postProject",
     `\t\t${templateView.projectGuidUpper} = ${templateView.projectGuidUpper}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,26 +3073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-webapis/web-storage@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@react-native-webapis/web-storage@npm:0.3.0"
-  peerDependencies:
-    "@callstack/react-native-visionos": ">=0.73"
-    react: ">=18.2.0"
-    react-native: ">=0.72"
-    react-native-macos: ">=0.72"
-    react-native-windows: ">=0.72"
-  peerDependenciesMeta:
-    "@callstack/react-native-visionos":
-      optional: true
-    react-native-macos:
-      optional: true
-    react-native-windows:
-      optional: true
-  checksum: 10c0/beb7d762abce424dca060c9af53c2c65fa5033098cc7ad552fa0d75d588046da1027d7f776d4fb2d90ee4c445890e229d9fd3c167ed8f9e8d7c5bf189043560d
-  languageName: node
-  linkType: hard
-
 "@react-native-windows/cli@npm:0.75.1":
   version: 0.75.1
   resolution: "@react-native-windows/cli@npm:0.75.1"
@@ -7553,7 +7533,6 @@ __metadata:
     "@babel/preset-env": "npm:^7.20.0"
     "@callstack/react-native-visionos": "npm:^0.75.0"
     "@react-native-community/cli": "npm:^14.0.0"
-    "@react-native-webapis/web-storage": "npm:^0.3.0"
     "@react-native/babel-preset": "npm:^0.75.0"
     "@react-native/metro-config": "npm:^0.75.0"
     "@rnx-kit/metro-config": "npm:^2.0.0"


### PR DESCRIPTION
### Description

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

In `Main.cpp`, currently the call to `ReactNativeIsland::Arrange()` is being passed an 'undefined' `layoutDirection`. This change modifies the `constraints` object so that the `layoutDirection` is not undefined.

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->
When trying to launch an example fabric app in this async-storage [branch](https://github.com/Yajur-Grover/async-storage/tree/yg-fabric-windows-upgrade), I got the following error:
![image](https://github.com/user-attachments/assets/63e1a4e1-cb36-430f-b7e1-366dbd90f529)

This change resolves this issue so that `layoutDirection` is never set to `Undefined`. 

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan
<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->

I initially tried following the below test plan, which I got from the [PR adding New Architecture](https://github.com/microsoft/react-native-test-app/pull/1885):

```
npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-fabric
yarn windows

# In a separate terminal
yarn start
```
However, `yarn windows` would give me the following error: 
```
"C:\new-account-repos\react-native-test-app\example\windows\Example.sln" (Restore target) (1) ->
(_FilterRestoreGraphProjectInputItems target) ->
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets(4
65,5): error MSB3202: The project file "C:\new-account-repos\react-native-test-app\example\Folly\Folly.vcxproj" was not
 found. [C:\new-account-repos\react-native-test-app\example\windows\Example.sln]
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets(4
65,5): error MSB3202: The project file "C:\new-account-repos\react-native-test-app\example\fmt\fmt.vcxproj" was not fou
nd. [C:\new-account-repos\react-native-test-app\example\windows\Example.sln]
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets(4
65,5): error MSB3202: The project file "C:\new-account-repos\react-native-test-app\example\Microsoft.ReactNative\Micros
oft.ReactNative.vcxproj" was not found. [C:\new-account-repos\react-native-test-app\example\windows\Example.sln]
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets(4
65,5): error MSB3202: The project file "C:\new-account-repos\react-native-test-app\example\Common\Common.vcxproj" was n
ot found. [C:\new-account-repos\react-native-test-app\example\windows\Example.sln]
```

Looking at the generated solution file `Example.sln`, the paths for several of the Project declarations were incorrect - e.g `Microsoft.ReactNative` had the path `..\\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj` whereas the correct path is `..\\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj`. After fixing all the instances of this path issue in `Example.sln`, the app was able to launch successfully.
