### PR TITLE
ci(android): remove deprecated `gradle-home-cache-cleanup` option

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -61,7 +61,6 @@ runs:
         gradle-home-cache-excludes: |
           caches
           jdks
-        gradle-home-cache-cleanup: true
     - name: Set up MSBuild
       if: ${{ inputs.platform == 'windows' }}
       uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
### Description

Addresses the deprecation warning in the `gradle/actions/setup-gradle` action.

> Warning: This job uses deprecated functionality from the 'gradle/actions/setup-gradle' action. Consult the Job Summary for more details.
DEPRECATION: The `gradle-home-cache-cleanup` input parameter has been replaced by `cache-cleanup`. See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a