### PR TITLE
feat(android): add support for android manifest meta-data

### DIFF
--- a/android/android-manifest.js
+++ b/android/android-manifest.js
@@ -98,6 +98,17 @@ function generateAndroidManifest(appManifestPath, manifestOutput, fs = nodefs) {
     }
   }
 
+  // https://developer.android.com/guide/topics/manifest/meta-data-element
+  const metaData = android.metaData;
+  if (Array.isArray(metaData)) {
+    const names = ["android:name"];
+    const attributes = ["android:value"];
+    const entries = toXML(metaData, names, attributes, attributeNamePrefix);
+    if (entries.length > 0) {
+      manifest.application["meta-data"] = entries;
+    }
+  }
+
   const builder = new XMLBuilder(xmlOptions);
   fs.mkdirSync(path.dirname(manifestOutput), { recursive: true, mode: 0o755 });
   fs.writeFileSync(manifestOutput, builder.build(xml));

--- a/docs/android.metaData.md
+++ b/docs/android.metaData.md
@@ -31,6 +31,7 @@ becomes
 <details>
 <summary>History</summary>
 
-TODO
+- [[4.2.0](https://github.com/microsoft/react-native-test-app/releases/tag/4.2.0)]
+  Added
 
 </details>

--- a/docs/android.metaData.md
+++ b/docs/android.metaData.md
@@ -1,0 +1,36 @@
+A name-value pair for an item of additional, arbitrary data that can be supplied to the application.
+
+Equivalent to
+[`<meta-data>`](https://developer.android.com/guide/topics/manifest/meta-data-element).
+
+Example:
+
+```xml
+<application>
+  <meta-data
+      android:name="com.google.android.gms.wallet.api.enabled"
+      android:value="true" />
+</application>
+```
+
+becomes
+
+```json
+{
+  "android": {
+    "metaData": [
+      {
+        "android:name": "com.google.android.gms.wallet.api.enabled",
+        "android:value": "true"
+      }
+    ]
+  }
+}
+```
+
+<details>
+<summary>History</summary>
+
+TODO
+
+</details>

--- a/schema.json
+++ b/schema.json
@@ -329,7 +329,7 @@
         },
         "metaData": {
           "description": "A name-value pair for an item of additional, arbitrary data that can be supplied to the application.",
-          "markdownDescription": "A name-value pair for an item of additional, arbitrary data that can be supplied to the application.\n\nEquivalent to\n[`<meta-data>`](https://developer.android.com/guide/topics/manifest/meta-data-element).\n\nExample:\n\n```xml\n<application>\n  <meta-data\n      android:name=\"com.google.android.gms.wallet.api.enabled\"\n      android:value=\"true\" />\n</application>\n```\n\nbecomes\n\n```json\n{\n  \"android\": {\n    \"metaData\": [\n      {\n        \"android:name\": \"com.google.android.gms.wallet.api.enabled\",\n        \"android:value\": \"true\"\n      }\n    ]\n  }\n}\n```\n\n<details>\n<summary>History</summary>\n\nTODO\n\n</details>",
+          "markdownDescription": "A name-value pair for an item of additional, arbitrary data that can be supplied to the application.\n\nEquivalent to\n[`<meta-data>`](https://developer.android.com/guide/topics/manifest/meta-data-element).\n\nExample:\n\n```xml\n<application>\n  <meta-data\n      android:name=\"com.google.android.gms.wallet.api.enabled\"\n      android:value=\"true\" />\n</application>\n```\n\nbecomes\n\n```json\n{\n  \"android\": {\n    \"metaData\": [\n      {\n        \"android:name\": \"com.google.android.gms.wallet.api.enabled\",\n        \"android:value\": \"true\"\n      }\n    ]\n  }\n}\n```\n\n<details>\n<summary>History</summary>\n\n- [[4.2.0](https://github.com/microsoft/react-native-test-app/releases/tag/4.2.0)]\n  Added\n\n</details>",
           "type": "array",
           "items": {
             "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -326,6 +326,22 @@
               }
             }
           }
+        },
+        "metaData": {
+          "description": "A name-value pair for an item of additional, arbitrary data that can be supplied to the application.",
+          "markdownDescription": "A name-value pair for an item of additional, arbitrary data that can be supplied to the application.\n\nEquivalent to\n[`<meta-data>`](https://developer.android.com/guide/topics/manifest/meta-data-element).\n\nExample:\n\n```xml\n<application>\n  <meta-data\n      android:name=\"com.google.android.gms.wallet.api.enabled\"\n      android:value=\"true\" />\n</application>\n```\n\nbecomes\n\n```json\n{\n  \"android\": {\n    \"metaData\": [\n      {\n        \"android:name\": \"com.google.android.gms.wallet.api.enabled\",\n        \"android:value\": \"true\"\n      }\n    ]\n  }\n}\n```\n\n<details>\n<summary>History</summary>\n\nTODO\n\n</details>",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "android:name": {
+                "type": "string"
+              },
+              "android:value": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/scripts/internal/generate-schema.mts
+++ b/scripts/internal/generate-schema.mts
@@ -42,6 +42,7 @@ export async function readDocumentation(): Promise<Partial<Docs>> {
     "android.icons",
     "android.package",
     "android.permissions",
+    "android.metaData",
     "android.signingConfigs",
     "android.versionCode",
     "ios.buildNumber",

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -299,6 +299,18 @@ export function generateSchema(docs = {}) {
               },
             },
           },
+          metaData: {
+            description: extractBrief(docs["android.metaData"]),
+            markdownDescription: docs["android.metaData"],
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                "android:name": { type: "string" },
+                "android:value": { type: "string" },
+              },
+            },
+          },
         },
       },
       ios: {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -14,12 +14,19 @@ export type AndroidConfig = {
       "android:name": string;
       "android:maxSdkVersion"?: string;
     }[];
+    metaData?: {
+      "android:name": string;
+      "android:value": string;
+    }[];
   };
 };
 
 export type AndroidManifest = {
   "uses-feature": Record<string, string>[];
   "uses-permission": Record<string, string>[];
+  application: {
+    "meta-data": Record<string, string>[];
+  };
 };
 
 /************************
@@ -207,6 +214,7 @@ export type Docs = {
   "android.icons": string;
   "android.package": string;
   "android.permissions": string;
+  "android.metaData": string;
   "android.signingConfigs": string;
   "android.versionCode": string;
   "ios.buildNumber": string;


### PR DESCRIPTION
### Description

Add support for application meta-data in android config.

In my case this was useful to set the com.google.android.gms.wallet.api.enabled meta-data required by google pay apis.

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Tested that adding this config does add the proper xml in the generated AndroidManifest.xml.
