### PR TITLE
fix: include `Gemfile` when generating new projects

### DIFF
--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 // @ts-check
+/**
+ * @import {
+ *   Configuration,
+ *   ConfigureParams,
+ *   FileCopy,
+ *   Manifest,
+ *   Platform,
+ *   PlatformConfiguration,
+ *   PlatformPackage,
+ * } from "./types.js";
+ */
 import * as nodefs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
@@ -28,16 +39,6 @@ import { downloadPackage } from "./utils/npm.mjs";
 import { parseArgs } from "./utils/parseargs.mjs";
 
 /**
- * @typedef {import("./types.js").Configuration} Configuration
- * @typedef {import("./types.js").ConfigureParams} ConfigureParams
- * @typedef {import("./types.js").FileCopy} FileCopy
- * @typedef {Required<import("./types.js").Manifest>} Manifest
- * @typedef {import("./types.js").PlatformConfiguration} PlatformConfiguration
- * @typedef {import("./types.js").PlatformPackage} PlatformPackage
- * @typedef {import("./types.js").Platform} Platform
- */
-
-/**
  * @param {...string} paths
  * @returns {{ source: string; }}
  */
@@ -57,7 +58,7 @@ function mergeObjects(lhs, rhs) {
     : sortByKeys(rhs);
 }
 
-/** @type {() => Manifest} */
+/** @type {() => Required<Manifest>} */
 const readManifest = memo(() =>
   readJSONFile(new URL("../package.json", import.meta.url))
 );

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -304,6 +304,9 @@ export const getConfig = (() => {
                     : {
                         "App.js": { source: path.join(templateDir, "App.js") },
                       }),
+                  Gemfile: {
+                    source: path.join(templateDir, "Gemfile"),
+                  },
                   "app.json": appManifest(name),
                   "index.js": {
                     source: path.join(templateDir, "index.js"),

--- a/scripts/configure.mjs
+++ b/scripts/configure.mjs
@@ -38,6 +38,14 @@ import { parseArgs } from "./utils/parseargs.mjs";
  */
 
 /**
+ * @param {...string} paths
+ * @returns {{ source: string; }}
+ */
+function copyFrom(...paths) {
+  return { source: path.join(...paths) };
+}
+
+/**
  * Merges two objects.
  * @param {unknown} lhs
  * @param {Record<string, unknown>} rhs
@@ -274,18 +282,14 @@ export const getConfig = (() => {
       configuration = {
         common: {
           files: {
-            ".gitignore": {
-              source: path.join(testAppPath, "example", gitignore),
-            },
-            ".watchmanconfig": {
-              source: path.join(templateDir, "_watchmanconfig"),
-            },
-            "babel.config.js": {
-              source: path.join(templateDir, "babel.config.js"),
-            },
-            "metro.config.js": {
-              source: path.join(testAppPath, "example", "metro.config.js"),
-            },
+            ".gitignore": copyFrom(testAppPath, "example", gitignore),
+            ".watchmanconfig": copyFrom(templateDir, "_watchmanconfig"),
+            "babel.config.js": copyFrom(templateDir, "babel.config.js"),
+            "metro.config.js": copyFrom(
+              testAppPath,
+              "example",
+              "metro.config.js"
+            ),
             "react-native.config.js": reactNativeConfig(params),
             ...(!init
               ? undefined
@@ -294,23 +298,15 @@ export const getConfig = (() => {
                   // drop support for 0.70
                   ...(fs.existsSync(path.join(templateDir, "App.tsx"))
                     ? {
-                        "App.tsx": {
-                          source: path.join(templateDir, "App.tsx"),
-                        },
-                        "tsconfig.json": {
-                          source: path.join(templateDir, "tsconfig.json"),
-                        },
+                        "App.tsx": copyFrom(templateDir, "App.tsx"),
+                        "tsconfig.json": copyFrom(templateDir, "tsconfig.json"),
                       }
                     : {
-                        "App.js": { source: path.join(templateDir, "App.js") },
+                        "App.js": copyFrom(templateDir, "App.js"),
                       }),
-                  Gemfile: {
-                    source: path.join(templateDir, "Gemfile"),
-                  },
+                  Gemfile: copyFrom(templateDir, "Gemfile"),
                   "app.json": appManifest(name),
-                  "index.js": {
-                    source: path.join(templateDir, "index.js"),
-                  },
+                  "index.js": copyFrom(templateDir, "index.js"),
                   "package.json": readTextFile(
                     path.join(templateDir, "package.json"),
                     fs
@@ -329,16 +325,14 @@ export const getConfig = (() => {
         android: {
           files: {
             "build.gradle": buildGradle(),
-            "gradle/wrapper/gradle-wrapper.jar": {
-              source: path.join(
-                testAppPath,
-                "example",
-                "android",
-                "gradle",
-                "wrapper",
-                "gradle-wrapper.jar"
-              ),
-            },
+            "gradle/wrapper/gradle-wrapper.jar": copyFrom(
+              testAppPath,
+              "example",
+              "android",
+              "gradle",
+              "wrapper",
+              "gradle-wrapper.jar"
+            ),
             "gradle/wrapper/gradle-wrapper.properties": (() => {
               const gradleWrapperProperties = path.join(
                 testAppPath,
@@ -358,17 +352,13 @@ export const getConfig = (() => {
               return props;
             })(),
             "gradle.properties": gradleProperties(targetVersionNum),
-            gradlew: {
-              source: path.join(testAppPath, "example", "android", "gradlew"),
-            },
-            "gradlew.bat": {
-              source: path.join(
-                testAppPath,
-                "example",
-                "android",
-                "gradlew.bat"
-              ),
-            },
+            gradlew: copyFrom(testAppPath, "example", "android", "gradlew"),
+            "gradlew.bat": copyFrom(
+              testAppPath,
+              "example",
+              "android",
+              "gradlew.bat"
+            ),
             "settings.gradle": settingsGradle(name),
           },
           oldFiles: [],
@@ -432,9 +422,12 @@ export const getConfig = (() => {
         },
         windows: {
           files: {
-            ".gitignore": {
-              source: path.join(testAppPath, "example", "windows", gitignore),
-            },
+            ".gitignore": copyFrom(
+              testAppPath,
+              "example",
+              "windows",
+              gitignore
+            ),
           },
           oldFiles: [
             `${name}.sln`,

--- a/test/configure/getConfig.test.ts
+++ b/test/configure/getConfig.test.ts
@@ -48,6 +48,7 @@ describe("getConfig()", () => {
       ".gitignore",
       ".watchmanconfig",
       "App.tsx",
+      "Gemfile",
       "app.json",
       "babel.config.js",
       "index.js",


### PR DESCRIPTION
### Description

Include `Gemfile` when generating new projects

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a