### PR TITLE
fix(apple): fix `ENOBUFS` when reading/writing plists

### DIFF
--- a/ios/app.mjs
+++ b/ios/app.mjs
@@ -295,7 +295,7 @@ export function makeProject(projectRoot, targetPlatform, options, fs = nodefs) {
     ReactTestAppUITests: project.uitestsBuildSettings,
   };
 
-  const pbxproj = openXcodeProject(project.xcodeprojPath, fs);
+  const pbxproj = openXcodeProject(project.xcodeprojPath);
   for (const target of pbxproj.targets) {
     const { name: targetName } = target;
     if (typeof targetName !== "string" || !(targetName in mods)) {
@@ -303,8 +303,7 @@ export function makeProject(projectRoot, targetPlatform, options, fs = nodefs) {
     }
 
     const targetBuildSettings = Object.entries(mods[targetName]);
-    for (const config of target.buildConfigurations) {
-      const { buildSettings } = config;
+    for (const { buildSettings } of target.buildConfigurations) {
       assertObject(buildSettings, "target.buildConfigurations[].buildSettings");
 
       for (const [setting, value] of targetBuildSettings) {

--- a/ios/xcode.mjs
+++ b/ios/xcode.mjs
@@ -10,7 +10,7 @@ import {
   isObject,
   isString,
   jsonFromPlist,
-  plistFromJSON,
+  writePlistFromJSON,
 } from "./utils.mjs";
 
 /**
@@ -227,7 +227,7 @@ export function configureBuildSchemes(
 /**
  * @param {string} xcodeproj
  */
-export function openXcodeProject(xcodeproj, fs = nodefs) {
+export function openXcodeProject(xcodeproj) {
   const projectPath = path.join(xcodeproj, "project.pbxproj");
   const pbxproj = jsonFromPlist(projectPath);
   assertObject(pbxproj.objects, "pbxproj.objects");
@@ -242,7 +242,7 @@ export function openXcodeProject(xcodeproj, fs = nodefs) {
 
   return {
     save() {
-      fs.writeFileSync(projectPath, plistFromJSON(pbxproj, projectPath));
+      writePlistFromJSON(projectPath, pbxproj);
     },
     get targets() {
       return targets.map((target, index) => {


### PR DESCRIPTION
### Description

`spawnSync` may run out of buffer when reading/writing big plists

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a