### PR TITLE
chore: escape quotation marks in commit messages

### DIFF
--- a/scripts/internal/release-notes.mts
+++ b/scripts/internal/release-notes.mts
@@ -46,7 +46,7 @@ function repositoryUrl() {
 function main(lastRelease: string, nextRelease: string): void {
   const args = [
     "log",
-    `--pretty=format:{ "hash": "%H", "message": "%s" }`,
+    `--pretty=format:{ ＂hash＂: ＂%H＂, ＂message＂: ＂%s＂ }`,
     `${lastRelease}...${nextRelease}`,
   ];
   const git = spawn("git", args, { stdio: ["ignore", "pipe", "inherit"] });
@@ -65,6 +65,8 @@ function main(lastRelease: string, nextRelease: string): void {
     const output = Buffer.concat(buffers)
       .toString()
       .trim()
+      .replaceAll('"', '\\"')
+      .replaceAll("＂", '"')
       .replaceAll("\n", ",");
     const commits = JSON.parse(output);
     if (commits.length === 0) {


### PR DESCRIPTION
### Description

Escape quotation marks in commit messages using the rarely used "fill-width" variant

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

The following should not throw an exception:

```
yarn release-notes 4.0.0 4.0.9
```