### PR TITLE
fix(android): avoid loading legacy autolinking script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
     # Nightly builds against react-native@nightly at 4:00, Monday through Friday
     - cron: 0 4 * * 1-5
 env:
-  GRADLE_HANGS_ON_WINDOWS: 1 # https://github.com/microsoft/react-native-test-app/issues/2206
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   VisualStudioVersion: "17.0"
 concurrency:
@@ -89,7 +88,6 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
       - name: Populate Gradle cache
-        if: ${{ runner.os != 'Windows' || env.GRADLE_HANGS_ON_WINDOWS != '1' }}
         uses: ./.github/actions/gradle
         with:
           arguments: clean
@@ -257,7 +255,7 @@ jobs:
     name: "Android"
     strategy:
       matrix:
-        runner: [ubuntu-24.04] # TODO: Re-add Windows: https://github.com/microsoft/react-native-test-app/issues/2206
+        runner: [ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -305,7 +303,7 @@ jobs:
     strategy:
       matrix:
         template: [all, android]
-        runner: [ubuntu-24.04] # TODO: Re-add Windows: https://github.com/microsoft/react-native-test-app/issues/2206
+        runner: [ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.runner }}
     if: ${{ github.event_name != 'schedule' }}
     steps:

--- a/test-app.gradle
+++ b/test-app.gradle
@@ -13,9 +13,11 @@ checkEnvironment(rootDir, testAppDir)
 applyConfigPlugins(rootDir, testAppDir)
 
 def reactNativeDir = file(findNodeModulesPath("react-native", rootDir))
-def cliAndroidDir = findNodeModulesPath("@react-native-community/cli-platform-android", reactNativeDir)
 
-apply(from: "${cliAndroidDir}/native_modules.gradle")
+def importLegacyAutolinkingModule = { File startDir ->
+    def cliAndroidDir = findNodeModulesPath("@react-native-community/cli-platform-android", startDir)
+    apply(from: "${cliAndroidDir}/native_modules.gradle")
+}
 
 ext.applyTestAppSettings = { DefaultSettings settings ->
     settings.include(":app")
@@ -46,6 +48,7 @@ ext.applyTestAppSettings = { DefaultSettings settings ->
             settings.project(path).projectDir = file(info.projectDir)
         }
     } else {
+        importLegacyAutolinkingModule(reactNativeDir)
         applyNativeModulesSettingsGradle(settings)
     }
 
@@ -65,6 +68,7 @@ ext.applyTestAppSettings = { DefaultSettings settings ->
 ext.applyTestAppModule = { Project project ->
     def reactNativeVersion = getPackageVersionNumber("react-native", rootDir)
     if (reactNativeVersion >= 0 && reactNativeVersion < v(0, 75, 0)) {
+        importLegacyAutolinkingModule(reactNativeDir)
         applyNativeModulesAppBuildGradle(project)
     }
 

--- a/test/android/test-app-util.test.ts
+++ b/test/android/test-app-util.test.ts
@@ -8,10 +8,6 @@ import {
   runGradleWithProject,
 } from "./gradle.js";
 
-// TODO: https://github.com/microsoft/react-native-test-app/issues/2206
-const GRADLE_HANGS_ON_WINDOWS = process.platform === "win32";
-const testOptions = { skip: GRADLE_HANGS_ON_WINDOWS };
-
 describe("test-app-util.gradle", () => {
   const defaultTestProject = "TestAppUtilTest";
 
@@ -25,12 +21,10 @@ describe("test-app-util.gradle", () => {
   }
 
   after(() => {
-    if (!testOptions.skip) {
-      removeProject(defaultTestProject);
-    }
+    removeProject(defaultTestProject);
   });
 
-  it("getAppName() returns `displayName`", testOptions, async () => {
+  it("getAppName() returns `displayName`", async () => {
     const { status, stdout } = await runGradle({
       "app.json": JSON.stringify({
         name: "AppName",
@@ -46,7 +40,7 @@ describe("test-app-util.gradle", () => {
     match(stdout, /getAppName\(\) = AppDisplayName/);
   });
 
-  it("getApplicationId() returns default id", testOptions, async () => {
+  it("getApplicationId() returns default id", async () => {
     const { status, stdout } = await runGradle({
       "app.json": JSON.stringify({
         name: "AppName",
@@ -62,7 +56,7 @@ describe("test-app-util.gradle", () => {
     match(stdout, /getApplicationId\(\) = com.microsoft.reacttestapp/);
   });
 
-  it("getApplicationId() returns package name", testOptions, async () => {
+  it("getApplicationId() returns package name", async () => {
     const { status, stdout } = await runGradle({
       "app.json": JSON.stringify({
         name: "AppName",
@@ -81,140 +75,116 @@ describe("test-app-util.gradle", () => {
     match(stdout, /getApplicationId\(\) = com.contoso.application.id/);
   });
 
-  it(
-    "getPackageVersionNumber() returns `react-native` version as a number",
-    testOptions,
-    async () => {
-      const { status, stdout } = await runGradle({
-        "android/build.gradle": buildGradle(
-          'println("getPackageVersionNumber() = " + project.ext.getPackageVersionNumber("react-native", rootDir))'
-        ),
-      });
+  it("getPackageVersionNumber() returns `react-native` version as a number", async () => {
+    const { status, stdout } = await runGradle({
+      "android/build.gradle": buildGradle(
+        'println("getPackageVersionNumber() = " + project.ext.getPackageVersionNumber("react-native", rootDir))'
+      ),
+    });
 
-      const versionNumber = toVersionNumber(reactNativeVersion());
+    const versionNumber = toVersionNumber(reactNativeVersion());
 
-      equal(status, 0);
-      match(
-        stdout,
-        new RegExp(`getPackageVersionNumber\\(\\) = ${versionNumber}`)
-      );
-    }
-  );
+    equal(status, 0);
+    match(
+      stdout,
+      new RegExp(`getPackageVersionNumber\\(\\) = ${versionNumber}`)
+    );
+  });
 
-  it(
-    "getSigningConfigs() fails if `storeFile` is missing",
-    testOptions,
-    async () => {
-      const { status, stderr } = await runGradle({
-        "app.json": JSON.stringify({
-          name: "AppName",
-          displayName: "AppDisplayName",
-          resources: ["dist/res", "dist/main.android.jsbundle"],
-          android: { signingConfigs: { debug: {} } },
-        }),
-        "android/build.gradle": buildGradle(
-          'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
-        ),
-      });
+  it("getSigningConfigs() fails if `storeFile` is missing", async () => {
+    const { status, stderr } = await runGradle({
+      "app.json": JSON.stringify({
+        name: "AppName",
+        displayName: "AppDisplayName",
+        resources: ["dist/res", "dist/main.android.jsbundle"],
+        android: { signingConfigs: { debug: {} } },
+      }),
+      "android/build.gradle": buildGradle(
+        'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
+      ),
+    });
 
-      equal(status, 1);
-      match(stderr, /storeFile .* is missing/);
-    }
-  );
+    equal(status, 1);
+    match(stderr, /storeFile .* is missing/);
+  });
 
-  it(
-    "getSigningConfigs() skips empty `signingConfigs` config",
-    testOptions,
-    async () => {
-      const { status, stdout } = await runGradle({
-        "app.json": JSON.stringify({
-          name: "AppName",
-          displayName: "AppDisplayName",
-          resources: ["dist/res", "dist/main.android.jsbundle"],
-          android: { signingConfigs: {} },
-        }),
-        "android/build.gradle": buildGradle(
-          'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
-        ),
-      });
+  it("getSigningConfigs() skips empty `signingConfigs` config", async () => {
+    const { status, stdout } = await runGradle({
+      "app.json": JSON.stringify({
+        name: "AppName",
+        displayName: "AppDisplayName",
+        resources: ["dist/res", "dist/main.android.jsbundle"],
+        android: { signingConfigs: {} },
+      }),
+      "android/build.gradle": buildGradle(
+        'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
+      ),
+    });
 
-      equal(status, 0);
-      match(stdout, /getSigningConfigs\(\) = \[:\]/);
-    }
-  );
+    equal(status, 0);
+    match(stdout, /getSigningConfigs\(\) = \[:\]/);
+  });
 
-  it(
-    "getSigningConfigs() returns debug signing config",
-    testOptions,
-    async () => {
-      const { status, stdout } = await runGradle({
-        "app.json": JSON.stringify({
-          name: "AppName",
-          displayName: "AppDisplayName",
-          resources: ["dist/res", "dist/main.android.jsbundle"],
-          android: {
-            signingConfigs: {
-              debug: {
-                storeFile: "../README.md",
-              },
+  it("getSigningConfigs() returns debug signing config", async () => {
+    const { status, stdout } = await runGradle({
+      "app.json": JSON.stringify({
+        name: "AppName",
+        displayName: "AppDisplayName",
+        resources: ["dist/res", "dist/main.android.jsbundle"],
+        android: {
+          signingConfigs: {
+            debug: {
+              storeFile: "../README.md",
             },
           },
-        }),
-        "android/build.gradle": buildGradle(
-          'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
-        ),
-      });
+        },
+      }),
+      "android/build.gradle": buildGradle(
+        'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
+      ),
+    });
 
-      equal(status, 0);
-      match(
-        stdout,
-        /getSigningConfigs\(\) = \[debug:\[keyAlias:androiddebugkey, keyPassword:android, storePassword:android, storeFile:.*\]\]/
-      );
-    }
-  );
+    equal(status, 0);
+    match(
+      stdout,
+      /getSigningConfigs\(\) = \[debug:\[keyAlias:androiddebugkey, keyPassword:android, storePassword:android, storeFile:.*\]\]/
+    );
+  });
 
-  it(
-    "getSigningConfigs() returns release signing config",
-    testOptions,
-    async () => {
-      const { status, stdout } = await runGradle({
-        "app.json": JSON.stringify({
-          name: "AppName",
-          displayName: "AppDisplayName",
-          resources: ["dist/res", "dist/main.android.jsbundle"],
-          android: {
-            signingConfigs: {
-              release: {
-                storeFile: "../README.md",
-              },
+  it("getSigningConfigs() returns release signing config", async () => {
+    const { status, stdout } = await runGradle({
+      "app.json": JSON.stringify({
+        name: "AppName",
+        displayName: "AppDisplayName",
+        resources: ["dist/res", "dist/main.android.jsbundle"],
+        android: {
+          signingConfigs: {
+            release: {
+              storeFile: "../README.md",
             },
           },
-        }),
-        "android/build.gradle": buildGradle(
-          'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
-        ),
-      });
+        },
+      }),
+      "android/build.gradle": buildGradle(
+        'println("getSigningConfigs() = " + project.ext.getSigningConfigs())'
+      ),
+    });
 
-      equal(status, 0);
-      match(
-        stdout,
-        /getSigningConfigs\(\) = \[release:\[keyAlias:androiddebugkey, keyPassword:android, storePassword:android, storeFile:.*\]\]/
-      );
-    }
-  );
+    equal(status, 0);
+    match(
+      stdout,
+      /getSigningConfigs\(\) = \[release:\[keyAlias:androiddebugkey, keyPassword:android, storePassword:android, storeFile:.*\]\]/
+    );
+  });
 
-  it(
-    "toVersionNumber() handles pre-release identifiers",
-    testOptions,
-    async () => {
-      const { status, stdout } = await runGradle({
-        "android/build.gradle": buildGradle(
-          'println("toVersionNumber() = " + project.ext.toVersionNumber("1.2.3-053c2b4be"))'
-        ),
-      });
+  it("toVersionNumber() handles pre-release identifiers", async () => {
+    const { status, stdout } = await runGradle({
+      "android/build.gradle": buildGradle(
+        'println("toVersionNumber() = " + project.ext.toVersionNumber("1.2.3-053c2b4be"))'
+      ),
+    });
 
-      equal(status, 0);
-      match(stdout, new RegExp(`toVersionNumber\\(\\) = ${v(1, 2, 3)}`));
-    }
-  );
+    equal(status, 0);
+    match(stdout, new RegExp(`toVersionNumber\\(\\) = ${v(1, 2, 3)}`));
+  });
 });


### PR DESCRIPTION
### Description

Resolves #2206.
Resolves #2285.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Windows CI should pass.

Also verify that 0.74 still works:

```sh
npm run set-react-version 0.74
yarn
cd example/android
yarn android

# In a separate terminal
yarn start
```