### PR TITLE
fix: actually publish to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -669,7 +669,7 @@ jobs:
         run: |
           git config user.email 'github-actions[bot]'
           git config user.name 'github-actions[bot]@users.noreply.github.com'
-          yarn nx release
+          yarn nx release --yes
   autobot:
     name: "Autobot"
     permissions:


### PR DESCRIPTION
### Description

Make CI answer 'yes' to the confirmation prompt for publishing.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a