### PR TITLE
ci: log versions when building nightlies

### DIFF
--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -13,5 +13,9 @@ runs:
       shell: bash
     - name: Install npm dependencies (ignore lockfile changes)
       if: ${{ inputs.immutable != 'true' }}
-      run: yarn --no-immutable
+      run: |
+        yarn --no-immutable
+        yarn why react-native
+        yarn why react-native-macos
+        yarn why react-native-windows
       shell: bash


### PR DESCRIPTION
### Description

Log versions when building nightlies to make it easier to debug

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a