### PR TITLE
fix(config-plugins): correct path to `app/build.gradle`

### DIFF
--- a/scripts/config-plugins/plugins/withAndroidBaseMods.mjs
+++ b/scripts/config-plugins/plugins/withAndroidBaseMods.mjs
@@ -36,7 +36,10 @@ const defaultProviders = {
   ),
   projectBuildGradle: expoProviders.projectBuildGradle,
   settingsGradle: expoProviders.settingsGradle,
-  appBuildGradle: expoProviders.appBuildGradle,
+  appBuildGradle: modifyFilePath(
+    expoProviders.appBuildGradle,
+    "app/build.gradle"
+  ),
   mainActivity: modifyFilePath(
     expoProviders.mainActivity,
     "app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt"


### PR DESCRIPTION
### Description

`appBuildGradle` should be remapped to the correct `app/build.gradle` path.

Resolves #2259.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

See repro steps in #2259