### PR TITLE
fix: Show New Architecture experimental warning only for older React Native versions

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -111,6 +111,14 @@ end
 def use_new_architecture!(options, react_native_version)
   return unless new_architecture_enabled?(options, react_native_version)
 
+  if react_native_version < v(0, 76, 0)
+    Pod::UI.warn(
+      'As of writing, New Architecture (Fabric) is still experimental and ' \
+      'subject to change. For more information, please see ' \
+      'https://reactnative.dev/docs/next/new-architecture-intro.'
+    )
+  end
+
   options[:fabric_enabled] = true
   options[:new_arch_enabled] = true
   ENV['RCT_NEW_ARCH_ENABLED'] = '1'

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -111,12 +111,6 @@ end
 def use_new_architecture!(options, react_native_version)
   return unless new_architecture_enabled?(options, react_native_version)
 
-  Pod::UI.warn(
-    'As of writing, New Architecture (Fabric) is still experimental and ' \
-    'subject to change. For more information, please see ' \
-    'https://reactnative.dev/docs/next/new-architecture-intro.'
-  )
-
   options[:fabric_enabled] = true
   options[:new_arch_enabled] = true
   ENV['RCT_NEW_ARCH_ENABLED'] = '1'


### PR DESCRIPTION
### Description

New Architecture is stable already :)

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a