### PR TITLE
ci(android): configure Gradle wrapper before build

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -20,6 +20,10 @@ runs:
         fi
       shell: bash
       working-directory: ${{ inputs.project-root }}
+    - name: Configure Gradle wrapper
+      run: |
+        node --eval "require('./android/gradle-wrapper.js').configureGradleWrapper('${{ steps.build-root-directory-finder.outputs.build-root-directory }}')"
+      shell: bash
     - name: Build
       run: ./gradlew ${{ inputs.arguments }}
       shell: bash

--- a/.github/actions/setup-react-native/action.yml
+++ b/.github/actions/setup-react-native/action.yml
@@ -13,5 +13,4 @@ runs:
         rm example/macos/Podfile.lock
         rm example/visionos/Podfile.lock
         npm run set-react-version -- ${{ inputs.version }}
-        node --eval "require('./android/gradle-wrapper.js').configureGradleWrapper('example/android')"
       shell: bash


### PR DESCRIPTION
### Description

Configure Gradle wrapper before build

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a