### PR TITLE
fix: declare support for react-native-macos/-windows 0.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.0",
     "react-native": "0.70 - 0.77 || >=0.78.0-0 <0.78.0",
-    "react-native-macos": "^0.0.0-0 || 0.71 - 0.76",
-    "react-native-windows": "^0.0.0-0 || 0.70 - 0.76"
+    "react-native-macos": "^0.0.0-0 || 0.71 - 0.77",
+    "react-native-windows": "^0.0.0-0 || 0.70 - 0.77"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/windows/test-app.mjs
+++ b/windows/test-app.mjs
@@ -245,16 +245,17 @@ export async function generateSolution(destPath, options, fs = nodefs) {
   }
 
   if (info.useExperimentalNuGet) {
-    // In 0.70, the template was renamed from `NuGet.Config` to `NuGet_Config`
-    const nugetConfigPath0_70 = path.join(
-      rnWindowsPath,
-      "template",
-      "shared-app",
-      "proj",
-      "NuGet_Config"
-    );
-    const nugetConfigPath = fs.existsSync(nugetConfigPath0_70)
-      ? nugetConfigPath0_70
+    const nugetConfigTemplatePath = info.useFabric
+      ? path.join(rnWindowsPath, "templates", "cpp-app", "NuGet_Config")
+      : path.join(
+          rnWindowsPath,
+          "template",
+          "shared-app",
+          "proj",
+          "NuGet_Config"
+        );
+    const nugetConfigPath = fs.existsSync(nugetConfigTemplatePath)
+      ? nugetConfigTemplatePath
       : null;
     if (nugetConfigPath) {
       const nugetConfigDest = path.join(destPath, "NuGet.Config");
@@ -263,8 +264,10 @@ export async function generateSolution(destPath, options, fs = nodefs) {
         copyTasks.push(fs.promises.cp(nugetConfigDest, nugetConfigCopy));
       } else {
         const template = readTextFile(nugetConfigPath, fs);
-        const nuGetADOFeed = info.version.startsWith("0.0.0-");
-        const nugetConfig = mustache.render(template, { nuGetADOFeed });
+        const nugetConfig = mustache.render(template, {
+          addReactNativePublicAdoFeed: true,
+          nuGetADOFeed: info.version.startsWith("0.0.0-"),
+        });
         copyTasks.push(
           writeTextFile(nugetConfigDest, nugetConfig, fs.promises),
           writeTextFile(nugetConfigCopy, nugetConfig, fs.promises)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12035,8 +12035,8 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.0
     react-native: 0.70 - 0.77 || >=0.78.0-0 <0.78.0
-    react-native-macos: ^0.0.0-0 || 0.71 - 0.76
-    react-native-windows: ^0.0.0-0 || 0.70 - 0.76
+    react-native-macos: ^0.0.0-0 || 0.71 - 0.77
+    react-native-windows: ^0.0.0-0 || 0.70 - 0.77
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true


### PR DESCRIPTION
### Description

Declare support for react-native-macos/-windows 0.77

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```sh
npm run set-react-version 0.77
yarn clean
yarn
cd example

# macOS:
rm macos/Podfile.lock
pod install --project-directory=macos
yarn macos

# Windows:
yarn install-windows-test-app
yarn windows
```

### Screenshots

| macOS | Windows |
| :-: | :-: |
| ![Screenshot 2025-02-11 at 11 33 05](https://github.com/user-attachments/assets/05762d1d-21a2-4635-b817-bd6d7bc52672) | ![image](https://github.com/user-attachments/assets/2ace27ff-3479-4541-abaa-d417e8c8585e) |

> [!NOTE]
>
> macOS screenshot is blank because the JS part is broken. However, this does not affect RNTA since its main focus is on the native parts.
>
> ```
> ERROR  Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
> 
> Check the render method of `App`.
>     in App
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in AppContainer
>     in Example(RootComponent)
>  ERROR  Warning: Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
> 
> Check the render method of `App`.
> 
> This error is located at:
>     in App
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in AppContainer
>     in Example(RootComponent)
>  ERROR  Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
> 
> Check the render method of `LogBoxInspectorHeader`.
>     in LogBoxInspectorHeader (created by LogBoxInspector)
>     in RCTView (created by View)
>     in View (created by LogBoxInspector)
>     in LogBoxInspector (created by _LogBoxInspectorContainer)
>     in RCTView (created by View)
>     in View (created by _LogBoxInspectorContainer)
>     in _LogBoxInspectorContainer (created by LogBoxStateSubscription)
>     in LogBoxStateSubscription
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in RCTView (created by View)
>     in View (created by AppContainer)
>     in AppContainer
>     in LogBox(RootComponent)
> ```