### PR TITLE
ci(macos): re-enable smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
         with:
           project-directory: macos
           working-directory: example
-      - name: Build x86
+      - name: Build
         if: ${{ steps.affected.outputs.macos != '' }}
         run: |
           ../scripts/build/xcodebuild.sh macos/Example.xcworkspace build-for-testing
@@ -384,26 +384,9 @@ jobs:
           node --test test/config.test.mjs
         working-directory: example
       - name: Test
-        # Temporarily disabled due to random failures
-        if: false # ${{ steps.affected.outputs.macos != '' && github.event_name != 'schedule' }}
+        if: ${{ steps.affected.outputs.macos != '' && github.event_name != 'schedule' }}
         run: |
           ../scripts/build/xcodebuild.sh macos/Example.xcworkspace test-without-building
-        working-directory: example
-      - name: Prepare for arm64 build
-        if: ${{ steps.affected.outputs.macos != '' }}
-        run: |
-          rm -fr macos/build
-        working-directory: example
-      - name: Install Pods
-        if: ${{ steps.affected.outputs.macos != '' }}
-        uses: ./.github/actions/cocoapods
-        with:
-          project-directory: macos
-          working-directory: example
-      - name: Build arm64
-        if: ${{ steps.affected.outputs.macos != '' }}
-        run: |
-          ../scripts/build/xcodebuild.sh macos/Example.xcworkspace build ARCHS=arm64
         working-directory: example
     timeout-minutes: 60
   macos-template:

--- a/example/ios/ExampleTests/DevSupportTests.m
+++ b/example/ios/ExampleTests/DevSupportTests.m
@@ -12,6 +12,8 @@
     XCTAssertNotNil(ReactAppDidFinishLaunchingNotification);
     XCTAssertNotNil(ReactAppWillInitializeReactNativeNotification);
     XCTAssertNotNil(ReactAppDidInitializeReactNativeNotification);
+    XCTAssertNotNil(ReactAppRuntimeReadyNotification);
+    XCTAssertNotNil(ReactAppDidRegisterAppsNotification);
     XCTAssertNotNil(ReactAppSceneDidOpenURLNotification);
 }
 


### PR DESCRIPTION
### Description

Re-enabled macOS smoke test, and removed the x86 build step that hasn't built for x86 ever since we moved to ARM64 runners.

Resolves #2180.

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.