### PR TITLE
fix(visionos): fix build failing when Hermes is enabled

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   NewCops: enable
   Exclude:
+    - "**/Pods/**/*"
     - "**/node_modules/**/*"
     - "vendor/bundle/**/*"
   TargetRubyVersion: 2.6

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -102,6 +102,10 @@ def use_hermes?(options)
   use_hermes = ENV.fetch('USE_HERMES', nil)
   return use_hermes == '1' unless use_hermes.nil?
 
+  # Hermes prebuilds for visionOS was introduced in 0.76
+  is_visionos = options[:path].end_with?('react-native-visionos')
+  ENV['RCT_BUILD_HERMES_FROM_SOURCE'] = 'true' if is_visionos && options[:version] < v(0, 76, 0)
+
   options[:hermes_enabled] == true
 end
 

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -83,21 +83,47 @@ class TestPodHelpers < Minitest::Test
   end
 
   def test_use_hermes?
+    options = { path: '../node_modules/react-native' }
+
+    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
     ENV.delete('USE_HERMES')
 
-    refute(use_hermes?({}))
-    assert(use_hermes?({ hermes_enabled: true }))
+    refute(use_hermes?(options))
+    assert(use_hermes?({ **options, hermes_enabled: true }))
+    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
 
     ENV['USE_HERMES'] = '0'
 
-    refute(use_hermes?({}))
-    refute(use_hermes?({ hermes_enabled: true }))
+    refute(use_hermes?(options))
+    refute(use_hermes?({ **options, hermes_enabled: true }))
+    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
 
     ENV['USE_HERMES'] = '1'
 
-    assert(use_hermes?({}))
-    assert(use_hermes?({ hermes_enabled: true }))
+    assert(use_hermes?(options))
+    assert(use_hermes?({ **options, hermes_enabled: true }))
+    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
 
+    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
+    ENV.delete('USE_HERMES')
+  end
+
+  def test_use_hermes_visionos?
+    options = {
+      path: '../node_modules/@callstack/react-native-visionos',
+      hermes_enabled: true,
+    }
+
+    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
+    ENV.delete('USE_HERMES')
+
+    assert(use_hermes?({ **options, version: v(0, 76, 0) }))
+    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
+
+    assert(use_hermes?({ **options, version: v(0, 75, 0) }))
+    assert_equal('true', ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE'))
+
+    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
     ENV.delete('USE_HERMES')
   end
 


### PR DESCRIPTION
### Description

Fix build failing when Hermes is enabled on 0.75 or below.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
cd example
USE_HERMES=1 pod install --project-directory=visionos
yarn visionos
```