### PR TITLE
fix: workaround for `bunx` picking the wrong binary

### DIFF
--- a/.yarn/plugins/boost-workaround.cjs
+++ b/.yarn/plugins/boost-workaround.cjs
@@ -5,11 +5,11 @@
  * @typedef {{ configuration: Configuration; cwd: string; workspaces: Workspace[]; }} Project
  * @typedef {{ mode?: "skip-build" | "update-lockfile"; }} InstallOptions
  *
- * @type {{ name: string; factory: (require: NodeRequire) => unknown; }}
+ * @type {{ name: string; factory: (require: NodeJS.Require) => unknown; }}
  */
 module.exports = {
   name: "plugin-boost-workaround",
-  factory: (_require) => ({
+  factory: (require) => ({
     hooks: {
       /** @type {(project: Project, options: InstallOptions) => void} */
       afterAllInstalled(project, options) {
@@ -25,6 +25,7 @@ module.exports = {
           return;
         }
 
+        const { npath } = require("@yarnpkg/fslib");
         const fs = require("node:fs");
         const path = require("node:path");
 
@@ -33,18 +34,10 @@ module.exports = {
           "node_modules/react-native-macos/third-party-podspecs/boost.podspec",
         ];
 
-        /**
-         * @param {string} p
-         * @returns {string}
-         */
-        function normalize(p) {
-          // On Windows, paths are prefixed with `/`
-          return p.replace(/^[/\\]([^/\\]+:[/\\])/, "$1");
-        }
-
         for (const ws of project.workspaces) {
           for (const boostPodspec of boostPodspecs) {
-            const podspecPath = path.join(normalize(ws.cwd), boostPodspec);
+            const workspaceDir = npath.fromPortablePath(ws.cwd);
+            const podspecPath = path.join(workspaceDir, boostPodspec);
             if (!fs.existsSync(podspecPath)) {
               continue;
             }

--- a/.yarn/plugins/undo-bin-sorting.cjs
+++ b/.yarn/plugins/undo-bin-sorting.cjs
@@ -1,0 +1,71 @@
+// @ts-check
+/**
+ * @typedef {{ values: Map<string, unknown>; }} Configuration
+ * @typedef {{ cwd: string; }} Workspace
+ * @typedef {{ configuration: Configuration; cwd: string; workspaces: Workspace[]; }} Project
+ * @typedef {{ mode?: "skip-build" | "update-lockfile"; }} InstallOptions
+ */
+
+/**
+ * Yarn always sorts `package.json` during install. This is problematic because
+ * we need the `bin` field to be in a specific order to workaround an issue with
+ * `bunx` always picking the first binary.
+ *
+ * For more context, see:
+ *
+ *   - https://github.com/microsoft/react-native-test-app/issues/2417
+ *   - https://github.com/yarnpkg/berry/issues/6184
+ *
+ * @type {{ name: string; factory: (require: NodeJS.Require) => unknown; }}
+ */
+module.exports = {
+  name: "plugin-undo-bin-sorting",
+  factory: (require) => {
+    const { npath } = require("@yarnpkg/fslib");
+    const fs = require("node:fs");
+
+    const asText = /** @type {const} */ ({ encoding: "utf-8" });
+
+    let manifestPath = "";
+    let orig_rawManifest = "";
+    return {
+      hooks: {
+        /** @type {(project: Project) => void} */
+        validateProject(project) {
+          const pp = npath.join(project.cwd, "package.json");
+          manifestPath = npath.fromPortablePath(pp);
+          orig_rawManifest = fs.readFileSync(manifestPath, asText);
+        },
+        /** @type {(project: Project, options: InstallOptions) => void} */
+        afterAllInstalled() {
+          const rawManifest = fs.readFileSync(manifestPath, asText);
+          if (rawManifest === orig_rawManifest) {
+            return;
+          }
+
+          const manifest = JSON.parse(rawManifest);
+          const bin = Object.keys(manifest.bin);
+
+          const orig_manifest = JSON.parse(orig_rawManifest);
+          const orig_bin = Object.keys(orig_manifest.bin);
+
+          const length = bin.length;
+          if (length !== orig_bin.length) {
+            throw new Error("Did Yarn add something to the 'bin' field?");
+          }
+
+          for (let i = 0; i < length; ++i) {
+            if (bin[i] !== orig_bin[i]) {
+              manifest.bin = orig_manifest.bin;
+              const fd = fs.openSync(manifestPath, "w", 0o644);
+              fs.writeSync(fd, JSON.stringify(manifest, undefined, 2));
+              fs.writeSync(fd, "\n");
+              fs.closeSync(fd);
+              break;
+            }
+          }
+        },
+      },
+    };
+  },
+};

--- a/.yarn/plugins/undo-bin-sorting.cjs
+++ b/.yarn/plugins/undo-bin-sorting.cjs
@@ -23,6 +23,7 @@ module.exports = {
   factory: (require) => {
     const { npath } = require("@yarnpkg/fslib");
     const fs = require("node:fs");
+    const path = require("node:path");
 
     const asText = /** @type {const} */ ({ encoding: "utf-8" });
 
@@ -32,8 +33,8 @@ module.exports = {
       hooks: {
         /** @type {(project: Project) => void} */
         validateProject(project) {
-          const pp = npath.join(project.cwd, "package.json");
-          manifestPath = npath.fromPortablePath(pp);
+          const projectRoot = npath.fromPortablePath(project.cwd);
+          manifestPath = path.join(projectRoot, "package.json");
           orig_rawManifest = fs.readFileSync(manifestPath, asText);
         },
         /** @type {(project: Project, options: InstallOptions) => void} */

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -25,5 +25,6 @@ plugins:
   - path: .yarn/plugins/link-project.cjs
   - path: .yarn/plugins/boost-workaround.cjs
   - path: .yarn/plugins/npm-workaround.cjs
+  - path: .yarn/plugins/undo-bin-sorting.cjs
 tsEnableAutoTypes: false
 yarnPath: .yarn/releases/yarn-4.6.0.cjs

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   ],
   "main": "scripts/configure-projects.js",
   "bin": {
-    "configure-test-app": "scripts/configure.mjs",
     "init": "scripts/init.mjs",
     "init-test-app": "scripts/init.mjs",
+    "configure-test-app": "scripts/configure.mjs",
     "install-windows-test-app": "windows/test-app.mjs"
   },
   "repository": {


### PR DESCRIPTION
### Description

`bunx react-native-test-app init` is not equivalent to `npx --package react-native-test-app init`. As of 1.2.5, `bunx` always picks the first binary (which used to be `configure-test-app`), making it look like the `init` command failed. By making `init` first, we get around this issue.

Resolves #2417.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a