### PR TITLE
fix(android): dynamic CLI resolution based on current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@rnx-kit/react-native-host": "^0.5.0",
+    "@rnx-kit/tools-react-native": "^2.0.0",
     "ajv": "^8.0.0",
     "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12380,6 +12380,7 @@ __metadata:
     "@react-native-community/template": "npm:^0.75.0"
     "@rnx-kit/eslint-plugin": "npm:^0.8.0"
     "@rnx-kit/react-native-host": "npm:^0.5.0"
+    "@rnx-kit/tools-react-native": "npm:^2.0.0"
     "@rnx-kit/tsconfig": "npm:^2.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Use `@rnx-kit/tools-react-native` to correctly resolve `@react-native-community/cli` to load the project config.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd example
yarn android

# In a separate terminal
yarn start
```

### Screenshots

![Screenshot_1731670996](https://github.com/user-attachments/assets/1f1c9d23-5764-4942-afac-5cd6cbe62cf6)
