### PR TITLE
test: starting with 0.80, JSC is no longer available

### DIFF
--- a/example/test/specs/app.spec.mjs
+++ b/example/test/specs/app.spec.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { equal } from "node:assert/strict";
+import { equal, match } from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { remote } from "webdriverio";
 import { findNearest, readTextFile } from "../../../scripts/helpers.js";
@@ -103,8 +103,9 @@ describe("App", () => {
     const reactNative = await client.$(byId("react-native-value"));
     equal(await reactNative.getText(), reactNativeVersion);
 
-    const hermes = await client.$(byId("hermes-value"));
-    equal(await hermes.getText(), getCapability("react:hermes"));
+    const jsEngine = await client.$(byId("js-engine-value"));
+    const isHermes = config.capabilities["react:hermes"];
+    match(await jsEngine.getText(), isHermes ? /^Hermes/ : /^JSC$/);
 
     const fabric = await client.$(byId("fabric-value"));
     equal(await fabric.getText(), getCapability("react:fabric"));

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -310,6 +310,7 @@ export type ApplePlatform = "ios" | "macos" | "visionos";
 export type TargetPlatform = ApplePlatform | "android" | "windows";
 
 export type BuildConfig = {
+  version: string;
   platform: TargetPlatform;
   variant: "fabric" | "paper";
   engine?: "hermes" | "jsc";


### PR DESCRIPTION
### Description

Starting with 0.80, JSC is no longer available so we can't test it either.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run test:matrix 0.80 -- --ios
```