### PR TITLE
fix(android): bump Gradle wrapper version for 0.76

### DIFF
--- a/.github/actions/setup-react-native/action.yml
+++ b/.github/actions/setup-react-native/action.yml
@@ -13,4 +13,5 @@ runs:
         rm example/macos/Podfile.lock
         rm example/visionos/Podfile.lock
         npm run set-react-version -- ${{ inputs.version }}
+        node --eval "require('./android/gradle-wrapper.js').configureGradleWrapper('example/android')"
       shell: bash

--- a/android/gradle-wrapper.js
+++ b/android/gradle-wrapper.js
@@ -34,7 +34,7 @@ const INT_MAX = 2 ** 31 - 1;
  * @type {[number, [number, string], [number, string]][]}
  */
 const GRADLE_VERSIONS = [
-  [v(0, 76, 0), [v(8, 10, 1), "8.10.1"], [INT_MAX, ""]], // 0.76: [8.10.1, *)
+  [v(0, 76, 0), [v(8, 10, 2), "8.10.2"], [INT_MAX, ""]], // 0.76: [8.10.2, *)
   [v(0, 75, 0), [v(8, 8, 0), "8.8"], [v(8, 9, 0), "8.8"]], // 0.75: [8.8, 8.9)
   [v(0, 74, 0), [v(8, 6, 0), "8.6"], [v(8, 9, 0), "8.8"]], // 0.74: [8.6, 8.9)
   [v(0, 73, 0), [v(8, 3, 0), "8.3"], [v(8, 9, 0), "8.8"]], // 0.73: [8.3, 8.9)
@@ -50,7 +50,8 @@ function configureGradleWrapper(sourceDir, fs = nodefs) {
   const androidCommands = ["build-android", "run-android"];
   if (
     process.env["RNTA_CONFIGURE_GRADLE_WRAPPER"] === "0" ||
-    !process.argv.some((arg) => androidCommands.includes(arg))
+    (process.argv.length > 1 &&  // Allow this script to be called directly
+      !process.argv.some((arg) => androidCommands.includes(arg)))
   ) {
     return;
   }

--- a/android/gradle-wrapper.js
+++ b/android/gradle-wrapper.js
@@ -50,7 +50,7 @@ function configureGradleWrapper(sourceDir, fs = nodefs) {
   const androidCommands = ["build-android", "run-android"];
   if (
     process.env["RNTA_CONFIGURE_GRADLE_WRAPPER"] === "0" ||
-    (process.argv.length > 1 &&  // Allow this script to be called directly
+    (process.argv.length > 1 && // Allow this script to be called directly
       !process.argv.some((arg) => androidCommands.includes(arg)))
   ) {
     return;

--- a/test/android/gradle-wrapper.test.ts
+++ b/test/android/gradle-wrapper.test.ts
@@ -135,7 +135,7 @@ describe("configureGradleWrapper()", () => {
     process.argv.push("run-android");
 
     const cases = [
-      ["8.9", "0.76.0", "gradle-8.10.1-bin.zip"],
+      ["8.9", "0.76.0", "gradle-8.10.2-bin.zip"],
       ["8.9", "0.75.0", "gradle-8.8-bin.zip"],
       ["8.7", "0.75.0", "gradle-8.8-bin.zip"],
       ["8.9", "0.74.0", "gradle-8.8-bin.zip"],
@@ -190,7 +190,7 @@ describe("configureGradleWrapper()", () => {
     process.argv.push("run-android");
 
     const cases = [
-      ["8.10.1", "0.76.0"],
+      ["8.10.2", "0.76.0"],
       ["8.8", "0.75.0"],
       ["8.8", "0.74.0"],
       ["8.8", "0.73.0"],


### PR DESCRIPTION
### Description

Bump Gradle wrapper version for 0.76 to 8.10.2. Also make sure to bump the wrapper on CI when building nightlies.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.76
node --eval "require('./android/gradle-wrapper.js').configureGradleWrapper('example/android')"
```

Verify that `example/android/gradle/wrapper/gradle-wrapper.properties` was set to 8.10.2.