### PR TITLE
fix: old arch is no longer available in 0.82

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_react-native_version.yml
+++ b/.github/ISSUE_TEMPLATE/new_react-native_version.yml
@@ -51,12 +51,8 @@ body:
       label: End-to-end tests
       description: Leave these unchecked. Combinations of configurations that have been tested.
       options:
-        - label: "Android - Fabric: disabled"
-        - label: "Android - Fabric: **enabled**"
-        - label: "iOS - Fabric: disabled / Hermes: disabled"
-        - label: "iOS - Fabric: disabled / Hermes: **enabled**"
-        - label: "iOS - Fabric: **enabled** / Hermes: disabled"
-        - label: "iOS - Fabric: **enabled** / Hermes: **enabled**"
+        - label: "Android"
+        - label: "iOS"
         - label: "macOS"
         - label: "visionOS"
         - label: "Windows - NuGet: disabled"

--- a/android/react-native.gradle
+++ b/android/react-native.gradle
@@ -8,8 +8,16 @@ ext.isBridgelessEnabled = { Project project, boolean isNewArchEnabled ->
     if (isNewArchEnabled) {
         def bridgelessEnabled = project.findProperty("react.bridgelessEnabled")
                                     ?: project.findProperty("bridgelessEnabled")
+
+        def version = getPackageVersionNumber("react-native", project.rootDir)
+        if (version >= v(0, 82, 0)) {
+            if (bridgelessEnabled != null) {
+                logger.warn("WARNING: As of 0.82, bridgeless can no longer be disabled")
+            }
+            return true
+        }
+
         if (bridgelessEnabled != "false") {
-            def version = getPackageVersionNumber("react-native", project.rootDir)
             def isSupported = version == 0 || version >= v(0, 73, 0)
 
             if (bridgelessEnabled == "true") {
@@ -38,8 +46,16 @@ ext.isFabricEnabled = { Project project ->
 ext.isNewArchitectureEnabled = { Project project ->
     def newArchEnabled = project.findProperty("react.newArchEnabled")
                              ?: project.findProperty("newArchEnabled")
+
+    def version = getPackageVersionNumber("react-native", project.rootDir)
+    if (version >= v(0, 82, 0)) {
+        if (newArchEnabled != null) {
+            logger.warn("WARNING: As of 0.82, New Architecture can no longer be disabled")
+        }
+        return true
+    }
+
     if (newArchEnabled == "true") {
-        def version = getPackageVersionNumber("react-native", project.rootDir)
         def isSupported = version == 0 || version >= v(0, 71, 0)
         if (!isSupported) {
             throw new GradleException([
@@ -50,5 +66,6 @@ ext.isNewArchitectureEnabled = { Project project ->
         }
         return isSupported
     }
+
     return false
 }

--- a/ios/features.mjs
+++ b/ios/features.mjs
@@ -5,6 +5,13 @@ import { v } from "../scripts/helpers.js";
 /**
  * @param {number} reactNativeVersion
  */
+function isNewArchExclusive(reactNativeVersion) {
+  return reactNativeVersion >= v(0, 82, 0);
+}
+
+/**
+ * @param {number} reactNativeVersion
+ */
 function supportsNewArch(reactNativeVersion) {
   return reactNativeVersion === 0 || reactNativeVersion >= v(0, 71, 0);
 }
@@ -15,6 +22,10 @@ function supportsNewArch(reactNativeVersion) {
  * @returns {boolean}
  */
 export function isNewArchEnabled(reactNativeVersion, options) {
+  if (isNewArchExclusive(reactNativeVersion)) {
+    return true;
+  }
+
   if (!supportsNewArch(reactNativeVersion)) {
     return false;
   }
@@ -42,6 +53,10 @@ export function isNewArchEnabled(reactNativeVersion, options) {
  * @returns {boolean}
  */
 export function isBridgelessEnabled(reactNativeVersion, options) {
+  if (isNewArchExclusive(reactNativeVersion)) {
+    return true;
+  }
+
   if (isNewArchEnabled(reactNativeVersion, options)) {
     if (reactNativeVersion >= v(0, 74, 0)) {
       return options["bridgelessEnabled"] !== false;

--- a/test/ios/app.test.ts
+++ b/test/ios/app.test.ts
@@ -141,7 +141,7 @@ describe("generateProject()", macosOnly, () => {
 
   for (const platform of ["ios", "macos", "visionos"] as const) {
     it(`[${platform}] generates Xcode project files for old architecture`, () => {
-      setMockFiles(makeMockProject());
+      setMockFiles(makeMockProject(undefined, "0.81.0"));
 
       const result = generateProject(platform, platform, {});
 
@@ -475,7 +475,7 @@ const PROJECT_FILES = {
     ios: {
       result: {
         buildSettings: {
-          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=1000000000"],
+          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=81000"],
           OTHER_SWIFT_FLAGS: [],
           PRODUCT_BUILD_NUMBER: "1",
           PRODUCT_DISPLAY_NAME: "ContosoApp",
@@ -485,7 +485,7 @@ const PROJECT_FILES = {
         communityAutolinkingScriptPath: undefined,
         reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native",
-        reactNativeVersion: 1000000000,
+        reactNativeVersion: 81000,
         resources: ["main.ios.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
@@ -534,7 +534,7 @@ const PROJECT_FILES = {
     macos: {
       result: {
         buildSettings: {
-          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=1000000000"],
+          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=81000"],
           OTHER_SWIFT_FLAGS: [],
           PRODUCT_BUILD_NUMBER: "1",
           PRODUCT_DISPLAY_NAME: "ContosoApp",
@@ -544,7 +544,7 @@ const PROJECT_FILES = {
         communityAutolinkingScriptPath: undefined,
         reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/react-native-macos",
-        reactNativeVersion: 1000000000,
+        reactNativeVersion: 81000,
         resources: ["main.macos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},
@@ -594,7 +594,7 @@ const PROJECT_FILES = {
     visionos: {
       result: {
         buildSettings: {
-          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=1000000000"],
+          GCC_PREPROCESSOR_DEFINITIONS: ["REACT_NATIVE_VERSION=81000"],
           OTHER_SWIFT_FLAGS: [],
           PRODUCT_BUILD_NUMBER: "1",
           PRODUCT_DISPLAY_NAME: "ContosoApp",
@@ -604,7 +604,7 @@ const PROJECT_FILES = {
         communityAutolinkingScriptPath: undefined,
         reactNativeHostPath: "../node_modules/@rnx-kit/react-native-host",
         reactNativePath: "/~/node_modules/@callstack/react-native-visionos",
-        reactNativeVersion: 1000000000,
+        reactNativeVersion: 81000,
         resources: ["main.visionos.jsbundle"],
         testsBuildSettings: {},
         uitestsBuildSettings: {},

--- a/test/ios/features.test.ts
+++ b/test/ios/features.test.ts
@@ -14,6 +14,9 @@ describe("isBridgelessEnabled()", () => {
   // Bridgeless mode is enabled by default starting with 0.74
   const defaultVersion = v(0, 74, 0);
 
+  // Bridgeless mode is always enabled starting with 0.82
+  const exclusiveVersion = v(0, 82, 0);
+
   before(() => {
     delete process.env["RCT_NEW_ARCH_ENABLED"];
   });
@@ -39,6 +42,18 @@ describe("isBridgelessEnabled()", () => {
       !isBridgelessEnabled(defaultVersion, {
         bridgelessEnabled: false,
         fabricEnabled: true,
+      })
+    );
+  });
+
+  it("always returns true starting with 0.82", () => {
+    ok(isBridgelessEnabled(exclusiveVersion, {}));
+    ok(isBridgelessEnabled(exclusiveVersion, { fabricEnabled: false }));
+    ok(isBridgelessEnabled(exclusiveVersion, { fabricEnabled: true }));
+    ok(
+      isBridgelessEnabled(exclusiveVersion, {
+        fabricEnabled: true,
+        bridgelessEnabled: false,
       })
     );
   });
@@ -108,6 +123,9 @@ describe("isNewArchEnabled()", () => {
   // New architecture is first publicly available in 0.68, but we'll require 0.71
   const firstAvailableVersion = v(0, 71, 0);
 
+  // New architecture is always enabled starting with 0.82
+  const exclusiveVersion = v(0, 82, 0);
+
   before(() => {
     delete process.env["RCT_NEW_ARCH_ENABLED"];
   });
@@ -139,5 +157,11 @@ describe("isNewArchEnabled()", () => {
     ok(!isNewArchEnabled(v(0, 70, 999), {}));
     ok(!isNewArchEnabled(firstAvailableVersion, {}));
     ok(!isNewArchEnabled(firstAvailableVersion, { fabric_enabled: true }));
+  });
+
+  it("always returns true starting with 0.82", () => {
+    ok(isNewArchEnabled(exclusiveVersion, {}));
+    ok(isNewArchEnabled(exclusiveVersion, { fabricEnabled: false }));
+    ok(isNewArchEnabled(exclusiveVersion, { newArchEnabled: false }));
   });
 });


### PR DESCRIPTION
### Description

New arch can no longer be disabled in 0.82.

See also autolinking fix here: https://github.com/facebook/react-native/pull/53138

### Platforms affected

- [x] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a