### PR TITLE
refactor(apple): port 'privacy_manifest.rb' to JS

### DIFF
--- a/ios/privacyManifest.mjs
+++ b/ios/privacyManifest.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import { isObject, toPlist } from "./utils.mjs";
+
+/**
+ * @import { ApplePlatform, JSONObject, JSONValue } from "../scripts/types.js";
+ *
+ * @typedef {{
+ *   NSPrivacyTracking: boolean;
+ *   NSPrivacyTrackingDomains: JSONValue[];
+ *   NSPrivacyCollectedDataTypes: JSONValue[];
+ *   NSPrivacyAccessedAPITypes: JSONValue[];
+ * }} PrivacyManifest;
+ */
+
+// https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+export const PRIVACY_ACCESSED_API_TYPES = "NSPrivacyAccessedAPITypes";
+export const PRIVACY_COLLECTED_DATA_TYPES = "NSPrivacyCollectedDataTypes";
+export const PRIVACY_TRACKING = "NSPrivacyTracking";
+export const PRIVACY_TRACKING_DOMAINS = "NSPrivacyTrackingDomains";
+
+// https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+export const PRIVACY_ACCESSED_API_TYPE = "NSPrivacyAccessedAPIType";
+export const PRIVACY_ACCESSED_API_TYPE_REASONS =
+  "NSPrivacyAccessedAPITypeReasons";
+export const PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP =
+  "NSPrivacyAccessedAPICategoryFileTimestamp";
+export const PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME =
+  "NSPrivacyAccessedAPICategorySystemBootTime";
+export const PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS =
+  "NSPrivacyAccessedAPICategoryUserDefaults";
+
+/**
+ * @param {JSONObject} appConfig
+ * @param {ApplePlatform} targetPlatform
+ * @returns {JSONObject | undefined}
+ */
+function getUserPrivacyManifest(appConfig, targetPlatform) {
+  const platformConfig = appConfig[targetPlatform];
+  if (!isObject(platformConfig)) {
+    return;
+  }
+
+  const userPrivacyManifest = platformConfig["privacyManifest"];
+  if (!isObject(userPrivacyManifest)) {
+    return;
+  }
+
+  return userPrivacyManifest;
+}
+
+/**
+ * @param {JSONObject} appConfig
+ * @param {ApplePlatform} targetPlatform
+ * @param {string} destination
+ * @returns {Promise<void>}
+ */
+export async function generatePrivacyManifest(
+  appConfig,
+  targetPlatform,
+  destination,
+  fs = nodefs
+) {
+  /** @type {PrivacyManifest} */
+  const manifest = {
+    [PRIVACY_TRACKING]: false,
+    [PRIVACY_TRACKING_DOMAINS]: [],
+    [PRIVACY_COLLECTED_DATA_TYPES]: [],
+    [PRIVACY_ACCESSED_API_TYPES]: [
+      {
+        [PRIVACY_ACCESSED_API_TYPE]:
+          PRIVACY_ACCESSED_API_CATEGORY_FILE_TIMESTAMP,
+        [PRIVACY_ACCESSED_API_TYPE_REASONS]: ["C617.1"],
+      },
+      {
+        [PRIVACY_ACCESSED_API_TYPE]:
+          PRIVACY_ACCESSED_API_CATEGORY_SYSTEM_BOOT_TIME,
+        [PRIVACY_ACCESSED_API_TYPE_REASONS]: ["35F9.1"],
+      },
+      {
+        [PRIVACY_ACCESSED_API_TYPE]:
+          PRIVACY_ACCESSED_API_CATEGORY_USER_DEFAULTS,
+        [PRIVACY_ACCESSED_API_TYPE_REASONS]: ["CA92.1"],
+      },
+    ],
+  };
+
+  const userPrivacyManifest = getUserPrivacyManifest(appConfig, targetPlatform);
+  if (userPrivacyManifest) {
+    const tracking = userPrivacyManifest[PRIVACY_TRACKING];
+    if (typeof tracking === "boolean") {
+      manifest[PRIVACY_TRACKING] = tracking;
+    }
+
+    const fields = /** @type {const} */ ([
+      PRIVACY_TRACKING_DOMAINS,
+      PRIVACY_COLLECTED_DATA_TYPES,
+      PRIVACY_ACCESSED_API_TYPES,
+    ]);
+    for (const field of fields) {
+      const value = userPrivacyManifest[field];
+      if (Array.isArray(value)) {
+        manifest[field].push(...value);
+      }
+    }
+  }
+
+  const xcprivacy = await toPlist(manifest);
+  fs.writeFileSync(path.join(destination, "PrivacyInfo.xcprivacy"), xcprivacy);
+}

--- a/ios/utils.mjs
+++ b/ios/utils.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import { spawn } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -24,4 +25,32 @@ export function isObject(obj) {
 export function projectPath(p, targetPlatform) {
   const packageDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
   return path.join(packageDir, targetPlatform, p);
+}
+
+/**
+ * @param {JSONObject} source
+ * @returns {Promise<string>}
+ */
+export function toPlist(source) {
+  return new Promise((resolve, reject) => {
+    const args = ["-convert", "xml1", "-r", "-o", "-", "--", "-"];
+    const plutil = spawn("/usr/bin/plutil", args, {
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    /** @type {string[]} */
+    const data = [];
+    plutil.stdout.on("data", (chunk) => data.push(chunk.toString()));
+
+    plutil.on("exit", (exitCode) => {
+      if (exitCode !== 0) {
+        reject(new Error("Failed to generate 'PrivacyInfo.xcprivacy'"));
+      } else {
+        resolve(data.join(""));
+      }
+    });
+
+    plutil.stdin.write(JSON.stringify(source));
+    plutil.stdin.end();
+  });
 }

--- a/test/ios/privacyManifest.test.ts
+++ b/test/ios/privacyManifest.test.ts
@@ -14,7 +14,9 @@ describe("generatePrivacyManifest()", macosOnly, () => {
   }
 
   function readPrivacyManifest() {
-    return fs.readFileSync("PrivacyInfo.xcprivacy", { encoding: "utf-8" });
+    return fs
+      .readFileSync("PrivacyInfo.xcprivacy", { encoding: "utf-8" })
+      .split("\n");
   }
 
   afterEach(() => {
@@ -24,13 +26,13 @@ describe("generatePrivacyManifest()", macosOnly, () => {
   it("generates a default manifest", async () => {
     await generatePrivacyManifest({});
 
-    deepEqual(readPrivacyManifest().split("\n"), DEFAULT_PRIVACY_MANIFEST);
+    deepEqual(readPrivacyManifest(), DEFAULT_PRIVACY_MANIFEST);
   });
 
   it("handles invalid configuration", async () => {
     await generatePrivacyManifest({ ios: { privacyManifest: "YES" } });
 
-    deepEqual(readPrivacyManifest().split("\n"), DEFAULT_PRIVACY_MANIFEST);
+    deepEqual(readPrivacyManifest(), DEFAULT_PRIVACY_MANIFEST);
   });
 
   it("appends to default manifest", async () => {
@@ -44,7 +46,7 @@ describe("generatePrivacyManifest()", macosOnly, () => {
       },
     });
 
-    deepEqual(readPrivacyManifest().split("\n"), [
+    deepEqual(readPrivacyManifest(), [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
       '<plist version="1.0">',

--- a/test/ios/privacyManifest.test.ts
+++ b/test/ios/privacyManifest.test.ts
@@ -1,0 +1,136 @@
+import { deepEqual } from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { generatePrivacyManifest as generatePrivacyManifestActual } from "../../ios/privacyManifest.mjs";
+import type { JSONObject } from "../../scripts/types.ts";
+import { fs, setMockFiles } from "../fs.mock.ts";
+
+const macosOnly = { skip: process.platform === "win32" };
+
+describe("generatePrivacyManifest()", macosOnly, () => {
+  function generatePrivacyManifest(config: JSONObject): Promise<void> {
+    const destination = ".";
+    fs.mkdirSync(destination, { recursive: true, mode: 0o755 });
+    return generatePrivacyManifestActual(config, "ios", destination, fs);
+  }
+
+  function readPrivacyManifest() {
+    return fs.readFileSync("PrivacyInfo.xcprivacy", { encoding: "utf-8" });
+  }
+
+  afterEach(() => {
+    setMockFiles();
+  });
+
+  it("generates a default manifest", async () => {
+    await generatePrivacyManifest({});
+
+    deepEqual(readPrivacyManifest().split("\n"), DEFAULT_PRIVACY_MANIFEST);
+  });
+
+  it("handles invalid configuration", async () => {
+    await generatePrivacyManifest({ ios: { privacyManifest: "YES" } });
+
+    deepEqual(readPrivacyManifest().split("\n"), DEFAULT_PRIVACY_MANIFEST);
+  });
+
+  it("appends to default manifest", async () => {
+    await generatePrivacyManifest({
+      ios: {
+        privacyManifest: {
+          NSPrivacyTracking: true,
+          NSPrivacyTrackingDomains: ["test"],
+          NSPrivacyAccessedAPITypes: ["test"],
+        },
+      },
+    });
+
+    deepEqual(readPrivacyManifest().split("\n"), [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+      '<plist version="1.0">',
+      "<dict>",
+      "	<key>NSPrivacyAccessedAPITypes</key>",
+      "	<array>",
+      "		<dict>",
+      "			<key>NSPrivacyAccessedAPIType</key>",
+      "			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>",
+      "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+      "			<array>",
+      "				<string>C617.1</string>",
+      "			</array>",
+      "		</dict>",
+      "		<dict>",
+      "			<key>NSPrivacyAccessedAPIType</key>",
+      "			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>",
+      "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+      "			<array>",
+      "				<string>35F9.1</string>",
+      "			</array>",
+      "		</dict>",
+      "		<dict>",
+      "			<key>NSPrivacyAccessedAPIType</key>",
+      "			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>",
+      "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+      "			<array>",
+      "				<string>CA92.1</string>",
+      "			</array>",
+      "		</dict>",
+      "		<string>test</string>",
+      "	</array>",
+      "	<key>NSPrivacyCollectedDataTypes</key>",
+      "	<array/>",
+      "	<key>NSPrivacyTracking</key>",
+      "	<true/>",
+      "	<key>NSPrivacyTrackingDomains</key>",
+      "	<array>",
+      "		<string>test</string>",
+      "	</array>",
+      "</dict>",
+      "</plist>",
+      "",
+    ]);
+  });
+});
+
+const DEFAULT_PRIVACY_MANIFEST = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+  '<plist version="1.0">',
+  "<dict>",
+  "	<key>NSPrivacyAccessedAPITypes</key>",
+  "	<array>",
+  "		<dict>",
+  "			<key>NSPrivacyAccessedAPIType</key>",
+  "			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>",
+  "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+  "			<array>",
+  "				<string>C617.1</string>",
+  "			</array>",
+  "		</dict>",
+  "		<dict>",
+  "			<key>NSPrivacyAccessedAPIType</key>",
+  "			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>",
+  "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+  "			<array>",
+  "				<string>35F9.1</string>",
+  "			</array>",
+  "		</dict>",
+  "		<dict>",
+  "			<key>NSPrivacyAccessedAPIType</key>",
+  "			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>",
+  "			<key>NSPrivacyAccessedAPITypeReasons</key>",
+  "			<array>",
+  "				<string>CA92.1</string>",
+  "			</array>",
+  "		</dict>",
+  "	</array>",
+  "	<key>NSPrivacyCollectedDataTypes</key>",
+  "	<array/>",
+  "	<key>NSPrivacyTracking</key>",
+  "	<false/>",
+  "	<key>NSPrivacyTrackingDomains</key>",
+  "	<array/>",
+  "</dict>",
+  "</plist>",
+  "",
+];

--- a/test/pack.test.ts
+++ b/test/pack.test.ts
@@ -157,6 +157,7 @@ describe("npm pack", () => {
       "ios/info_plist.rb",
       "ios/node.rb",
       "ios/pod_helpers.rb",
+      "ios/privacyManifest.mjs",
       "ios/privacy_manifest.rb",
       "ios/test_app.rb",
       "ios/use_react_native-0.70.rb",


### PR DESCRIPTION
### Description

Port 'privacy_manifest.rb' to JS and add tests.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a