### PR TITLE
fix(macos): declare support for 0.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@expo/config-plugins": ">=5.0",
     "react": "17.0.1 - 19.0",
     "react-native": "0.66 - 0.76 || >=0.77.0-0 <0.77.0",
-    "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75",
+    "react-native-macos": "^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.76",
     "react-native-windows": "^0.0.0-0 || 0.66 - 0.76"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12412,7 +12412,7 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 19.0
     react-native: 0.66 - 0.76 || >=0.77.0-0 <0.77.0
-    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75
+    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.76
     react-native-windows: ^0.0.0-0 || 0.66 - 0.76
   peerDependenciesMeta:
     "@callstack/react-native-visionos":


### PR DESCRIPTION
### Description

Declare support for 0.76

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.76
yarn
cd example
pod install --project-directory=macos
yarn macos

# In a separate terminal
yarn start
```