### PR TITLE
fix(windows): always enable NuGet when building New Arch

### DIFF
--- a/windows/project.mjs
+++ b/windows/project.mjs
@@ -450,7 +450,7 @@ export function projectInfo(
       (newArch || (useHermes ?? versionNumber >= v(0, 73, 0))) &&
       getHermesVersion(rnWindowsPath, fs),
     nugetDependencies: getNuGetDependencies(rnWindowsPath),
-    useExperimentalNuGet: !newArch && useNuGet,
+    useExperimentalNuGet: newArch || useNuGet,
     useFabric: newArch,
     usePackageReferences: versionNumber === 0 || versionNumber >= v(0, 68, 0),
     xamlVersion:


### PR DESCRIPTION
### Description

We can no longer build Windows + New Arch without NuGet. Not sure if it's a bug, but this will unblock early adopters.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version 0.76
yarn remove react-native-macos --all
cd example
yarn install-windows-test-app --use-fabric
yarn windows
```