### PR TITLE
fix(windows): update template to set paths dynamically

### DIFF
--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -198,6 +198,10 @@ export function generateSolution(destPath, options, fs = nodefs) {
           ...templateView,
           name: path.basename(projectFileName, path.extname(projectFileName)),
           useExperimentalNuget: info.useExperimentalNuGet,
+          rnwPathFromProjectRoot: path.relative(
+            path.dirname(projectManifest),
+            rnWindowsPath
+          ),
         })
         // The current version of this template (v0.63.18) assumes that
         // `react-native-windows` is always installed in


### PR DESCRIPTION
### Description

A new `rnwPathFromProjectRoot` parameter was recently introduced to calculate the path correctly from the project's root directory.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version canary-windows
yarn
cd example
yarn install-windows-test-app --use-fabric
yarn windows

# In a separate terminal
yarn start
```