### PR TITLE
fix: bump `@rnx-kit/react-native-host` to 0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:rb": "bundle exec ruby -Ilib:test -e \"Dir.glob('./test/test_*.rb').each { |file| require(file) }\""
   },
   "dependencies": {
-    "@rnx-kit/react-native-host": "^0.5.9",
+    "@rnx-kit/react-native-host": "^0.5.10",
     "@rnx-kit/tools-react-native": "^2.1.0",
     "ajv": "^8.0.0",
     "cliui": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,7 +3864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.5.9":
+"@rnx-kit/react-native-host@npm:^0.5.10":
   version: 0.5.10
   resolution: "@rnx-kit/react-native-host@npm:0.5.10"
   peerDependencies:
@@ -12186,7 +12186,7 @@ __metadata:
     "@react-native-community/template": "npm:^0.78.0"
     "@rnx-kit/eslint-plugin": "npm:^0.8.0"
     "@rnx-kit/lint-lockfile": "npm:^0.1.0"
-    "@rnx-kit/react-native-host": "npm:^0.5.9"
+    "@rnx-kit/react-native-host": "npm:^0.5.10"
     "@rnx-kit/tools-react-native": "npm:^2.1.0"
     "@rnx-kit/tsconfig": "npm:^2.0.0"
     "@swc-node/register": "npm:^1.10.0"


### PR DESCRIPTION
### Description

Bumps `@rnx-kit/react-native-host` to 0.5.10

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a