### PR TITLE
fix(android): reduce redundant `apply(from:)` calls

### DIFF
--- a/android/autolink.gradle
+++ b/android/autolink.gradle
@@ -1,5 +1,7 @@
 import groovy.json.JsonSlurper
 
+ext.rnta_autolink_gradle = true
+
 ext.autolinkModules = { File projectRoot, File output, String testAppDir ->
     String[] autolink = ["node", "${testAppDir}/android/autolink.mjs", projectRoot.toString(), output.toString()]
     def stderr = new StringBuffer()

--- a/android/config-plugins.gradle
+++ b/android/config-plugins.gradle
@@ -1,4 +1,8 @@
-apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
+ext.rnta_config_plugins_gradle = true
+
+if (!hasProperty("rnta_node_gradle")) {
+    apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
+}
 
 ext.applyConfigPlugins = { File rootDir, String testAppDir ->
     if (!findNodeModulesPath("@expo/config-plugins", rootDir)) {

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -1,5 +1,9 @@
-apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
-apply(from: "${buildscript.sourceFile.getParent()}/react-native.gradle")
+if (!hasProperty("rnta_node_gradle")) {
+    apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
+}
+if (!hasProperty("rnta_react_native_gradle")) {
+    apply(from: "${buildscript.sourceFile.getParent()}/react-native.gradle")
+}
 
 /**
  * Returns the recommended Gradle plugin version for the specified React Native

--- a/android/manifest.gradle
+++ b/android/manifest.gradle
@@ -3,6 +3,8 @@ import java.nio.file.Paths
 
 def _manifest = null
 
+ext.rnta_manifest_gradle = true
+
 ext.getAppName = {
     def manifest = getManifest()
     if (manifest != null) {

--- a/android/media-types.gradle
+++ b/android/media-types.gradle
@@ -1,3 +1,5 @@
+ext.rnta_media_types_gradle = true
+
 ext.isFontFile = { File file ->
     // https://github.com/facebook/react-native/blob/3dfedbc1aec18a4255e126fde96d5dc7b1271ea7/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.java#L28
     return [".otf", ".ttf"].any { file.name.endsWith(it) }

--- a/android/node.gradle
+++ b/android/node.gradle
@@ -1,7 +1,11 @@
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
 
-apply(from: "${buildscript.sourceFile.getParent()}/utils.gradle")
+ext.rnta_node_gradle = true
+
+if (!hasProperty("rnta_utils_gradle")) {
+    apply(from: "${buildscript.sourceFile.getParent()}/utils.gradle")
+}
 
 def _dependencies = [:]
 

--- a/android/react-native.gradle
+++ b/android/react-native.gradle
@@ -1,4 +1,8 @@
-apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
+ext.rnta_react_native_gradle = true
+
+if (!hasProperty("rnta_node_gradle")) {
+    apply(from: "${buildscript.sourceFile.getParent()}/node.gradle")
+}
 
 ext.isBridgelessEnabled = { Project project, boolean isNewArchEnabled ->
     if (isNewArchEnabled) {

--- a/android/utils.gradle
+++ b/android/utils.gradle
@@ -1,6 +1,8 @@
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
 
+ext.rnta_utils_gradle = true
+
 ext.checkEnvironment = { rootDir, testAppDir ->
     String[] args = ["node", "-p", "JSON.stringify(require('./android/gradle-wrapper.js').GRADLE_VERSIONS)"]
     def stdout = new StringBuffer()

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -3,11 +3,11 @@ import java.nio.file.Paths
 import org.gradle.initialization.DefaultSettings
 
 def testAppDir = buildscript.sourceFile.getParent()
+apply(from: "${testAppDir}/android/utils.gradle")
+apply(from: "${testAppDir}/android/node.gradle")
 apply(from: "${testAppDir}/android/autolink.gradle")
 apply(from: "${testAppDir}/android/config-plugins.gradle")
 apply(from: "${testAppDir}/android/media-types.gradle")
-apply(from: "${testAppDir}/android/node.gradle")
-apply(from: "${testAppDir}/android/utils.gradle")
 
 checkEnvironment(rootDir, testAppDir)
 applyConfigPlugins(rootDir, testAppDir)


### PR DESCRIPTION
### Description

Reduce redundant `apply(from:)` calls

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example/android
./gradlew clean --debug
```

Inspect the log and verify that Gradle modules are only applied once.