### PR TITLE
fix(windows): declare support for 0.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react": "18.1 - 19.1",
     "react-native": "0.70 - 0.79 || >=0.80.0-0 <0.80.0",
     "react-native-macos": "^0.0.0-0 || 0.71 - 0.78",
-    "react-native-windows": "^0.0.0-0 || 0.70 - 0.78"
+    "react-native-windows": "^0.0.0-0 || 0.70 - 0.79"
   },
   "peerDependenciesMeta": {
     "@callstack/react-native-visionos": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12155,7 +12155,7 @@ __metadata:
     react: 18.1 - 19.1
     react-native: 0.70 - 0.79 || >=0.80.0-0 <0.80.0
     react-native-macos: ^0.0.0-0 || 0.71 - 0.78
-    react-native-windows: ^0.0.0-0 || 0.70 - 0.78
+    react-native-windows: ^0.0.0-0 || 0.70 - 0.79
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true


### PR DESCRIPTION
### Description

Declare support for `react-native-windows` 0.79

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

```
npm run set-react-version 0.79
yarn
cd example
yarn install-windows-test-app --use-nuget
yarn windows

# In a separate terminal
yarn start
```

### Screenshots

| Old Arch | New Arch |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/f240e46d-3f0f-4a5c-9341-000aeabee140) | ![image](https://github.com/user-attachments/assets/3efcd84e-d14b-47f1-94cf-bd8420b925c8) |
