### PR TITLE
ci(visionos): download visionOS SDK

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -79,6 +79,15 @@ runs:
       run: |
         sudo xcode-select --switch ${{ inputs.xcode-developer-dir }}
       shell: bash
+    - name: Download visionOS SDK
+      if: ${{ inputs.platform == 'visionos' }}
+      run: |
+        # https://github.com/actions/runner-images/issues/10559
+        sudo xcodebuild -runFirstLaunch
+        sudo xcrun simctl list
+        sudo xcodebuild -downloadPlatform visionOS
+        sudo xcodebuild -runFirstLaunch
+      shell: bash
     - name: Cache /.ccache
       if: ${{ steps.setup-ccache.outputs.cache-key }}
       uses: actions/cache@v4


### PR DESCRIPTION
### Description

[visionOS was removed](https://github.com/actions/runner-images/issues/10559) to save disk space on the `macos-14` runners.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

CI should pass.