### PR TITLE
fix: support more extensions when looking for `react-native.config.*`

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -13,6 +13,9 @@ inputs:
   java-version:
     description: Desired Java version
     default: "17"
+  node-version:
+    description: Desired Node version
+    default: "22"
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
 runs:
@@ -72,7 +75,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4.2.0
       with:
-        node-version: "22"
+        node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache-npm-dependencies }}
     - name: Set up Xcode
       if: ${{ inputs.xcode-developer-dir != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -550,6 +550,7 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: windows
+          node-version: "22.13"
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -606,6 +607,7 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: windows
+          node-version: "22.13"
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -1,6 +1,8 @@
 // @ts-check
 "use strict";
 
+/** @import { ProjectConfig, ProjectParams } from "./types.js"; */
+
 /**
  * This script (and its dependencies) currently cannot be converted to ESM
  * because it is consumed in `react-native.config.js`.
@@ -19,7 +21,54 @@ const {
   v,
 } = require("./helpers");
 
-/** @import { ProjectConfig, ProjectParams } from "./types.js"; */
+/**
+ * Finds `react-native.config.[ts,mjs,cjs,js]`.
+ *
+ * @note A naive search on disk might yield false positives so we also try to
+ * use the stack trace to find it. This currently works in Node (V8) and Bun
+ * (JSC).
+ *
+ * @returns {string}
+ */
+function findReactNativeConfig(fs = nodefs) {
+  // stack[0] holds this file
+  // stack[1] holds where this function was called
+  // stack[2] holds the file we're interested in
+  const position = 2;
+  if (position < Error.stackTraceLimit) {
+    const orig_prepareStackTrace = Error.prepareStackTrace;
+    let stack;
+    try {
+      Error.prepareStackTrace = (_, stack) => stack;
+      stack = new Error().stack;
+    } finally {
+      Error.prepareStackTrace = orig_prepareStackTrace;
+    }
+
+    if (Array.isArray(stack)) {
+      const file = stack[position]?.getFileName();
+      if (file) {
+        return file;
+      }
+    }
+  }
+
+  const configFiles = [
+    "react-native.config.ts",
+    "react-native.config.mjs",
+    "react-native.config.cjs",
+    "react-native.config.js",
+  ];
+
+  for (const file of configFiles) {
+    const reactNativeConfig = findNearest(file, undefined, fs);
+    if (reactNativeConfig) {
+      return reactNativeConfig;
+    }
+  }
+
+  throw new Error("Failed to find `react-native.config.[ts,mjs,cjs,js]`");
+}
 
 /**
  * Returns the version number of a React Native dependency.
@@ -94,14 +143,7 @@ function windowsProjectPath(solutionFile, fs = nodefs) {
  * @returns {Partial<ProjectParams>}
  */
 function configureProjects({ android, ios, windows }, fs = nodefs) {
-  const reactNativeConfig = findNearest(
-    "react-native.config.js",
-    undefined,
-    fs
-  );
-  if (!reactNativeConfig) {
-    throw new Error("Failed to find `react-native.config.js`");
-  }
+  const reactNativeConfig = findReactNativeConfig(fs);
 
   /** @type {Partial<ProjectParams>} */
   const config = {};

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -26,7 +26,16 @@ const {
  *
  * @note A naive search on disk might yield false positives so we also try to
  * use the stack trace to find it. This currently works in Node (V8) and Bun
- * (JSC).
+ * (JSC), but not on Windows for some reason. On Windows, this causes 'xpath' to
+ * crash:
+ *
+ *     [xmldom error]	invalid doc source
+ *     #[line:0,col:undefined]
+ *
+ *     D:\~\node_modules\xpath\xpath.js:1787
+ *         if (firstNode.nodeType === 9) {
+ *                       ^
+ *     TypeError: Cannot read properties of undefined (reading 'nodeType')
  *
  * @returns {string}
  */
@@ -35,7 +44,7 @@ function findReactNativeConfig(fs = nodefs) {
   // stack[1] holds where this function was called
   // stack[2] holds the file we're interested in
   const position = 2;
-  if (position < Error.stackTraceLimit) {
+  if (position < Error.stackTraceLimit && process.platform !== "win32") {
     const orig_prepareStackTrace = Error.prepareStackTrace;
     let stack;
     try {
@@ -46,9 +55,12 @@ function findReactNativeConfig(fs = nodefs) {
     }
 
     if (Array.isArray(stack)) {
-      const file = stack[position]?.getFileName();
-      if (path.basename(file).startsWith("react-native.config.")) {
-        return file;
+      const callsite = stack[position];
+      if (callsite && typeof callsite === "object" && "getFileName" in callsite) {
+        const file = callsite.getFileName();
+        if (path.basename(file).startsWith("react-native.config.")) {
+          return file;
+        }
       }
     }
   }

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -26,25 +26,16 @@ const {
  *
  * @note A naive search on disk might yield false positives so we also try to
  * use the stack trace to find it. This currently works in Node (V8) and Bun
- * (JSC), but not on Windows for some reason. On Windows, this causes 'xpath' to
- * crash:
+ * (JSC).
  *
- *     [xmldom error]	invalid doc source
- *     #[line:0,col:undefined]
- *
- *     D:\~\node_modules\xpath\xpath.js:1787
- *         if (firstNode.nodeType === 9) {
- *                       ^
- *     TypeError: Cannot read properties of undefined (reading 'nodeType')
- *
- * @returns {string}
+ * @returns {string} Path to `react-native.config.[ts,mjs,cjs,js]`
  */
 function findReactNativeConfig(fs = nodefs) {
   // stack[0] holds this file
   // stack[1] holds where this function was called
   // stack[2] holds the file we're interested in
   const position = 2;
-  if (position < Error.stackTraceLimit && process.platform !== "win32") {
+  if (position < Error.stackTraceLimit) {
     const orig_prepareStackTrace = Error.prepareStackTrace;
     let stack;
     try {
@@ -56,7 +47,11 @@ function findReactNativeConfig(fs = nodefs) {
 
     if (Array.isArray(stack)) {
       const callsite = stack[position];
-      if (callsite && typeof callsite === "object" && "getFileName" in callsite) {
+      if (
+        callsite &&
+        typeof callsite === "object" &&
+        "getFileName" in callsite
+      ) {
         const file = callsite.getFileName();
         if (path.basename(file).startsWith("react-native.config.")) {
           return file;

--- a/scripts/configure-projects.js
+++ b/scripts/configure-projects.js
@@ -47,7 +47,7 @@ function findReactNativeConfig(fs = nodefs) {
 
     if (Array.isArray(stack)) {
       const file = stack[position]?.getFileName();
-      if (file) {
+      if (path.basename(file).startsWith("react-native.config.")) {
         return file;
       }
     }
@@ -196,5 +196,6 @@ function configureProjects({ android, ios, windows }, fs = nodefs) {
 
 exports.configureProjects = configureProjects;
 exports.internalForTestingPurposesOnly = {
+  findReactNativeConfig,
   getAndroidPackageName,
 };

--- a/test/configure-projects.test.ts
+++ b/test/configure-projects.test.ts
@@ -105,7 +105,7 @@ describe("findReactNativeConfig()", () => {
         ...nodefs,
         existsSync: (p) => typeof p === "string" && p.endsWith(configFile),
       });
-      ok(result);
+      ok(result.endsWith(configFile));
     });
   }
 });

--- a/test/configure-projects.test.ts
+++ b/test/configure-projects.test.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal, fail } from "node:assert/strict";
+import { deepEqual, equal, fail, ok, throws } from "node:assert/strict";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "node:test";
@@ -80,6 +80,34 @@ describe("configureProjects()", () => {
       },
     });
   });
+});
+
+describe("findReactNativeConfig()", () => {
+  const { findReactNativeConfig } = internalForTestingPurposesOnly;
+
+  const configFiles = [
+    "react-native.config.ts",
+    "react-native.config.mjs",
+    "react-native.config.cjs",
+    "react-native.config.js",
+  ];
+
+  it("throws if no config file is found", () => {
+    throws(
+      () => findReactNativeConfig({ ...nodefs, existsSync: () => false }),
+      new Error("Failed to find `react-native.config.[ts,mjs,cjs,js]`")
+    );
+  });
+
+  for (const configFile of configFiles) {
+    it(`finds '${configFile}'`, () => {
+      const result = findReactNativeConfig({
+        ...nodefs,
+        existsSync: (p) => typeof p === "string" && p.endsWith(configFile),
+      });
+      ok(result);
+    });
+  }
 });
 
 describe("getAndroidPackageName()", () => {


### PR DESCRIPTION
### Description

Support more extensions when looking for `react-native.config.*`

See also #2429

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a