### PR TITLE
refactor(apple): evaluate Hermes from JS

### DIFF
--- a/ios/app.mjs
+++ b/ios/app.mjs
@@ -13,7 +13,11 @@ import {
 import { cp_r, mkdir_p, rm_r } from "../scripts/utils/filesystem.mjs";
 import { generateAssetsCatalogs } from "./assetsCatalog.mjs";
 import { generateEntitlements } from "./entitlements.mjs";
-import { isBridgelessEnabled, isNewArchEnabled } from "./features.mjs";
+import {
+  isBridgelessEnabled,
+  isHermesEnabled,
+  isNewArchEnabled,
+} from "./features.mjs";
 import { generateInfoPlist } from "./infoPlist.mjs";
 import { generateLocalizations, getProductName } from "./localizations.mjs";
 import { generatePrivacyManifest } from "./privacyManifest.mjs";
@@ -220,8 +224,6 @@ export function generateProject(
     fs
   );
   const reactNativeVersion = readPackageVersion(reactNativePath, fs);
-  const useNewArch = isNewArchEnabled(options, reactNativeVersion);
-  const useBridgeless = isBridgelessEnabled(options, reactNativeVersion);
 
   /** @type {ProjectConfiguration} */
   const project = {
@@ -234,8 +236,9 @@ export function generateProject(
       reactNativeVersion,
       fs
     ),
-    useNewArch,
-    useBridgeless,
+    useHermes: isHermesEnabled(targetPlatform, reactNativeVersion, options),
+    useNewArch: isNewArchEnabled(reactNativeVersion, options),
+    useBridgeless: isBridgelessEnabled(reactNativeVersion, options),
     buildSettings: {},
     testsBuildSettings: {},
     uitestsBuildSettings: {},

--- a/ios/features.mjs
+++ b/ios/features.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-/** @import { JSONObject } from "../scripts/types.ts"; */
+/** @import { ApplePlatform, JSONObject } from "../scripts/types.ts"; */
 import { v } from "../scripts/helpers.js";
 
 /**
@@ -10,18 +10,18 @@ function supportsNewArch(reactNativeVersion) {
 }
 
 /**
- * @param {JSONObject} options
  * @param {number} reactNativeVersion
+ * @param {JSONObject} options
  * @returns {boolean}
  */
-export function isNewArchEnabled(options, reactNativeVersion) {
+export function isNewArchEnabled(reactNativeVersion, options) {
   if (!supportsNewArch(reactNativeVersion)) {
     return false;
   }
 
-  const envVar = process.env["RCT_NEW_ARCH_ENABLED"];
-  if (typeof envVar === "string") {
-    return envVar !== "0";
+  const newArchEnabled = process.env["RCT_NEW_ARCH_ENABLED"];
+  if (typeof newArchEnabled === "string") {
+    return newArchEnabled !== "0";
   }
 
   if ("newArchEnabled" in options) {
@@ -37,12 +37,12 @@ export function isNewArchEnabled(options, reactNativeVersion) {
 }
 
 /**
- * @param {JSONObject} options
  * @param {number} reactNativeVersion
+ * @param {JSONObject} options
  * @returns {boolean}
  */
-export function isBridgelessEnabled(options, reactNativeVersion) {
-  if (isNewArchEnabled(options, reactNativeVersion)) {
+export function isBridgelessEnabled(reactNativeVersion, options) {
+  if (isNewArchEnabled(reactNativeVersion, options)) {
     if (reactNativeVersion >= v(0, 74, 0)) {
       return options["bridgelessEnabled"] !== false;
     }
@@ -51,4 +51,25 @@ export function isBridgelessEnabled(options, reactNativeVersion) {
     }
   }
   return false;
+}
+
+/**
+ * @param {ApplePlatform} platform
+ * @param {number} reactNativeVersion
+ * @param {JSONObject} options
+ * @returns {boolean | "from-source"}
+ */
+export function isHermesEnabled(platform, reactNativeVersion, options) {
+  const useHermes = process.env["USE_HERMES"];
+  const enabled =
+    typeof useHermes === "string"
+      ? useHermes === "1"
+      : options["hermesEnabled"] === true;
+
+  // Hermes prebuilds for visionOS was introduced in 0.76
+  if (enabled && platform === "visionos" && reactNativeVersion < v(0, 76, 0)) {
+    return "from-source";
+  }
+
+  return enabled;
 }

--- a/ios/pod_helpers.rb
+++ b/ios/pod_helpers.rb
@@ -28,14 +28,9 @@ def find_file(file_name, current_dir)
 end
 
 def use_hermes?(options)
-  use_hermes = ENV.fetch('USE_HERMES', nil)
-  return use_hermes == '1' unless use_hermes.nil?
-
-  # Hermes prebuilds for visionOS was introduced in 0.76
-  is_visionos = options[:path].end_with?('react-native-visionos')
-  ENV['RCT_BUILD_HERMES_FROM_SOURCE'] = 'true' if is_visionos && options[:version] < v(0, 76, 0)
-
-  options[:hermes_enabled] == true
+  use_hermes = options[:use_hermes]
+  ENV['RCT_BUILD_HERMES_FROM_SOURCE'] = 'true' if use_hermes == 'from-source'
+  use_hermes != false
 end
 
 def use_new_architecture!(options, react_native_version)

--- a/ios/test_app.rb
+++ b/ios/test_app.rb
@@ -111,6 +111,7 @@ def use_react_native!(project_root, project, options)
                         app_path: find_file('package.json', project_root).parent.to_s,
                         path: react_native_path.relative_path_from(project_root).to_s,
                         rta_project_root: project_root,
+                        use_hermes: project[:use_hermes],
                         use_new_arch: project[:use_new_arch],
                         use_bridgeless: project[:use_bridgeless],
                         version: project[:react_native_version])
@@ -168,6 +169,7 @@ def make_project!(project_root, target_platform, options)
     :react_native_version => project['reactNativeVersion'],
     :react_native_host_path => project['reactNativeHostPath'],
     :community_autolinking_script_path => project['communityAutolinkingScriptPath'],
+    :use_hermes => project['useHermes'],
     :use_new_arch => project['useNewArch'],
     :use_bridgeless => project['useBridgeless'],
     :code_sign_identity => build_settings[CODE_SIGN_IDENTITY] || '',

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -139,6 +139,7 @@ export type ProjectConfiguration = {
   reactNativeHostPath: string;
   communityAutolinkingScriptPath?: string;
   singleApp?: string;
+  useHermes: boolean | "from-source";
   useNewArch: boolean;
   useBridgeless: boolean;
   buildSettings: Record<string, string | string[]>;

--- a/test/ios/app.test.ts
+++ b/test/ios/app.test.ts
@@ -268,6 +268,7 @@ const PROJECT_FILES = {
     testsBuildSettings: {},
     uitestsBuildSettings: {},
     useBridgeless: true,
+    useHermes: false,
     useNewArch: true,
     xcodeprojPath: "/~/node_modules/.generated/ios/ReactTestApp.xcodeproj",
   },
@@ -296,6 +297,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
+        useHermes: false,
         useNewArch: true,
         xcodeprojPath: "/~/node_modules/.generated/ios/ReactTestApp.xcodeproj",
       },
@@ -360,6 +362,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
+        useHermes: false,
         useNewArch: true,
         xcodeprojPath:
           "/~/node_modules/.generated/macos/ReactTestApp.xcodeproj",
@@ -425,6 +428,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: true,
+        useHermes: false,
         useNewArch: true,
         xcodeprojPath:
           "/~/node_modules/.generated/visionos/ReactTestApp.xcodeproj",
@@ -486,6 +490,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
+        useHermes: false,
         useNewArch: false,
         xcodeprojPath: "/~/node_modules/.generated/ios/ReactTestApp.xcodeproj",
       },
@@ -544,6 +549,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
+        useHermes: false,
         useNewArch: false,
         xcodeprojPath:
           "/~/node_modules/.generated/macos/ReactTestApp.xcodeproj",
@@ -603,6 +609,7 @@ const PROJECT_FILES = {
         testsBuildSettings: {},
         uitestsBuildSettings: {},
         useBridgeless: false,
+        useHermes: false,
         useNewArch: false,
         xcodeprojPath:
           "/~/node_modules/.generated/visionos/ReactTestApp.xcodeproj",

--- a/test/ios/xcode.test.ts
+++ b/test/ios/xcode.test.ts
@@ -43,6 +43,7 @@ function makeProjectConfiguration(): ProjectConfiguration {
     reactNativePath: "",
     reactNativeVersion: 0,
     reactNativeHostPath: "",
+    useHermes: false,
     useNewArch: false,
     useBridgeless: false,
     buildSettings: {},

--- a/test/test_pod_helpers.rb
+++ b/test/test_pod_helpers.rb
@@ -18,48 +18,12 @@ class TestPodHelpers < Minitest::Test
   end
 
   def test_use_hermes?
-    options = { path: '../node_modules/react-native' }
-
-    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
-    ENV.delete('USE_HERMES')
-
-    refute(use_hermes?(options))
-    assert(use_hermes?({ **options, hermes_enabled: true }))
+    refute(use_hermes?({ use_hermes: false }))
+    assert(use_hermes?({ use_hermes: true }))
     refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
 
-    ENV['USE_HERMES'] = '0'
-
-    refute(use_hermes?(options))
-    refute(use_hermes?({ **options, hermes_enabled: true }))
-    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
-
-    ENV['USE_HERMES'] = '1'
-
-    assert(use_hermes?(options))
-    assert(use_hermes?({ **options, hermes_enabled: true }))
-    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
-
-    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
-    ENV.delete('USE_HERMES')
-  end
-
-  def test_use_hermes_visionos?
-    options = {
-      path: '../node_modules/@callstack/react-native-visionos',
-      hermes_enabled: true,
-    }
-
-    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
-    ENV.delete('USE_HERMES')
-
-    assert(use_hermes?({ **options, version: v(0, 76, 0) }))
-    refute(ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE', nil))
-
-    assert(use_hermes?({ **options, version: v(0, 75, 0) }))
+    assert(use_hermes?({ use_hermes: 'from-source' }))
     assert_equal('true', ENV.fetch('RCT_BUILD_HERMES_FROM_SOURCE'))
-
-    ENV.delete('RCT_BUILD_HERMES_FROM_SOURCE')
-    ENV.delete('USE_HERMES')
   end
 
   def test_v


### PR DESCRIPTION
### Description

Evaluate Hermes from JS

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
npm run test:matrix -- --ios
```

### Screenshots

| JSC  | Hermes | Fabric | Fabric + Hermes |
| :--: | :----: | :----: | :-------------: |
| ![Screenshot-iOS](https://github.com/user-attachments/assets/e4eec4eb-2c47-430a-8582-1c1f83c67fce) | ![Screenshot-iOS-hermes](https://github.com/user-attachments/assets/6a95930f-14d4-4770-a6ec-0e4dc3fdfa27) | ![Screenshot-iOS-fabric-concurrent](https://github.com/user-attachments/assets/3db1fad3-fd07-4787-8555-1c3c093a53f7) | ![Screenshot-iOS-hermes-fabric-concurrent](https://github.com/user-attachments/assets/9d29bc12-bdc5-459e-bc75-3920d9487d7b) |