### PR TITLE
fix(apple): use core's autolinking script

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,6 +13,11 @@ PODS:
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Default (= 2024.01.01.00)
+  - RCT-Folly/Default (2024.01.01.00):
+    - boost
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
   - RCT-Folly/Fabric (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1706,13 +1711,13 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   Example-Tests: fd3881e0cd75134e3f658c9dbb1788c0c578a504
   FBLazyVector: 430e10366de01d1e3d57374500b1b150fe482e6d
-  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: 726d24248aeab6d7180dac71a936bbca6a994ed1
   RCTRequired: a94e7febda6db0345d207e854323c37e3a31d93b
   RCTTypeSafety: 28e24a6e44f5cbf912c66dde6ab7e07d1059a205

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -360,9 +360,12 @@ def use_test_app_internal!(target_platform, options)
     install! 'cocoapods', :deterministic_uuids => false
   end
 
-  require_relative(autolink_script_path(project_root,
-                                        target_platform,
-                                        project_target[:react_native_version]))
+  # As of 0.75, we should use `use_native_modules!` from `react-native` instead
+  if project_target[:react_native_version] < v(0, 75, 0)
+    require_relative(autolink_script_path(project_root,
+                                          target_platform,
+                                          project_target[:react_native_version]))
+  end
 
   begin
     platform :ios, platforms[:ios] if target_platform == :ios


### PR DESCRIPTION
### Description

Use React Native's autolinking script starting from 0.75

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
cd example
pod install --project-directory=ios
yarn ios

# In a separate terminal
yarn start
```