### PR TITLE
chore: `swiftlint` should not lint `node_modules`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,3 +5,4 @@ disabled_rules:
 excluded:
   - example/*/Pods/
   - example/node_modules/
+  - node_modules/


### PR DESCRIPTION
### Description

`swiftlint` should not lint `node_modules`:

```
% yarn lint:swift
Linting Swift files in current working directory
[...]
/~/node_modules/@react-native-community/template/template/ios/HelloWorld/AppDelegate.swift:8:135: warning: Colon Spacing Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals (colon)
/~/node_modules/@react-native-community/template/template/ios/HelloWorld/AppDelegate.swift:8:1: warning: Line Length Violation: Line should be 120 characters or less; currently it has 159 characters (line_length)
[...]
Done linting! Found 2 violations, 0 serious in 16 files.
```

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a