### PR TITLE
fix: fix pnpm related errors when on 0.76

### DIFF
--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -29,9 +29,13 @@ def apply_config_plugins(project_root, target_platform)
   raise 'Failed to apply config plugins' unless result
 end
 
-def autolink_script_path(project_root, target_platform)
-  react_native = react_native_path(project_root, target_platform)
-  package_path = resolve_module('@react-native-community/cli-platform-ios', react_native)
+def autolink_script_path(project_root, target_platform, react_native_version)
+  start_dir = if react_native_version >= v(0, 76, 0)
+                project_root
+              else
+                react_native_path(project_root, target_platform)
+              end
+  package_path = resolve_module('@react-native-community/cli-platform-ios', start_dir)
   File.join(package_path, 'native_modules')
 end
 
@@ -356,7 +360,9 @@ def use_test_app_internal!(target_platform, options)
     install! 'cocoapods', :deterministic_uuids => false
   end
 
-  require_relative(autolink_script_path(project_root, target_platform))
+  require_relative(autolink_script_path(project_root,
+                                        target_platform,
+                                        project_target[:react_native_version]))
 
   begin
     platform :ios, platforms[:ios] if target_platform == :ios

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -31,8 +31,10 @@ const {
  */
 const getRNPackageVersion = (() => {
   const isTesting = "NODE_TEST_CONTEXT" in process.env;
+
   /** @type {Record<string, number>} */
   let versions = {};
+
   /** @type {(packageName: string) => number} */
   return (packageName, fs = nodefs) => {
     if (isTesting || !versions[packageName]) {
@@ -49,7 +51,12 @@ const getRNPackageVersion = (() => {
  * @returns {number}
  */
 function cliPlatformIOSVersion() {
-  return getRNPackageVersion("@react-native-community/cli-platform-ios");
+  try {
+    return getRNPackageVersion("@react-native-community/cli-platform-ios");
+  } catch (_) {
+    // The returned value doesn't matter when we're on 0.76 or later
+    return Number.MAX_SAFE_INTEGER;
+  }
 }
 
 /**
@@ -61,17 +68,24 @@ function getAndroidPackageName(manifestPath, fs = nodefs) {
     return undefined;
   }
 
-  const rncliAndroidVersion = getRNPackageVersion(
-    "@react-native-community/cli-platform-android",
-    fs
-  );
-  if (rncliAndroidVersion < v(12, 3, 7)) {
-    // TODO: This block can be removed when we drop support for 0.72
-    return undefined;
-  }
-  if (rncliAndroidVersion >= v(13, 0, 0) && rncliAndroidVersion < v(13, 6, 9)) {
-    // TODO: This block can be removed when we drop support for 0.73
-    return undefined;
+  try {
+    const rncliAndroidVersion = getRNPackageVersion(
+      "@react-native-community/cli-platform-android",
+      fs
+    );
+    if (rncliAndroidVersion < v(12, 3, 7)) {
+      // TODO: This block can be removed when we drop support for 0.72
+      return undefined;
+    }
+    if (
+      rncliAndroidVersion >= v(13, 0, 0) &&
+      rncliAndroidVersion < v(13, 6, 9)
+    ) {
+      // TODO: This block can be removed when we drop support for 0.73
+      return undefined;
+    }
+  } catch (_) {
+    // We're on 0.76 or later
   }
 
   /** @type {{ android?: { package?: string }}} */

--- a/test/test_test_app.rb
+++ b/test/test_test_app.rb
@@ -37,10 +37,17 @@ class TestTestApp < Minitest::Test
 
   def test_autolink_script_path
     react_native_dir = fixture_path('test_app', 'node_modules', 'react-native')
+    autolink_path = fixture_path('test_app',
+                                 'node_modules',
+                                 '@react-native-community',
+                                 'cli-platform-ios',
+                                 'native_modules').to_s
 
     stub :react_native_path, react_native_dir do
-      assert(require(autolink_script_path(fixture_path('test_app'), :ios)))
+      assert_equal(autolink_script_path(fixture_path('test_app'), :ios, v(0, 75, 0)), autolink_path)
     end
+
+    assert_equal(autolink_script_path(fixture_path('test_app'), :ios, v(0, 76, 0)), autolink_path)
   end
 
   def test_react_native_pods


### PR DESCRIPTION
### Description

Fix pnpm related errors when on 0.76

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

See https://github.com/microsoft/rnx-kit/pull/3409