### PR TITLE
ci: explicitly set npm registry url for publishing

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -76,6 +76,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache-npm-dependencies }}
+        registry-url: https://registry.npmjs.org
     - name: Set up Xcode
       if: ${{ inputs.xcode-developer-dir != '' }}
       run: |


### PR DESCRIPTION
### Description

We need to explicitly set the npm registry URL for Nx Release to be able to publish npm packages.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a