### PR TITLE
fix(apple): fix notification naming inconsistency

### DIFF
--- a/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -7,7 +7,7 @@ OBJC_EXTERN NSNotificationName const ReactAppDidFinishLaunchingNotification;
 OBJC_EXTERN NSNotificationName const ReactAppWillInitializeReactNativeNotification;
 OBJC_EXTERN NSNotificationName const ReactAppDidInitializeReactNativeNotification;
 
-OBJC_EXTERN NSNotificationName const ReactAppRuntimeReady;
+OBJC_EXTERN NSNotificationName const ReactAppRuntimeReadyNotification;
 OBJC_EXTERN NSNotificationName const ReactAppDidRegisterAppsNotification;
 
 OBJC_EXTERN NSNotificationName const ReactAppSceneDidOpenURLNotification;

--- a/ios/ReactTestApp/ReactTestApp-DevSupport.m
+++ b/ios/ReactTestApp/ReactTestApp-DevSupport.m
@@ -8,7 +8,7 @@ NSNotificationName const ReactAppWillInitializeReactNativeNotification =
 NSNotificationName const ReactAppDidInitializeReactNativeNotification =
     @"ReactAppDidInitializeReactNativeNotification";
 
-NSNotificationName const ReactAppRuntimeReady = @"ReactAppRuntimeReady";
+NSNotificationName const ReactAppRuntimeReadyNotification = @"ReactAppRuntimeReadyNotification";
 NSNotificationName const ReactAppDidRegisterAppsNotification =
     @"ReactAppDidRegisterAppsNotification";
 


### PR DESCRIPTION
### Description

Fix notification naming inconsistency

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a