### PR TITLE
fix(windows): use new property when enabling New Arch

### DIFF
--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -6,6 +6,7 @@
 
       See https://reactnative.dev/docs/new-architecture-intro
     -->
+    <RnwNewArch>false</RnwNewArch>
     <UseFabric>false</UseFabric>
 
     <!--

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -238,6 +238,7 @@ export function generateSolution(destPath, options, fs = nodefs) {
     const { useExperimentalNuGet, useFabric, versionNumber } = info;
     const url = new URL(experimentalFeaturesPropsFilename, import.meta.url);
     copyAndReplaceAsync(fileURLToPath(url), experimentalFeaturesPropsPath, {
+      "<RnwNewArch>false</RnwNewArch>": `<RnwNewArch>${useFabric}</RnwNewArch>`,
       "<UseFabric>false</UseFabric>": `<UseFabric>${useFabric}</UseFabric>`,
       "<UseHermes>true</UseHermes>": `<UseHermes>${useHermes == null ? versionNumber >= v(0, 73, 0) : useHermes}</UseHermes>`,
       "<UseWinUI3>false</UseWinUI3>": `<UseWinUI3>${useFabric}</UseWinUI3>`,


### PR DESCRIPTION
### Description

`RnwNewArch` was recently introduced in 0.76

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a