### PR TITLE
fix(windows): allow specifying MSBuild properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,7 +564,7 @@ jobs:
           yarn build:windows
       - name: Generate Visual Studio solution
         run: |
-          yarn install-windows-test-app --use-nuget
+          yarn install-windows-test-app --use-nuget --msbuildprops WindowsTargetPlatformVersion=10.0.26100.0
         working-directory: example
       - name: Test `react-native config`
         run: |
@@ -616,7 +616,7 @@ jobs:
           yarn build:windows
       - name: Generate Visual Studio solution
         run: |
-          yarn install-windows-test-app --use-nuget
+          yarn install-windows-test-app --use-nuget --msbuildprops WindowsTargetPlatformVersion=10.0.26100.0
         working-directory: template-example
       - name: Determine whether the Windows app needs to be built
         id: affected

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "init": "scripts/init.mjs",
     "init-test-app": "scripts/init.mjs",
     "configure-test-app": "scripts/configure.mjs",
-    "install-windows-test-app": "windows/test-app.mjs"
+    "install-windows-test-app": "windows/app.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -177,49 +177,8 @@ type InferredOptionTypes<O> = { [key in keyof O]: InferredOptionType<O[key]> };
 
 export type Args<O> = InferredOptionTypes<O> & { _: string[] };
 
-/***********************
- * windows/project.mjs *
- ***********************/
-
-export type AppxBundle = {
-  appName: string;
-  appxManifest: string;
-  assetItems: string;
-  assetItemFilters: string;
-  assetFilters: string;
-  packageCertificate: string;
-  singleApp?: string;
-};
-
-export type MSBuildProjectOptions = {
-  autolink: boolean;
-  useFabric?: boolean;
-  useHermes?: boolean;
-  useNuGet: boolean;
-};
-
-export type MSBuildProjectParams = {
-  projDir: string;
-  projectFileName: string;
-  projectFiles: [string, Record<string, string>?][];
-  solutionTemplatePath: string;
-};
-
-export type ProjectInfo = {
-  version: string;
-  versionNumber: number;
-  bundle: AppxBundle;
-  nugetDependencies: [string, string][];
-  useExperimentalNuGet: boolean;
-  useFabric: boolean;
-};
-
-export type MSBuildProjectConfigurator = (
-  info: ProjectInfo
-) => MSBuildProjectParams;
-
 /************************
- * windows/test-app.mjs *
+ * windows/app.mjs *
  ************************/
 
 type Resources = string[] | { windows?: string[] };
@@ -247,6 +206,48 @@ export type AppManifest = {
     certificateThumbprint?: string;
   };
 };
+
+/***********************
+ * windows/project.mjs *
+ ***********************/
+
+export type AppxBundle = {
+  appName: string;
+  appxManifest: string;
+  assetItems: string;
+  assetItemFilters: string;
+  assetFilters: string;
+  packageCertificate: string;
+  singleApp?: string;
+};
+
+export type MSBuildProjectOptions = {
+  autolink: boolean;
+  msbuildprops?: string;
+  useFabric?: boolean;
+  useHermes?: boolean;
+  useNuGet: boolean;
+};
+
+export type MSBuildProjectParams = {
+  projDir: string;
+  projectFileName: string;
+  projectFiles: [string, Record<string, string>?][];
+  solutionTemplatePath: string;
+};
+
+export type ProjectInfo = {
+  version: string;
+  versionNumber: number;
+  bundle: AppxBundle;
+  nugetDependencies: [string, string][];
+  useExperimentalNuGet: boolean;
+  useFabric: boolean;
+};
+
+export type MSBuildProjectConfigurator = (
+  info: ProjectInfo
+) => MSBuildProjectParams;
 
 /**************
  * schema.mjs *

--- a/test/pack.test.ts
+++ b/test/pack.test.ts
@@ -322,8 +322,8 @@ describe("npm pack", () => {
       "windows/Win32/pch.h",
       "windows/Win32/resource.h",
       "windows/Win32/targetver.h",
+      "windows/app.mjs",
       "windows/project.mjs",
-      "windows/test-app.mjs",
       "windows/uwp.mjs",
       "windows/win32.mjs",
     ]);

--- a/test/windows/copyAndReplace.test.ts
+++ b/test/windows/copyAndReplace.test.ts
@@ -1,7 +1,7 @@
 import { equal, fail, match, rejects } from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { readTextFile as readTextFileActual } from "../../scripts/helpers.js";
-import { copyAndReplace as copyAndReplaceActual } from "../../windows/test-app.mjs";
+import { copyAndReplace as copyAndReplaceActual } from "../../windows/app.mjs";
 import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("copyAndReplace()", () => {

--- a/test/windows/findUserProjects.test.ts
+++ b/test/windows/findUserProjects.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, equal } from "node:assert/strict";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { findUserProjects, toProjectEntry } from "../../windows/test-app.mjs";
+import { findUserProjects, toProjectEntry } from "../../windows/app.mjs";
 
 describe("findUserProjects()", () => {
   it("finds all user projects, ignoring android/ios/macos/node_modules", () => {

--- a/test/windows/generateSolution.test.ts
+++ b/test/windows/generateSolution.test.ts
@@ -1,7 +1,7 @@
 import { equal } from "node:assert/strict";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { generateSolution as generateSolutionActual } from "../../windows/test-app.mjs";
+import { generateSolution as generateSolutionActual } from "../../windows/app.mjs";
 import { fs, setMockFiles } from "../fs.mock.ts";
 
 describe("generateSolution()", () => {

--- a/test/windows/parseMSBuildProperties.test.ts
+++ b/test/windows/parseMSBuildProperties.test.ts
@@ -1,0 +1,28 @@
+import { equal, ok, throws } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseMSBuildProperties } from "../../windows/app.mjs";
+
+describe("parseMSBuildProperties()", () => {
+  it("handles empty string", () => {
+    ok(!parseMSBuildProperties(undefined), "should return undefined");
+    ok(!parseMSBuildProperties(""), "should return undefined");
+  });
+
+  it("parses single property", () => {
+    equal(parseMSBuildProperties("Prop=Value"), "<Prop>Value</Prop>");
+  });
+
+  it("parses multiple properties", () => {
+    equal(
+      parseMSBuildProperties("Prop1=Value1,Prop2=Value2"),
+      "<Prop1>Value1</Prop1>\n<Prop2>Value2</Prop2>"
+    );
+  });
+
+  it("throws on invalid input", () => {
+    throws(() => parseMSBuildProperties("NULL"));
+    throws(() => parseMSBuildProperties("Prop="));
+    throws(() => parseMSBuildProperties("=Value"));
+    throws(() => parseMSBuildProperties("Prop=Value,"));
+  });
+});

--- a/test/windows/replaceContent.test.ts
+++ b/test/windows/replaceContent.test.ts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import { describe, it } from "node:test";
-import { replaceContent } from "../../windows/test-app.mjs";
+import { replaceContent } from "../../windows/app.mjs";
 
 describe("replaceContent()", () => {
   it("returns same string with no replacements", () => {

--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -33,6 +33,8 @@
     -->
     <UseExperimentalNuget>false</UseExperimentalNuget>
 
+    <!-- AdditionalMSBuildProperties -->
+
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 </Project>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,7 +12178,7 @@ __metadata:
     configure-test-app: scripts/configure.mjs
     init: scripts/init.mjs
     init-test-app: scripts/init.mjs
-    install-windows-test-app: windows/test-app.mjs
+    install-windows-test-app: windows/app.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Allow specifying MSBuild properties, similar to `@react-native-windows/cli`.

The motivation for this feature is [GitHub Actions' sudden removal of a Windows SDK version](https://github.com/actions/runner-images/commit/8dd1e0b0a41e491d4dee23db3ef6b3c2c2fff348) required by React Native Windows, without so much as a notice or warning anywhere. This currently causes all Windows builds to fail:

`Command failed with error MSBuildError: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 10.0.22621.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [D:\a\react-native-test-app\react-native-test-app\example\node_modules\.generated\windows\UWP\ReactTestApp.vcxproj]`

(Example build log: https://github.com/microsoft/react-native-test-app/actions/runs/15815022444/job/44572279102)

Adding this feature will allow us to specify the Windows SDK version in our GitHub Actions workflows.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

CI should pass.