### PR TITLE
docs: add react-native-video as library using RNTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ in the wiki.
 [BabylonReactNative](https://github.com/BabylonJS/BabylonReactNative) &bull;
 [callstack/repack](https://github.com/callstack/repack) &bull;
 [lottie-react-native](https://github.com/lottie-react-native/lottie-react-native) &bull;
-[TheWidlarzGroup/react-native-video](https://github.com/TheWidlarzGroup/react-native-video) &bull;
 [react-native-add-calendar-event](https://github.com/vonovak/react-native-add-calendar-event) &bull;
 [react-native-apple-authentication](https://github.com/invertase/react-native-apple-authentication) &bull;
 [react-native-async-storage](https://github.com/react-native-async-storage/async-storage) &bull;
@@ -108,6 +107,7 @@ in the wiki.
 [react-native-netinfo](https://github.com/react-native-netinfo/react-native-netinfo) &bull;
 [react-native-pager-view](https://github.com/callstack/react-native-pager-view) &bull;
 [react-native-segmented-control](https://github.com/react-native-segmented-control/segmented-control) &bull;
+[react-native-video](https://github.com/TheWidlarzGroup/react-native-video) &bull;
 [react-native-webview](https://github.com/react-native-webview/react-native-webview) &bull;
 [realm-js](https://github.com/realm/realm-js) &bull;
 [shopify/restyle](https://github.com/Shopify/restyle) &bull;

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ in the wiki.
 [BabylonReactNative](https://github.com/BabylonJS/BabylonReactNative) &bull;
 [callstack/repack](https://github.com/callstack/repack) &bull;
 [lottie-react-native](https://github.com/lottie-react-native/lottie-react-native) &bull;
+[TheWidlarzGroup/react-native-video](https://github.com/TheWidlarzGroup/react-native-video) &bull;
 [react-native-add-calendar-event](https://github.com/vonovak/react-native-add-calendar-event) &bull;
 [react-native-apple-authentication](https://github.com/invertase/react-native-apple-authentication) &bull;
 [react-native-async-storage](https://github.com/react-native-async-storage/async-storage) &bull;


### PR DESCRIPTION
### Description
Added react-native-video as a library that uses react-native-test-app. The integration began on October 20, 2024, so it is relatively new
<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
