### PR TITLE
refactor(apple): move host and autolinking resolution to JS

### DIFF
--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -1,15 +1,5 @@
 require('json')
 
-def app_manifest(project_root)
-  @app_manifest ||= {}
-  return @app_manifest[project_root] if @app_manifest.key?(project_root)
-
-  manifest_path = find_file('app.json', project_root)
-  return if manifest_path.nil?
-
-  @app_manifest[project_root] = JSON.parse(File.read(manifest_path))
-end
-
 def assert(condition, message)
   raise message unless condition
 end
@@ -50,39 +40,8 @@ def new_architecture_enabled?(options, react_native_version)
   ENV.fetch('RCT_NEW_ARCH_ENABLED', options[:fabric_enabled] ? '1' : '0') != '0'
 end
 
-def resolve_module(request, start_dir = Pod::Config.instance.installation_root)
-  @module_cache ||= {}
-  return @module_cache[request] if @module_cache.key?(request)
-
-  @module_cache[request] = resolve_module_uncached(request, start_dir).to_s
-end
-
-def resolve_module_relative(request)
-  path = resolve_module_uncached(request, Pathname.new(__dir__))
-  path.relative_path_from(Pod::Config.instance.installation_root).to_s
-end
-
-def resolve_module_uncached(request, start_dir)
-  # Always resolve `start_dir` as it may be a symlink
-  package_json = find_file("node_modules/#{request}/package.json", start_dir.realdirpath)
-  raise "Cannot find module '#{request}'" if package_json.nil?
-
-  package_json.dirname
-end
-
-def resolve_resources(manifest, target_platform)
-  resources = manifest['resources']
-  return if !resources || resources.empty?
-
-  resources.instance_of?(Array) ? resources : resources[target_platform.to_s]
-end
-
 def supports_new_architecture?(react_native_version)
   react_native_version.zero? || react_native_version >= v(0, 71, 0)
-end
-
-def try_pod(name, podspec, project_root)
-  pod name, :podspec => podspec if File.exist?(File.join(project_root, podspec))
 end
 
 def use_hermes?(options)

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -136,12 +136,15 @@ export type ProjectConfiguration = {
   xcodeprojPath: string;
   reactNativePath: string;
   reactNativeVersion: number;
+  reactNativeHostPath: string;
+  communityAutolinkingScriptPath?: string;
   singleApp?: string;
   useNewArch: boolean;
   useBridgeless: boolean;
   buildSettings: Record<string, string | string[]>;
   testsBuildSettings: Record<string, string>;
   uitestsBuildSettings: Record<string, string>;
+  resources?: string[];
 };
 
 export type XmlOptions = Pick<

--- a/test/ios/app.test.ts
+++ b/test/ios/app.test.ts
@@ -23,12 +23,23 @@ describe("generateProject()", macosOnly, () => {
     return generateProjectActual(projectRoot, platform, options, mockfs);
   }
 
-  function makeMockProject(overrides?: Record<string, unknown>) {
+  function makeMockProject(
+    overrides?: Record<string, unknown>,
+    reactNativeVersion = "1000.0.0"
+  ) {
     const manifestURL = new URL("../../package.json", import.meta.url);
     const manifest = readTextFile(fileURLToPath(manifestURL));
     const { name, version, defaultPlatformPackages } = JSON.parse(manifest);
     return {
-      "app.json": JSON.stringify({ name: "ContosoApp", ...overrides }),
+      "app.json": JSON.stringify({
+        name: "ContosoApp",
+        resources: {
+          ios: ["main.ios.jsbundle"],
+          macos: ["main.macos.jsbundle"],
+          visionos: ["main.visionos.jsbundle"],
+        },
+        ...overrides,
+      }),
       "ios/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme":
         "",
       "ios/ReactTestApp/Assets.xcassets/AppIcon.iconset/Contents.json": "",
@@ -58,15 +69,21 @@ describe("generateProject()", macosOnly, () => {
       "node_modules/@callstack/react-native-visionos/package.json":
         JSON.stringify({
           name: "@callstack/react-native-visionos",
-          version: "1000.0.0",
+          version: reactNativeVersion,
         }),
+      "node_modules/@react-native-community/cli-platform-ios/native_modules.rb":
+        "",
+      "node_modules/@rnx-kit/react-native-host/package.json": JSON.stringify({
+        name: "@rnx-kit/react-native-host",
+        version: reactNativeVersion,
+      }),
       "node_modules/react-native/package.json": JSON.stringify({
         name: "react-native",
-        version: "1000.0.0",
+        version: reactNativeVersion,
       }),
       "node_modules/react-native-macos/package.json": JSON.stringify({
         name: "react-native-macos",
-        version: "1000.0.0",
+        version: reactNativeVersion,
       }),
     };
   }
@@ -214,6 +231,17 @@ describe("generateProject()", macosOnly, () => {
 
     deepEqual(trimPaths(result, cwd), PROJECT_FILES.customReactNative);
   });
+
+  it("finds community autolinking script for older versions", () => {
+    setMockFiles(makeMockProject(undefined, "0.74.0"));
+
+    const result = generateProject("ios", "ios", {});
+
+    equal(
+      result.communityAutolinkingScriptPath,
+      "node_modules/@react-native-community/cli-platform-ios/native_modules.rb"
+    );
+  });
 });
 
 const PROJECT_FILES = {
@@ -232,8 +260,11 @@ const PROJECT_FILES = {
       PRODUCT_VERSION: "1.0",
       USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
     },
+    communityAutolinkingScriptPath: undefined,
+    reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
     reactNativePath: "/~/node_modules/react-native-macos",
     reactNativeVersion: 1000000000,
+    resources: ["main.ios.jsbundle"],
     testsBuildSettings: {},
     uitestsBuildSettings: {},
     useBridgeless: true,
@@ -257,8 +288,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native",
         reactNativeVersion: 1000000000,
+        resources: ["main.ios.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
@@ -288,6 +322,8 @@ const PROJECT_FILES = {
         "/visionos/ReactTestAppUITests/Info.plist",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/ios/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",
@@ -316,8 +352,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native-macos",
         reactNativeVersion: 1000000000,
+        resources: ["main.macos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
@@ -348,6 +387,8 @@ const PROJECT_FILES = {
         "/visionos/ReactTestAppUITests/Info.plist",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/macos/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",
@@ -376,8 +417,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/@callstack/react-native-visionos",
         reactNativeVersion: 1000000000,
+        resources: ["main.visionos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
@@ -408,6 +452,8 @@ const PROJECT_FILES = {
         "/visionos/.xcode.env",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/visionos/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",
@@ -432,8 +478,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native",
         reactNativeVersion: 1000000000,
+        resources: ["main.ios.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
@@ -463,6 +512,8 @@ const PROJECT_FILES = {
         "/visionos/ReactTestAppUITests/Info.plist",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/ios/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",
@@ -485,8 +536,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native-macos",
         reactNativeVersion: 1000000000,
+        resources: ["main.macos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
@@ -517,6 +571,8 @@ const PROJECT_FILES = {
         "/visionos/ReactTestAppUITests/Info.plist",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/macos/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",
@@ -539,8 +595,11 @@ const PROJECT_FILES = {
           PRODUCT_VERSION: "1.0",
           USER_HEADER_SEARCH_PATHS: ["/~/node_modules/.generated"],
         },
+        communityAutolinkingScriptPath: undefined,
+        reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/@callstack/react-native-visionos",
         reactNativeVersion: 1000000000,
+        resources: ["main.visionos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
@@ -571,6 +630,8 @@ const PROJECT_FILES = {
         "/visionos/.xcode.env",
         "/package.json",
         "/node_modules/@callstack/react-native-visionos/package.json",
+        "/node_modules/@react-native-community/cli-platform-ios/native_modules.rb",
+        "/node_modules/@rnx-kit/react-native-host/package.json",
         "/node_modules/react-native/package.json",
         "/node_modules/react-native-macos/package.json",
         "/node_modules/.generated/visionos/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme",

--- a/test/ios/xcode.test.ts
+++ b/test/ios/xcode.test.ts
@@ -42,6 +42,7 @@ function makeProjectConfiguration(): ProjectConfiguration {
     xcodeprojPath: "",
     reactNativePath: "",
     reactNativeVersion: 0,
+    reactNativeHostPath: "",
     useNewArch: false,
     useBridgeless: false,
     buildSettings: {},


### PR DESCRIPTION
### Description

Move host and autolinking resolution to JS

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.74
yarn clean
yarn
cd example
rm ios/Podfile.lock
pod install --project-directory=ios
```