### PR TITLE
chore: disable automatic Pod install

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -6,6 +6,9 @@ const project = (() => {
         sourceDir: "android",
       },
       ios: {
+        // `rnc-cli` does not account for all the ways CocoaPods can be
+        // installed and therefore breaks in many setups.
+        automaticPodsInstallation: false,
         sourceDir: "ios",
       },
       windows: {


### PR DESCRIPTION
### Description

Disable automatic Pod install

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.