### PR TITLE
ci(android): explicitly enable New Arch when building nightlies

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -15,6 +15,12 @@ runs:
         node --eval "require('./android/gradle-wrapper.js').configureGradleWrapper('${{ inputs.project-root }}/android')"
       shell: bash
     - name: Build
+      if: ${{ github.event_name != 'schedule' }}
       run: ./gradlew ${{ inputs.arguments }}
+      shell: bash
+      working-directory: ${{ inputs.project-root }}/android
+    - name: Build nightly
+      if: ${{ github.event_name == 'schedule' }}
+      run: ./gradlew -PnewArchEnabled=true ${{ inputs.arguments }}
       shell: bash
       working-directory: ${{ inputs.project-root }}/android


### PR DESCRIPTION
### Description

Explicitly enable New Arch when building nightlies otherwise community modules won't know

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
npm run set-react-version nightly
yarn clean
yarn
cd example/android/
./gradlew -PnewArchEnabled=true assembleDebug
```