### PR TITLE
fix: allow React 19.1 to be used with upcoming 0.80

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "peerDependencies": {
     "@callstack/react-native-visionos": "0.73 - 0.78",
     "@expo/config-plugins": ">=5.0",
-    "react": "18.1 - 19.0",
+    "react": "18.1 - 19.1",
     "react-native": "0.70 - 0.79 || >=0.80.0-0 <0.80.0",
     "react-native-macos": "^0.0.0-0 || 0.71 - 0.78",
     "react-native-windows": "^0.0.0-0 || 0.70 - 0.78"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12217,7 +12217,7 @@ __metadata:
   peerDependencies:
     "@callstack/react-native-visionos": 0.73 - 0.78
     "@expo/config-plugins": ">=5.0"
-    react: 18.1 - 19.0
+    react: 18.1 - 19.1
     react-native: 0.70 - 0.79 || >=0.80.0-0 <0.80.0
     react-native-macos: ^0.0.0-0 || 0.71 - 0.78
     react-native-windows: ^0.0.0-0 || 0.70 - 0.78


### PR DESCRIPTION
### Description

See https://github.com/facebook/react-native/commit/0e11e6a28bf3a12e30b5c6a7e93f3a5653888375

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a