### PR TITLE
fix(ios): handle `isDebuggingRemotely` being removed in 0.79

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,6 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="m"
     >
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-
         <activity android:name="com.microsoft.reacttestapp.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/ios/ReactTestApp/React+Compatibility.h
+++ b/ios/ReactTestApp/React+Compatibility.h
@@ -4,6 +4,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSURL *RTADefaultJSBundleURL();
 
+void RTADisableRemoteDebugging();
+
 IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector);
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactTestApp/React+Compatibility.m
+++ b/ios/ReactTestApp/React+Compatibility.m
@@ -12,6 +12,10 @@
 
 #define MAKE_VERSION(maj, min, patch) ((maj * 1000000) + (min * 1000) + patch)
 
+#if REACT_NATIVE_VERSION < MAKE_VERSION(0, 79, 0)
+#import <React/RCTDevSettings.h>
+#endif
+
 IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
 {
     Method originalMethod = class_getInstanceMethod(class, originalSelector);
@@ -31,6 +35,16 @@ IMP RTASwizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector)
     }
 
     return originalImpl;
+}
+
+// MARK: - [0.79.0] `isDebuggingRemotely` was removed
+// See https://github.com/facebook/react-native/commit/9aae84a688b5af87faf4b68676b6357de26f797f
+
+void RTADisableRemoteDebugging()
+{
+#if REACT_NATIVE_VERSION < MAKE_VERSION(0, 79, 0)
+    [[RCTDevSettings alloc] init].isDebuggingRemotely = NO;
+#endif
 }
 
 // MARK: - [0.71.13] The additional `inlineSourceMap:` was added in 0.71.13

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -81,7 +81,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
                 // When loading the embedded bundle, we must disable remote
                 // debugging to prevent the bridge from getting stuck in
                 // -[RCTWebSocketExecutor executeApplicationScript:sourceURL:onComplete:]
-                RCTDevSettings().isDebuggingRemotely = false
+                RTADisableRemoteDebugging();
             }
             RCTTriggerReloadCommandListeners("ReactTestApp")
             return

--- a/ios/ReactTestApp/ReactInstance.swift
+++ b/ios/ReactTestApp/ReactInstance.swift
@@ -81,7 +81,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
                 // When loading the embedded bundle, we must disable remote
                 // debugging to prevent the bridge from getting stuck in
                 // -[RCTWebSocketExecutor executeApplicationScript:sourceURL:onComplete:]
-                RTADisableRemoteDebugging();
+                RTADisableRemoteDebugging()
             }
             RCTTriggerReloadCommandListeners("ReactTestApp")
             return


### PR DESCRIPTION
### Description

`isDebuggingRemotely` is removed in 0.79

See build logs: https://github.com/microsoft/react-native-test-app/actions/runs/13045379719/job/36394998395

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version nightly
yarn
cd example
pod install --project-directory=ios
yarn ios --simulator 'iPhone 16 Pro'
```

### Screenshots

![image](https://github.com/user-attachments/assets/d0cb8dcd-76ad-4a29-bf2f-96c0281e2306)
