### PR TITLE
docs: do not recommend using `@latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,23 @@ _If you want to migrate an existing test app for a library, follow the
 You can generate a new project using `npx`:
 
 ```sh
-npx --package react-native-test-app@latest init
+npx --package react-native-test-app@<version> init
+# For example: npx --package react-native-test-app@4.2.3 init
 ```
+
+You can always find the latest version here:
+https://github.com/microsoft/react-native-test-app/releases
+
+Alternatively, if you're using a Bash-compatible shell:
+
+```sh
+npx --package react-native-test-app@$(npm view react-native-test-app version) init
+```
+
+> [!NOTE]
+>
+> We don't recommend using `@latest` because npm may not always use the latest
+> version. See https://github.com/npm/cli/issues/5262 for more details.
 
 In this example, we will create a project named "sample" in `sample` with apps
 for all platforms:


### PR DESCRIPTION
### Description

We got reports of `npx react-native-test-app@latest init` not working correctly because `npx` fails to satisfy peer dependencies:

```
❯ npx --package react-native-test-app@latest init
Need to install the following packages:
react-native-test-app@4.2.2
Ok to proceed? (y) y

npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: undefined@undefined
npm error Found: react-native-test-app@3.10.14
npm error node_modules/react-native-test-app
npm error   react-native-test-app@"4.2.2" from the root project
npm error
npm error Could not resolve dependency:
npm error react-native-test-app@"4.2.2" from the root project
npm error
npm error Conflicting peer dependency: react@19.0.0
npm error node_modules/react
npm error   peer react@"^19.0.0" from @callstack/react-native-visionos@0.78.0
npm error   node_modules/@callstack/react-native-visionos
npm error     peerOptional @callstack/react-native-visionos@"0.73 - 0.78" from react-native-test-app@4.2.2
npm error     node_modules/react-native-test-app
npm error       react-native-test-app@"4.2.2" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

Which is confusing because `npx` asked to install 4.2.2, but invokes the `init` script with 3.10.14. This is related to how `npx` resolves `@latest` and caching, which I do not fully understand.

Thanks to @szymonrybczak for reporting the issue.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a