### PR TITLE
fix: declare support for 0.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@callstack/react-native-visionos": "0.73 - 0.78",
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.0",
-    "react-native": "0.70 - 0.78 || >=0.79.0-0 <0.79.0",
+    "react-native": "0.70 - 0.79 || >=0.80.0-0 <0.80.0",
     "react-native-macos": "^0.0.0-0 || 0.71 - 0.77",
     "react-native-windows": "^0.0.0-0 || 0.70 - 0.77"
   },

--- a/scripts/internal/set-react-version.mts
+++ b/scripts/internal/set-react-version.mts
@@ -238,7 +238,8 @@ async function resolveCommonDependencies(
     "@react-native/babel-preset": rnBabelPresetVersion,
     "@react-native/metro-config": rnMetroConfigVersion,
     "metro-react-native-babel-preset": metroBabelPresetVersion,
-    react: peerDependencies["react"],
+    // Replace range to avoid React version mismatch
+    react: peerDependencies["react"].replace(/^\^/, "~"),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12525,7 +12525,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.73 - 0.78
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.0
-    react-native: 0.70 - 0.78 || >=0.79.0-0 <0.79.0
+    react-native: 0.70 - 0.79 || >=0.80.0-0 <0.80.0
     react-native-macos: ^0.0.0-0 || 0.71 - 0.77
     react-native-windows: ^0.0.0-0 || 0.70 - 0.77
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for 0.79.

Resolves #2383.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

| Configuration | JSC  | Hermes | Fabric | Fabric + Hermes |
| :------------ | :--: | :----: | :----: | :-------------: |
| Android       | n/a  | ![Screenshot-Android-hermes](https://github.com/user-attachments/assets/708eb190-d196-48fd-830c-16710d96be26) |  n/a   | ![Screenshot-Android-hermes-fabric-concurrent](https://github.com/user-attachments/assets/8cb526e1-b76d-4799-b71b-6ae5eb0967a4) |
| iOS           | ![Screenshot-iOS](https://github.com/user-attachments/assets/1c570d19-c662-4097-8516-78002287499c) | ![Screenshot-iOS-hermes](https://github.com/user-attachments/assets/f96cb0e3-9d8b-4a63-9906-c36815ff3f66) | ![Screenshot-iOS-fabric-concurrent](https://github.com/user-attachments/assets/3e3cf8d5-e572-4012-b419-105e8be3b232) | ![Screenshot-iOS-hermes-fabric-concurrent](https://github.com/user-attachments/assets/7152491a-a2b1-4fd9-884a-a5309c24bb89) |
| visionOS      | TODO |  TODO  |  TODO  |      TODO       |