### PR TITLE
ci: fix 'empty ident name' when publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -661,6 +661,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
+          git config user.email 'github-actions[bot]'
+          git config user.name 'github-actions[bot]@users.noreply.github.com'
           yarn nx release
   autobot:
     name: "Autobot"


### PR DESCRIPTION
### Description

Publishing fails because Git identity has not been set:

```
NX   Unexpected error when creating tag 4.3.11:


Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az1[34](https://github.com/microsoft/react-native-test-app/actions/runs/15279298976/job/42974898179#step:7:35)4-429.xkidvujvxjlehivufvm5abktke.cx.internal.cloudapp.net>) not allowed

Pass --verbose to see the stacktrace.
```

Build log: https://github.com/microsoft/react-native-test-app/actions/runs/15279298976/job/42974898179

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

This can only be tested on `trunk`