### PR TITLE
ci(macos): temporarily disable Hermes builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,6 +423,9 @@ jobs:
       - name: Install Pods
         if: ${{ steps.affected.outputs.macos != '' }}
         run: |
+          # TODO: Disable Hermes while build issues are being resolved
+          # https://github.com/microsoft/react-native-macos/issues/2499
+          sed -i '' 's/:hermes_enabled => true/:hermes_enabled => false/' macos/Podfile
           pod install --project-directory=macos
         working-directory: template-example
       - name: Build


### PR DESCRIPTION
### Description

Upstream: https://github.com/microsoft/react-native-macos/issues/2499

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.