### PR TITLE
fix(visionos): declare support for 0.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "uuid": "^11.0.0"
   },
   "peerDependencies": {
-    "@callstack/react-native-visionos": "0.73 - 0.77",
+    "@callstack/react-native-visionos": "0.73 - 0.78",
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.0",
     "react-native": "0.70 - 0.78 || >=0.79.0-0 <0.79.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11974,7 +11974,7 @@ __metadata:
     typescript: "npm:^5.0.0"
     uuid: "npm:^11.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": 0.73 - 0.77
+    "@callstack/react-native-visionos": 0.73 - 0.78
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.0
     react-native: 0.70 - 0.78 || >=0.79.0-0 <0.79.0


### PR DESCRIPTION
### Description

Declare support for `react-native-visionos` 0.78

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```sh
yarn set-react-version 0.78
yarn clean
yarn
cd example
pod install --project-directory=visionos
yarn visionos

# In a separate terminal
yarn start
```

### Screenshots

![image](https://github.com/user-attachments/assets/45dfc009-e95c-4f9b-bfd2-59ef228cd640)
