### PR TITLE
chore: mark visionOS as not experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Instructions:
 ◉   Android
 ◉   iOS
 ◉   macOS
-◯   visionOS (Experimental)
+◯   visionOS
 ◉   Windows
 ✔ Where should we create the new project? … sample
 ```

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -230,9 +230,9 @@ function main() {
               { title: "iOS", value: "ios", selected: true },
               { title: "macOS", value: "macos", selected: true },
               {
-                title: "visionOS (Experimental)",
+                title: "visionOS",
                 value: "visionos",
-                selected: false,
+                selected: true,
               },
               { title: "Windows", value: "windows", selected: true },
             ],

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -229,11 +229,7 @@ function main() {
               { title: "Android", value: "android", selected: true },
               { title: "iOS", value: "ios", selected: true },
               { title: "macOS", value: "macos", selected: true },
-              {
-                title: "visionOS",
-                value: "visionos",
-                selected: false,
-              },
+              { title: "visionOS", value: "visionos", selected: false },
               { title: "Windows", value: "windows", selected: true },
             ],
             min: 1,

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -232,7 +232,7 @@ function main() {
               {
                 title: "visionOS",
                 value: "visionos",
-                selected: true,
+                selected: false,
               },
               { title: "Windows", value: "windows", selected: true },
             ],


### PR DESCRIPTION
### Description

Mark visionOS as no longer experimental.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

CI should pass
