### PR TITLE
ci(windows): use Node 22.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -544,7 +544,6 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: windows
-          node-version: "22.13"
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -602,7 +601,6 @@ jobs:
         uses: ./.github/actions/setup-toolchain
         with:
           platform: windows
-          node-version: "22.13"
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:


### PR DESCRIPTION
### Description

Use Node 22.15. We previously skipped 22.14 because of random build failures (see #2430).

For some reason, we're also seeing the same issues on 22.13 now, despite it working fine before: https://github.com/microsoft/react-native-test-app/actions/runs/15251301878/job/42888692405

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

CI should pass.