### PR TITLE
revert(android): force enable New Architecture from 0.77

### DIFF
--- a/android/react-native.gradle
+++ b/android/react-native.gradle
@@ -36,13 +36,10 @@ ext.isFabricEnabled = { Project project ->
 }
 
 ext.isNewArchitectureEnabled = { Project project ->
-    def NEW_ARCH_ENABLED = "newArchEnabled"
-    def SCOPED_NEW_ARCH_ENABLED = "react.newArchEnabled"
-
-    def newArchEnabled = project.findProperty(SCOPED_NEW_ARCH_ENABLED)
-                             ?: project.findProperty(NEW_ARCH_ENABLED)
-    def version = getPackageVersionNumber("react-native", project.rootDir)
+    def newArchEnabled = project.findProperty("react.newArchEnabled")
+                             ?: project.findProperty("newArchEnabled")
     if (newArchEnabled == "true") {
+        def version = getPackageVersionNumber("react-native", project.rootDir)
         def isSupported = version == 0 || version >= v(0, 71, 0)
         if (!isSupported) {
             throw new GradleException([
@@ -53,13 +50,5 @@ ext.isNewArchitectureEnabled = { Project project ->
         }
         return isSupported
     }
-
-    if (version < v(0, 77, 0)) {
-        return false
-    }
-
-    // As of 0.77, New Architecture is assumed on and doesn't build otherwise
-    project.ext[NEW_ARCH_ENABLED] = "true"
-    project.ext[SCOPED_NEW_ARCH_ENABLED] = "true"
-    return true
+    return false
 }


### PR DESCRIPTION
### Description

Latest nightly should now build old architecture again.

This reverts commit d3138e991737c5b476922e8b388ae6befcfa245f.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version nightly
yarn clean
yarn
cd example
yarn android

# In a separate terminal
yarn start
```

### Screenshots

![Screenshot_1732291148](https://github.com/user-attachments/assets/aa8d73ab-6fc9-43e0-91cc-974c6812854f)
