### PR TITLE
chore: fix non-fatal `fatal error: module 'RCTDeprecation' in AST file`

### DIFF
--- a/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
+++ b/ios/ReactTestApp/ReactTestApp-Bridging-Header.h
@@ -12,6 +12,9 @@
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
 #import <React/RCTVersion.h>
+#if __has_include(<RCTDeprecation/RCTDeprecation.h>)
+#import <RCTDeprecation/RCTDeprecation.h>
+#endif  // __has_include(<RCTDeprecation/RCTDeprecation.h>)
 #pragma clang diagnostic pop
 
 #import "React+Compatibility.h"


### PR DESCRIPTION
### Description

Attempt to fix the non-fatal `fatal error: module 'RCTDeprecation' in AST file` error

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

This only shows up when building from CLI but still succeeds. In Xcode, it doesn't show up at all.