### PR TITLE
ci(apple): bump Xcode to build nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: example
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -218,6 +219,7 @@ jobs:
           platform: ios
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -351,6 +353,7 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: example
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -409,6 +412,7 @@ jobs:
           platform: macos
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,6 +455,7 @@ jobs:
           platform: visionos
           project-root: example
           cache-key-prefix: example
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -508,6 +509,7 @@ jobs:
           platform: visionos
           project-root: example
           cache-key-prefix: template-${{ matrix.template }}
+          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:


### PR DESCRIPTION
### Description

Nightly builds broke: https://github.com/microsoft/react-native-test-app/actions/runs/15458167611/job/43514190855

Because Meta recently [bumped min Xcode version to 16.1](https://github.com/facebook/react-native/commit/c27a8804a6fdaea2d4bef4a4c689bfe2c343daaa) while GHA still [defaults to 16.0](https://github.com/actions/runner-images/blob/macos-15-arm64/20250602.1658/images/macos/macos-15-arm64-Readme.md#xcode).

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

CI should pass.