### PR TITLE
fix: declare support for `react-native-macos`/`-windows` 0.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.0",
     "react-native": "0.70 - 0.79 || >=0.80.0-0 <0.80.0",
-    "react-native-macos": "^0.0.0-0 || 0.71 - 0.77",
-    "react-native-windows": "^0.0.0-0 || 0.70 - 0.77"
+    "react-native-macos": "^0.0.0-0 || 0.71 - 0.78",
+    "react-native-windows": "^0.0.0-0 || 0.70 - 0.78"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12526,8 +12526,8 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.0
     react-native: 0.70 - 0.79 || >=0.80.0-0 <0.80.0
-    react-native-macos: ^0.0.0-0 || 0.71 - 0.77
-    react-native-windows: ^0.0.0-0 || 0.70 - 0.77
+    react-native-macos: ^0.0.0-0 || 0.71 - 0.78
+    react-native-windows: ^0.0.0-0 || 0.70 - 0.78
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true


### PR DESCRIPTION
### Description

Declare support for `react-native-macos`/`-windows` 0.78

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [x] Windows

### Test plan

| macOS | Windows |
| :-: | :-: |
| <img width="592" alt="Screenshot 2025-04-03 at 11 01 33" src="https://github.com/user-attachments/assets/3880b493-12d5-4bbb-a550-5ad88a89a30b" /> | <img width="1208" alt="image" src="https://github.com/user-attachments/assets/f5ed3591-5019-45f3-a632-e25cd3869b78" /> |