### PR TITLE
chore(dependency): update `react-native-windows` version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-native": "^0.75.0",
     "react-native-macos": "^0.75.2",
-    "react-native-windows": "^0.75.0"
+    "react-native-windows": "^0.75.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "react": "^18.2.0",
     "react-native": "^0.75.0",
     "react-native-macos": "^0.75.2",
-    "react-native-windows": "^0.75.0",
+    "react-native-windows": "^0.75.5",
     "semantic-release": "^24.0.0",
     "suggestion-bot": "^3.0.0",
     "tsx": "^4.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,37 +3150,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-windows/cli@npm:0.75.3":
-  version: 0.75.3
-  resolution: "@react-native-windows/cli@npm:0.75.3"
-  dependencies:
-    "@react-native-windows/codegen": "npm:0.75.1"
-    "@react-native-windows/fs": "npm:0.75.0"
-    "@react-native-windows/package-utils": "npm:0.75.0"
-    "@react-native-windows/telemetry": "npm:0.75.1"
-    "@xmldom/xmldom": "npm:^0.7.7"
-    chalk: "npm:^4.1.0"
-    cli-spinners: "npm:^2.2.0"
-    envinfo: "npm:^7.5.0"
-    find-up: "npm:^4.1.0"
-    glob: "npm:^7.1.1"
-    lodash: "npm:^4.17.15"
-    mustache: "npm:^4.0.1"
-    ora: "npm:^3.4.0"
-    prompts: "npm:^2.4.1"
-    semver: "npm:^7.3.2"
-    shelljs: "npm:^0.8.4"
-    username: "npm:^5.1.0"
-    uuid: "npm:^3.3.2"
-    xml-formatter: "npm:^2.4.0"
-    xml-parser: "npm:^1.2.1"
-    xpath: "npm:^0.0.27"
-  peerDependencies:
-    react-native: "*"
-  checksum: 10c0/bce01859f8943ca98fde01c6f2d8f1b16a8155ff93b4a2585a239829194ea5e2baef85176f06be58a71d07bf945ef7a5831b6b705a8abda69541ec71607ca78a
-  languageName: node
-  linkType: hard
-
 "@react-native-windows/cli@npm:0.75.4":
   version: 0.75.4
   resolution: "@react-native-windows/cli@npm:0.75.4"
@@ -3209,24 +3178,6 @@ __metadata:
   peerDependencies:
     react-native: "*"
   checksum: 10c0/95ff332d2077412268cd8bfd2aaf9591f6bc73cc76d215698d7deb3a5f24bbd33a34782e5bc461e53a48b71c7c76c328c9ba92c37e06bf6c1fa5842be7b9d471
-  languageName: node
-  linkType: hard
-
-"@react-native-windows/codegen@npm:0.75.1":
-  version: 0.75.1
-  resolution: "@react-native-windows/codegen@npm:0.75.1"
-  dependencies:
-    "@react-native-windows/fs": "npm:0.75.0"
-    chalk: "npm:^4.1.0"
-    globby: "npm:^11.1.0"
-    mustache: "npm:^4.0.1"
-    source-map-support: "npm:^0.5.19"
-    yargs: "npm:^16.2.0"
-  peerDependencies:
-    react-native: "*"
-  bin:
-    react-native-windows-codegen: bin.js
-  checksum: 10c0/ba025dc70013811e0c2bbb723057c6fbe67d6a59c5739d263b68c2143f7fb8320c1a1dcea02e06efe6eed90379606b2ced390d6e9d0911695324e388220b032f
   languageName: node
   linkType: hard
 
@@ -7683,7 +7634,7 @@ __metadata:
     react-native: "npm:^0.75.0"
     react-native-macos: "npm:^0.75.2"
     react-native-test-app: "workspace:*"
-    react-native-windows: "npm:^0.75.0"
+    react-native-windows: "npm:^0.75.5"
     webdriverio: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
@@ -12517,62 +12468,6 @@ __metadata:
     install-windows-test-app: windows/test-app.mjs
   languageName: unknown
   linkType: soft
-
-"react-native-windows@npm:^0.75.0":
-  version: 0.75.4
-  resolution: "react-native-windows@npm:0.75.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.0.0"
-    "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-community/cli": "npm:14.1.0"
-    "@react-native-community/cli-platform-android": "npm:14.1.0"
-    "@react-native-community/cli-platform-ios": "npm:14.1.0"
-    "@react-native-windows/cli": "npm:0.75.3"
-    "@react-native/assets": "npm:1.0.0"
-    "@react-native/assets-registry": "npm:0.75.3"
-    "@react-native/codegen": "npm:0.75.3"
-    "@react-native/community-cli-plugin": "npm:0.75.3"
-    "@react-native/gradle-plugin": "npm:0.75.3"
-    "@react-native/js-polyfills": "npm:0.75.3"
-    "@react-native/normalize-colors": "npm:0.75.3"
-    "@react-native/virtualized-lists": "npm:0.75.3"
-    abort-controller: "npm:^3.0.0"
-    anser: "npm:^1.4.9"
-    ansi-regex: "npm:^5.0.0"
-    base64-js: "npm:^1.5.1"
-    chalk: "npm:^4.0.0"
-    commander: "npm:^9.4.1"
-    event-target-shim: "npm:^5.0.1"
-    flow-enums-runtime: "npm:^0.0.6"
-    glob: "npm:^7.1.1"
-    invariant: "npm:^2.2.4"
-    jest-environment-node: "npm:^29.6.3"
-    jsc-android: "npm:^250231.0.0"
-    memoize-one: "npm:^5.0.0"
-    metro-runtime: "npm:^0.80.3"
-    metro-source-map: "npm:^0.80.3"
-    mkdirp: "npm:^0.5.1"
-    nullthrows: "npm:^1.1.1"
-    pretty-format: "npm:^26.5.2"
-    promise: "npm:^8.3.0"
-    react-devtools-core: "npm:^5.3.1"
-    react-refresh: "npm:^0.14.0"
-    react-shallow-renderer: "npm:^16.15.0"
-    regenerator-runtime: "npm:^0.13.2"
-    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
-    semver: "npm:^7.1.3"
-    source-map-support: "npm:^0.5.19"
-    stacktrace-parser: "npm:^0.1.10"
-    whatwg-fetch: "npm:^3.0.0"
-    ws: "npm:^6.2.2"
-    yargs: "npm:^17.6.2"
-  peerDependencies:
-    "@types/react": ^18.2.6
-    react: ^18.2.0
-    react-native: ^0.75.3
-  checksum: 10c0/2ee9b67c3691b451599bfbc068034f04c1b4870bf420561d001f1c0549b415e0ef051bd507963820493888c76bc904361716e54b179550b224576b418f5e6690
-  languageName: node
-  linkType: hard
 
 "react-native-windows@npm:^0.75.5":
   version: 0.75.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-windows/cli@npm:0.75.4":
+  version: 0.75.4
+  resolution: "@react-native-windows/cli@npm:0.75.4"
+  dependencies:
+    "@react-native-windows/codegen": "npm:0.75.2"
+    "@react-native-windows/fs": "npm:0.75.0"
+    "@react-native-windows/package-utils": "npm:0.75.0"
+    "@react-native-windows/telemetry": "npm:0.75.1"
+    "@xmldom/xmldom": "npm:^0.7.7"
+    chalk: "npm:^4.1.0"
+    cli-spinners: "npm:^2.2.0"
+    envinfo: "npm:^7.5.0"
+    find-up: "npm:^4.1.0"
+    glob: "npm:^7.1.1"
+    lodash: "npm:^4.17.15"
+    mustache: "npm:^4.0.1"
+    ora: "npm:^3.4.0"
+    prompts: "npm:^2.4.1"
+    semver: "npm:^7.3.2"
+    shelljs: "npm:^0.8.4"
+    username: "npm:^5.1.0"
+    uuid: "npm:^3.3.2"
+    xml-formatter: "npm:^2.4.0"
+    xml-parser: "npm:^1.2.1"
+    xpath: "npm:^0.0.27"
+  peerDependencies:
+    react-native: "*"
+  checksum: 10c0/95ff332d2077412268cd8bfd2aaf9591f6bc73cc76d215698d7deb3a5f24bbd33a34782e5bc461e53a48b71c7c76c328c9ba92c37e06bf6c1fa5842be7b9d471
+  languageName: node
+  linkType: hard
+
 "@react-native-windows/codegen@npm:0.75.1":
   version: 0.75.1
   resolution: "@react-native-windows/codegen@npm:0.75.1"
@@ -3196,6 +3227,24 @@ __metadata:
   bin:
     react-native-windows-codegen: bin.js
   checksum: 10c0/ba025dc70013811e0c2bbb723057c6fbe67d6a59c5739d263b68c2143f7fb8320c1a1dcea02e06efe6eed90379606b2ced390d6e9d0911695324e388220b032f
+  languageName: node
+  linkType: hard
+
+"@react-native-windows/codegen@npm:0.75.2":
+  version: 0.75.2
+  resolution: "@react-native-windows/codegen@npm:0.75.2"
+  dependencies:
+    "@react-native-windows/fs": "npm:0.75.0"
+    chalk: "npm:^4.1.0"
+    globby: "npm:^11.1.0"
+    mustache: "npm:^4.0.1"
+    source-map-support: "npm:^0.5.19"
+    yargs: "npm:^16.2.0"
+  peerDependencies:
+    react-native: "*"
+  bin:
+    react-native-windows-codegen: bin.js
+  checksum: 10c0/f594707a5f2b431a2a89536cf8bde78bc81897b48b5b47205bc2ab6547c812b243660c2ae797ead4ea0ac078924577e828102a8d7db095b785a72426322f0050
   languageName: node
   linkType: hard
 
@@ -12438,7 +12487,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-native: "npm:^0.75.0"
     react-native-macos: "npm:^0.75.2"
-    react-native-windows: "npm:^0.75.0"
+    react-native-windows: "npm:^0.75.5"
     semantic-release: "npm:^24.0.0"
     semver: "npm:^7.3.5"
     suggestion-bot: "npm:^3.0.0"
@@ -12522,6 +12571,62 @@ __metadata:
     react: ^18.2.0
     react-native: ^0.75.3
   checksum: 10c0/2ee9b67c3691b451599bfbc068034f04c1b4870bf420561d001f1c0549b415e0ef051bd507963820493888c76bc904361716e54b179550b224576b418f5e6690
+  languageName: node
+  linkType: hard
+
+"react-native-windows@npm:^0.75.5":
+  version: 0.75.5
+  resolution: "react-native-windows@npm:0.75.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    "@jest/create-cache-key-function": "npm:^29.6.3"
+    "@react-native-community/cli": "npm:14.1.0"
+    "@react-native-community/cli-platform-android": "npm:14.1.0"
+    "@react-native-community/cli-platform-ios": "npm:14.1.0"
+    "@react-native-windows/cli": "npm:0.75.4"
+    "@react-native/assets": "npm:1.0.0"
+    "@react-native/assets-registry": "npm:0.75.3"
+    "@react-native/codegen": "npm:0.75.3"
+    "@react-native/community-cli-plugin": "npm:0.75.3"
+    "@react-native/gradle-plugin": "npm:0.75.3"
+    "@react-native/js-polyfills": "npm:0.75.3"
+    "@react-native/normalize-colors": "npm:0.75.3"
+    "@react-native/virtualized-lists": "npm:0.75.3"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    base64-js: "npm:^1.5.1"
+    chalk: "npm:^4.0.0"
+    commander: "npm:^9.4.1"
+    event-target-shim: "npm:^5.0.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    glob: "npm:^7.1.1"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.6.3"
+    jsc-android: "npm:^250231.0.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.80.3"
+    metro-source-map: "npm:^0.80.3"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^26.5.2"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^5.3.1"
+    react-refresh: "npm:^0.14.0"
+    react-shallow-renderer: "npm:^16.15.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
+    semver: "npm:^7.1.3"
+    source-map-support: "npm:^0.5.19"
+    stacktrace-parser: "npm:^0.1.10"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^6.2.2"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: ^18.2.0
+    react-native: ^0.75.3
+  checksum: 10c0/4de9bacbd4c9a5ae2c1e1e8219f6becc95a078dabf0e4582ad35c3e1ba5303cc8ff41a47d4e6b89b8f32a88f7218dee678a21dafa87eb5957bf9630f03488d8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
Bump minimum version of RNW to 0.75.5 (latest) to include the following PR that was backported, to allow apps using RNTA on New Architecture to launch with no issue: https://github.com/microsoft/react-native-windows/pull/13866
<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

Example app screenshots:

Old Architecture:
![image](https://github.com/user-attachments/assets/2762308a-4fa4-4134-b586-0f13c75dd35c)

New Architecture:
![image](https://github.com/user-attachments/assets/86c0f540-a614-443e-bc8f-95cbec3f24fc)

