### PR TITLE
fix(android): support ESM config files

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4.1.0
       with:
-        node-version: "20"
+        node-version: "22"
         cache: ${{ inputs.cache-npm-dependencies }}
     - name: Set up Xcode
       if: ${{ inputs.xcode-developer-dir != '' }}

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "postpack": "node scripts/internal/pack.mjs post",
     "release-notes": "node scripts/internal/release-notes.mjs",
     "set-react-version": "node scripts/internal/set-react-version.mjs",
-    "show-affected": "node --import tsx scripts/build/affected.ts",
+    "show-affected": "node --experimental-transform-types --no-warnings scripts/build/affected.ts",
     "test": "node scripts/internal/test.mjs",
-    "test:js": "node --import tsx --test $(git ls-files '*.test.ts')",
+    "test:js": "node --experimental-transform-types --no-warnings --test $(git ls-files '*.test.ts')",
     "test:matrix": "node scripts/testing/test-matrix.mjs",
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('./test/test_*.rb').each { |file| require(file) }\""
   },
@@ -146,7 +146,6 @@
     "react-native-windows": "^0.75.0",
     "semantic-release": "^24.0.0",
     "suggestion-bot": "^3.0.0",
-    "tsx": "^4.16.2",
     "typescript": "^5.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "@rnx-kit/react-native-host": "^0.5.0",
-    "@rnx-kit/tools-react-native": "^2.0.0",
+    "@rnx-kit/tools-react-native": "^2.0.1",
     "ajv": "^8.0.0",
     "cliui": "^8.0.0",
     "fast-xml-parser": "^4.0.0",

--- a/scripts/internal/test.mjs
+++ b/scripts/internal/test.mjs
@@ -31,8 +31,8 @@ switch (getTarget(input)) {
     break;
   case "typescript":
     testWith(process.argv0, [
-      "--import",
-      "tsx",
+      "--experimental-transform-types",
+      "--no-warnings",
       "--test",
       "--experimental-test-coverage",
       ...input,

--- a/test/android/gradle.ts
+++ b/test/android/gradle.ts
@@ -6,8 +6,8 @@ import * as path from "node:path";
 import { URL, fileURLToPath } from "node:url";
 import { gatherConfig, writeAllFiles } from "../../scripts/configure.mjs";
 import { findNearest, readJSONFile } from "../../scripts/helpers.js";
-import type { ConfigureParams } from "../../scripts/types.js";
-import { templatePath } from "../template.js";
+import type { ConfigureParams } from "../../scripts/types.ts";
+import { templatePath } from "../template.ts";
 
 const GRADLE_TEST_TASK = "nodeTest";
 const MKDIR_OPTIONS = { recursive: true, mode: 0o755 };

--- a/test/android/test-app-util.test.ts
+++ b/test/android/test-app-util.test.ts
@@ -6,7 +6,7 @@ import {
   reactNativeVersion,
   removeProject,
   runGradleWithProject,
-} from "./gradle.js";
+} from "./gradle.ts";
 
 describe("test-app-util.gradle", () => {
   const defaultTestProject = "TestAppUtilTest";

--- a/test/configure/gatherConfig.test.ts
+++ b/test/configure/gatherConfig.test.ts
@@ -3,9 +3,9 @@ import { describe, it } from "node:test";
 import { gatherConfig as gatherConfigActual } from "../../scripts/configure.mjs";
 import { readTextFile } from "../../scripts/helpers.js";
 import { join } from "../../scripts/template.mjs";
-import type { Configuration, ConfigureParams } from "../../scripts/types.js";
-import { templatePath } from "../template.js";
-import { mockParams } from "./mockParams.js";
+import type { Configuration, ConfigureParams } from "../../scripts/types.ts";
+import { templatePath } from "../template.ts";
+import { mockParams } from "./mockParams.ts";
 
 describe("gatherConfig()", () => {
   const templateDir = templatePath.substring(

--- a/test/configure/getAppName.test.ts
+++ b/test/configure/getAppName.test.ts
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { getAppName as getAppNameActual } from "../../scripts/configure.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("getAppName()", () => {
   const getAppName: typeof getAppNameActual = (p) => getAppNameActual(p, fs);

--- a/test/configure/getConfig.test.ts
+++ b/test/configure/getConfig.test.ts
@@ -5,9 +5,9 @@ import {
   getConfig as getConfigActual,
   getPlatformPackage,
 } from "../../scripts/configure.mjs";
-import type { ConfigureParams, Platform } from "../../scripts/types.js";
-import { templatePath } from "../template.js";
-import { mockParams } from "./mockParams.js";
+import type { ConfigureParams, Platform } from "../../scripts/types.ts";
+import { templatePath } from "../template.ts";
+import { mockParams } from "./mockParams.ts";
 
 describe("getConfig()", () => {
   const getConfig: typeof getConfigActual = (params, platform) =>

--- a/test/configure/isDestructive.test.ts
+++ b/test/configure/isDestructive.test.ts
@@ -1,7 +1,7 @@
 import { equal, ok } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { isDestructive as isDestructiveActual } from "../../scripts/configure.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("isDestructive()", () => {
   /**

--- a/test/configure/mockParams.ts
+++ b/test/configure/mockParams.ts
@@ -1,5 +1,5 @@
 /* node:coverage disable */
-import type { ConfigureParams } from "../../scripts/types.js";
+import type { ConfigureParams } from "../../scripts/types.ts";
 
 /**
  * Returns mock parameters.

--- a/test/configure/reactNativeConfig.test.ts
+++ b/test/configure/reactNativeConfig.test.ts
@@ -1,8 +1,8 @@
 import { equal, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { reactNativeConfig as reactNativeConfigActual } from "../../scripts/configure.mjs";
-import type { ConfigureParams } from "../../scripts/types.js";
-import { mockParams } from "./mockParams.js";
+import type { ConfigureParams } from "../../scripts/types.ts";
+import { mockParams } from "./mockParams.ts";
 
 describe("reactNativeConfig()", () => {
   const reactNativeConfig = (params: ConfigureParams): string => {

--- a/test/configure/removeAllFiles.test.ts
+++ b/test/configure/removeAllFiles.test.ts
@@ -1,7 +1,7 @@
 import { ok } from "node:assert/strict";
 import { after, beforeEach, describe, it } from "node:test";
 import { removeAllFiles as removeAllFilesActual } from "../../scripts/configure.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("removeAllFiles()", () => {
   const removeAllFiles: typeof removeAllFilesActual = (files, destination) =>

--- a/test/configure/updatePackageManifest.test.ts
+++ b/test/configure/updatePackageManifest.test.ts
@@ -3,8 +3,8 @@ import { afterEach, describe, it } from "node:test";
 import { URL } from "node:url";
 import { updatePackageManifest as updatePackageManifestActual } from "../../scripts/configure.mjs";
 import { readJSONFile } from "../../scripts/helpers.js";
-import type { Manifest } from "../../scripts/types.js";
-import { fs, setMockFiles } from "../fs.mock.js";
+import type { Manifest } from "../../scripts/types.ts";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 function getExampleManifest() {
   const p = new URL("../../example/package.json", import.meta.url);

--- a/test/configure/writeAllFiles.test.ts
+++ b/test/configure/writeAllFiles.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { writeAllFiles as writeAllFilesActual } from "../../scripts/configure.mjs";
 import { readTextFile as readTextFileActual } from "../../scripts/helpers.js";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("writeAllFiles()", () => {
   const readTextFile: typeof readTextFileActual = (p) =>

--- a/test/embed-manifest/cpp.test.ts
+++ b/test/embed-manifest/cpp.test.ts
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { generate as generateActual } from "../../scripts/embed-manifest/cpp.mjs";
-import * as fixtures from "./fixtures.js";
+import * as fixtures from "./fixtures.ts";
 
 describe("embed manifest (C++)", () => {
   const generate = (json: Record<string, unknown>) => generateActual(json, "0");

--- a/test/embed-manifest/kotlin.test.ts
+++ b/test/embed-manifest/kotlin.test.ts
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { generate as generateActual } from "../../scripts/embed-manifest/kotlin.mjs";
-import * as fixtures from "./fixtures.js";
+import * as fixtures from "./fixtures.ts";
 
 describe("embed manifest (Kotlin)", () => {
   const generate = (json: Record<string, unknown>) => generateActual(json, "0");

--- a/test/embed-manifest/swift.test.ts
+++ b/test/embed-manifest/swift.test.ts
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { generate as generateActual } from "../../scripts/embed-manifest/swift.mjs";
-import * as fixtures from "./fixtures.js";
+import * as fixtures from "./fixtures.ts";
 
 describe("embed manifest (Swift)", () => {
   const generate = (json: Record<string, unknown>) => generateActual(json, "0");

--- a/test/embed-manifest/validate.test.ts
+++ b/test/embed-manifest/validate.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal, match, notEqual } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { validate as validateActual } from "../../scripts/embed-manifest/validate.mjs";
 import { findFile as findFileActual } from "../../scripts/helpers.js";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("validate()", () => {
   const findFile: typeof findFileActual = (file, startDir = undefined) =>

--- a/test/windows/copyAndReplace.test.ts
+++ b/test/windows/copyAndReplace.test.ts
@@ -2,7 +2,7 @@ import { equal, fail, match, rejects } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { readTextFile as readTextFileActual } from "../../scripts/helpers.js";
 import { copyAndReplace as copyAndReplaceActual } from "../../windows/test-app.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("copyAndReplace()", () => {
   const copyAndReplace: typeof copyAndReplaceActual = (src, dst, r) =>

--- a/test/windows/generateSolution.test.ts
+++ b/test/windows/generateSolution.test.ts
@@ -2,7 +2,7 @@ import { equal } from "node:assert/strict";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { generateSolution as generateSolutionActual } from "../../windows/test-app.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("generateSolution()", () => {
   const generateSolution: typeof generateSolutionActual = (d, cfg) =>

--- a/test/windows/getBundleResources.test.ts
+++ b/test/windows/getBundleResources.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal, match } from "node:assert/strict";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { getBundleResources as getBundleResourcesActual } from "../../windows/project.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("getBundleResources()", () => {
   const getBundleResources: typeof getBundleResourcesActual = (p) =>

--- a/test/windows/parseResources.test.ts
+++ b/test/windows/parseResources.test.ts
@@ -1,7 +1,7 @@
 import { deepEqual, equal, match } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { parseResources as parseResourcesActual } from "../../windows/project.mjs";
-import { fs, setMockFiles } from "../fs.mock.js";
+import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("parseResources()", () => {
   const parseResources: typeof parseResourcesActual = (r, p) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
+    "allowImportingTsExtensions": true,
     "moduleResolution": "Node",
     "noEmit": true,
     "lib": ["ES2022", "DOM"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,174 +1720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/aix-ppc64@npm:0.23.1"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/android-arm64@npm:0.23.1"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/android-arm@npm:0.23.1"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/android-x64@npm:0.23.1"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/darwin-arm64@npm:0.23.1"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/darwin-x64@npm:0.23.1"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/freebsd-arm64@npm:0.23.1"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/freebsd-x64@npm:0.23.1"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-arm64@npm:0.23.1"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-arm@npm:0.23.1"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-ia32@npm:0.23.1"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-loong64@npm:0.23.1"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-mips64el@npm:0.23.1"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-ppc64@npm:0.23.1"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-riscv64@npm:0.23.1"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-s390x@npm:0.23.1"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/linux-x64@npm:0.23.1"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/netbsd-x64@npm:0.23.1"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/openbsd-x64@npm:0.23.1"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/sunos-x64@npm:0.23.1"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/win32-arm64@npm:0.23.1"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-ia32@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/win32-ia32@npm:0.23.1"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.23.1":
-  version: 0.23.1
-  resolution: "@esbuild/win32-x64@npm:0.23.1"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -7032,89 +6864,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:~0.23.0":
-  version: 0.23.1
-  resolution: "esbuild@npm:0.23.1"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.23.1"
-    "@esbuild/android-arm": "npm:0.23.1"
-    "@esbuild/android-arm64": "npm:0.23.1"
-    "@esbuild/android-x64": "npm:0.23.1"
-    "@esbuild/darwin-arm64": "npm:0.23.1"
-    "@esbuild/darwin-x64": "npm:0.23.1"
-    "@esbuild/freebsd-arm64": "npm:0.23.1"
-    "@esbuild/freebsd-x64": "npm:0.23.1"
-    "@esbuild/linux-arm": "npm:0.23.1"
-    "@esbuild/linux-arm64": "npm:0.23.1"
-    "@esbuild/linux-ia32": "npm:0.23.1"
-    "@esbuild/linux-loong64": "npm:0.23.1"
-    "@esbuild/linux-mips64el": "npm:0.23.1"
-    "@esbuild/linux-ppc64": "npm:0.23.1"
-    "@esbuild/linux-riscv64": "npm:0.23.1"
-    "@esbuild/linux-s390x": "npm:0.23.1"
-    "@esbuild/linux-x64": "npm:0.23.1"
-    "@esbuild/netbsd-x64": "npm:0.23.1"
-    "@esbuild/openbsd-arm64": "npm:0.23.1"
-    "@esbuild/openbsd-x64": "npm:0.23.1"
-    "@esbuild/sunos-x64": "npm:0.23.1"
-    "@esbuild/win32-arm64": "npm:0.23.1"
-    "@esbuild/win32-ia32": "npm:0.23.1"
-    "@esbuild/win32-x64": "npm:0.23.1"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/08c2ed1105cc3c5e3a24a771e35532fe6089dd24a39c10097899072cef4a99f20860e41e9294e000d86380f353b04d8c50af482483d7f69f5208481cce61eec7
-  languageName: node
-  linkType: hard
-
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -7985,7 +7734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.3":
+"fsevents@npm:^2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -8174,7 +7923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.7.0, get-tsconfig@npm:^4.7.5":
+"get-tsconfig@npm:^4.7.0":
   version: 4.8.1
   resolution: "get-tsconfig@npm:4.8.1"
   dependencies:
@@ -12231,7 +11980,6 @@ __metadata:
     semantic-release: "npm:^24.0.0"
     semver: "npm:^7.3.5"
     suggestion-bot: "npm:^3.0.0"
-    tsx: "npm:^4.16.2"
     typescript: "npm:^5.0.0"
     uuid: "npm:^10.0.0"
   peerDependencies:
@@ -14181,22 +13929,6 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
-  languageName: node
-  linkType: hard
-
-"tsx@npm:^4.16.2":
-  version: 4.19.2
-  resolution: "tsx@npm:4.19.2"
-  dependencies:
-    esbuild: "npm:~0.23.0"
-    fsevents: "npm:~2.3.3"
-    get-tsconfig: "npm:^4.7.5"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    tsx: dist/cli.mjs
-  checksum: 10c0/63164b889b1d170403e4d8753a6755dec371f220f5ce29a8e88f1f4d6085a784a12d8dc2ee669116611f2c72757ac9beaa3eea5c452796f541bdd2dc11753721
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3352,12 +3352,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/tools-react-native@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@rnx-kit/tools-react-native@npm:2.0.0"
+"@rnx-kit/tools-react-native@npm:^2.0.0, @rnx-kit/tools-react-native@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@rnx-kit/tools-react-native@npm:2.0.1"
   dependencies:
     "@rnx-kit/tools-node": "npm:^3.0.0"
-  checksum: 10c0/859ababb03313d6130b4eaa91fc6a9ec2fd97edec7e30a8fecf82491050e65eae3c1865950613cca87d0d78fff530fd8d72e85bd3a57b45151825f7c357abd48
+  checksum: 10c0/55ec8ea8c279b994da7d4411e216d0d7ed643d817f4f87271606a8f11fb4eebfa596c17dc2effb188a94769b754bc590d3ed1e48724edf9f7d1e5d24c7e06379
   languageName: node
   linkType: hard
 
@@ -12206,7 +12206,7 @@ __metadata:
     "@react-native-community/template": "npm:^0.75.0"
     "@rnx-kit/eslint-plugin": "npm:^0.8.0"
     "@rnx-kit/react-native-host": "npm:^0.5.0"
-    "@rnx-kit/tools-react-native": "npm:^2.0.0"
+    "@rnx-kit/tools-react-native": "npm:^2.0.1"
     "@rnx-kit/tsconfig": "npm:^2.0.0"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Support loading `react-native.config.mjs`.

Partially addresses #2306.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a