### PR TITLE
fix(apple): unwrap Node wrappers before writing env files

### DIFF
--- a/ios/node.rb
+++ b/ios/node.rb
@@ -1,0 +1,28 @@
+require('json')
+require_relative('pod_helpers')
+
+def find_node
+  node_bin = `which node`.strip!
+  return node_bin if `file #{node_bin}`.include? 'Mach-O'
+
+  # If a wrapper is found, remove the path from `PATH` and try again. This can
+  # sometimes happen when `pod install` is run inside a "virtual" environment
+  # like Turborepo.
+  bin_dir = File.dirname(node_bin)
+  filtered_paths = ENV['PATH'].split(':').reject { |p| p.eql?(bin_dir) }
+  ENV['PATH'] = filtered_paths.join(':')
+
+  find_node
+end
+
+def nearest_node_modules(project_root)
+  path = find_file('node_modules', project_root)
+  assert(!path.nil?, "Could not find 'node_modules'")
+
+  path
+end
+
+def package_version(package_path)
+  package_json = JSON.parse(File.read(File.join(package_path, 'package.json')))
+  Gem::Version.new(package_json['version'])
+end

--- a/ios/node.rb
+++ b/ios/node.rb
@@ -7,7 +7,7 @@ def find_node
 
   # If a wrapper is found, remove the path from `PATH` and try again. This can
   # sometimes happen when `pod install` is run inside a "virtual" environment
-  # like Turborepo.
+  # like [Turborepo](https://turbo.build).
   bin_dir = File.dirname(node_bin)
   filtered_paths = ENV['PATH'].split(':').reject { |p| p.eql?(bin_dir) }
   raise "Could not find Node" if filtered_paths.empty?

--- a/ios/node.rb
+++ b/ios/node.rb
@@ -10,6 +10,8 @@ def find_node
   # like Turborepo.
   bin_dir = File.dirname(node_bin)
   filtered_paths = ENV['PATH'].split(':').reject { |p| p.eql?(bin_dir) }
+  raise "Could not find Node" if filtered_paths.empty?
+
   ENV['PATH'] = filtered_paths.join(':')
 
   find_node

--- a/ios/node.rb
+++ b/ios/node.rb
@@ -10,7 +10,7 @@ def find_node
   # like [Turborepo](https://turbo.build).
   bin_dir = File.dirname(node_bin)
   filtered_paths = ENV['PATH'].split(':').reject { |p| p.eql?(bin_dir) }
-  raise "Could not find Node" if filtered_paths.empty?
+  raise 'Could not find Node' if filtered_paths.empty?
 
   ENV['PATH'] = filtered_paths.join(':')
 

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -98,12 +98,6 @@ def try_pod(name, podspec, project_root)
   pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
 
-def override_build_settings!(build_settings, settings_to_append)
-  settings_to_append&.each do |setting, value|
-    build_settings[setting] = value
-  end
-end
-
 def use_hermes?(options)
   use_hermes = ENV.fetch('USE_HERMES', nil)
   return use_hermes == '1' unless use_hermes.nil?

--- a/ios/xcode.rb
+++ b/ios/xcode.rb
@@ -14,3 +14,9 @@ PRODUCT_DISPLAY_NAME = 'PRODUCT_DISPLAY_NAME'.freeze
 PRODUCT_VERSION = 'PRODUCT_VERSION'.freeze
 USER_HEADER_SEARCH_PATHS = 'USER_HEADER_SEARCH_PATHS'.freeze
 WARNING_CFLAGS = 'WARNING_CFLAGS'.freeze
+
+def override_build_settings!(build_settings, overrides)
+  overrides&.each do |setting, value|
+    build_settings[setting] = value
+  end
+end

--- a/test/pack.test.ts
+++ b/test/pack.test.ts
@@ -149,6 +149,7 @@ describe("npm pack", () => {
       "ios/assets_catalog.rb",
       "ios/entitlements.rb",
       "ios/info_plist.rb",
+      "ios/node.rb",
       "ios/pod_helpers.rb",
       "ios/privacy_manifest.rb",
       "ios/test_app.rb",

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -1,0 +1,31 @@
+require('minitest/autorun')
+
+require_relative('../ios/node')
+
+def fixture_path(*args)
+  Pathname.new(__dir__).join('__fixtures__', *args)
+end
+
+class TestTestApp < Minitest::Test
+  def test_nearest_node_modules
+    expected = fixture_path('test_app', 'node_modules')
+
+    assert_equal(expected, nearest_node_modules(fixture_path('test_app')))
+
+    react_native = fixture_path('test_app', 'node_modules', 'react-native')
+
+    assert_equal(expected, nearest_node_modules(react_native))
+
+    assert_equal(expected, nearest_node_modules(fixture_path('test_app', 'src')))
+  end
+
+  def test_package_version
+    react_native = fixture_path('test_app', 'node_modules', 'react-native')
+
+    assert_equal(Gem::Version.new('1000.0.0'), package_version(react_native))
+
+    cli = fixture_path('test_app', 'node_modules', '@react-native-community', 'cli-platform-ios')
+
+    assert_equal(Gem::Version.new('4.10.1'), package_version(cli))
+  end
+end

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -112,30 +112,4 @@ class TestPodHelpers < Minitest::Test
     assert_equal(1_001_000, v(1, 1, 0))
     assert_equal(1_001_001, v(1, 1, 1))
   end
-
-  def test_override_build_settings
-    build_settings = { 'OTHER_LDFLAGS' => '-l"Pods-TestApp"', 'ONLY_ACTIVE_ARCH' => 'NO' }
-
-    override_build_settings!(build_settings, {})
-
-    assert_equal('-l"Pods-TestApp"', build_settings['OTHER_LDFLAGS'])
-
-    override_build_settings!(build_settings, { 'OTHER_LDFLAGS' => ' -ObjC' })
-
-    assert_equal(' -ObjC', build_settings['OTHER_LDFLAGS'])
-
-    # Test passing a table
-    build_settings_arr = { 'OTHER_LDFLAGS' => ['$(inherited)', '-l"Pods-TestApp"'] }
-    override_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => [' -ObjC'] })
-
-    assert_equal([' -ObjC'], build_settings_arr['OTHER_LDFLAGS'])
-
-    # Test setting a new key
-    override_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
-
-    assert_equal('-DDEBUG', build_settings['OTHER_CFLAGS'])
-    override_build_settings!(build_settings, { 'ONLY_ACTIVE_ARCH' => 'YES' })
-
-    assert_equal('YES', build_settings['ONLY_ACTIVE_ARCH'])
-  end
 end

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -43,28 +43,6 @@ class TestTestApp < Minitest::Test
     end
   end
 
-  def test_nearest_node_modules
-    expected = fixture_path('test_app', 'node_modules')
-
-    assert_equal(expected, nearest_node_modules(fixture_path('test_app')))
-
-    react_native = fixture_path('test_app', 'node_modules', 'react-native')
-
-    assert_equal(expected, nearest_node_modules(react_native))
-
-    assert_equal(expected, nearest_node_modules(fixture_path('test_app', 'src')))
-  end
-
-  def test_package_version
-    react_native = fixture_path('test_app', 'node_modules', 'react-native')
-
-    assert_equal(Gem::Version.new('1000.0.0'), package_version(react_native))
-
-    cli = fixture_path('test_app', 'node_modules', '@react-native-community', 'cli-platform-ios')
-
-    assert_equal(Gem::Version.new('4.10.1'), package_version(cli))
-  end
-
   def test_react_native_pods
     [
       [0, '0.71'],

--- a/test/test_xcode.rb
+++ b/test/test_xcode.rb
@@ -1,0 +1,32 @@
+require('minitest/autorun')
+
+require_relative('../ios/xcode')
+
+class TestXcode < Minitest::Test
+  def test_override_build_settings
+    build_settings = { 'OTHER_LDFLAGS' => '-l"Pods-TestApp"', 'ONLY_ACTIVE_ARCH' => 'NO' }
+
+    override_build_settings!(build_settings, {})
+
+    assert_equal('-l"Pods-TestApp"', build_settings['OTHER_LDFLAGS'])
+
+    override_build_settings!(build_settings, { 'OTHER_LDFLAGS' => '-ObjC' })
+
+    assert_equal('-ObjC', build_settings['OTHER_LDFLAGS'])
+
+    # Test passing a table
+    build_settings_arr = { 'OTHER_LDFLAGS' => ['$(inherited)', '-l"Pods-TestApp"'] }
+    override_build_settings!(build_settings_arr, { 'OTHER_LDFLAGS' => ['-ObjC'] })
+
+    assert_equal(['-ObjC'], build_settings_arr['OTHER_LDFLAGS'])
+
+    # Test setting a new key
+    override_build_settings!(build_settings, { 'OTHER_CFLAGS' => '-DDEBUG' })
+
+    assert_equal('-DDEBUG', build_settings['OTHER_CFLAGS'])
+
+    override_build_settings!(build_settings, { 'ONLY_ACTIVE_ARCH' => 'YES' })
+
+    assert_equal('YES', build_settings['ONLY_ACTIVE_ARCH'])
+  end
+end


### PR DESCRIPTION
### Description

Unwrap Node wrappers before writing env files

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a