### PR TITLE
fix: declare support for 0.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@callstack/react-native-visionos": "0.73 - 0.77",
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.0",
-    "react-native": "0.70 - 0.77 || >=0.78.0-0 <0.78.0",
+    "react-native": "0.70 - 0.78 || >=0.79.0-0 <0.79.0",
     "react-native-macos": "^0.0.0-0 || 0.71 - 0.77",
     "react-native-windows": "^0.0.0-0 || 0.70 - 0.77"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12058,7 +12058,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.73 - 0.77
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.0
-    react-native: 0.70 - 0.77 || >=0.78.0-0 <0.78.0
+    react-native: 0.70 - 0.78 || >=0.79.0-0 <0.79.0
     react-native-macos: ^0.0.0-0 || 0.71 - 0.77
     react-native-windows: ^0.0.0-0 || 0.70 - 0.77
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for 0.78

Resolves #2374.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run test:matrix 0.78
```

| Configuration | JSC  | Hermes | Fabric | Fabric + Hermes |
| :------------ | :--: | :----: | :----: | :-------------: |
| Android       | n/a  | ![Screenshot-Android-hermes](https://github.com/user-attachments/assets/bd4fce9a-4f8e-45eb-83b1-d99e5ccdeb19) |  n/a   | ![Screenshot-Android-hermes-fabric-concurrent](https://github.com/user-attachments/assets/1cfd08a6-4716-4376-9fcb-756de6f277ab) |
| iOS           | ![Screenshot-iOS](https://github.com/user-attachments/assets/cf8359ac-9445-4b51-98dc-675efcf8ce78) | ![Screenshot-iOS-hermes](https://github.com/user-attachments/assets/3b6261bd-0943-4a28-abcc-5557e97756ab) | ![Screenshot-iOS-fabric-concurrent](https://github.com/user-attachments/assets/66768f6f-6079-480d-86b7-1b10d93dc0b8) | ![Screenshot-iOS-hermes-fabric-concurrent](https://github.com/user-attachments/assets/c761e4e6-e028-48da-b1ce-bb98bb95c0c4) |