### PR TITLE
fix(macos): declare support for 0.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.1",
     "react-native": "0.70 - 0.81 || >=0.82.0-0 <0.82.0",
-    "react-native-macos": "^0.0.0-0 || 0.71 - 0.78",
+    "react-native-macos": "^0.0.0-0 || 0.71 - 0.79",
     "react-native-windows": "^0.0.0-0 || 0.70 - 0.79"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12459,7 +12459,7 @@ __metadata:
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.1
     react-native: 0.70 - 0.81 || >=0.82.0-0 <0.82.0
-    react-native-macos: ^0.0.0-0 || 0.71 - 0.78
+    react-native-macos: ^0.0.0-0 || 0.71 - 0.79
     react-native-windows: ^0.0.0-0 || 0.70 - 0.79
   peerDependenciesMeta:
     "@callstack/react-native-visionos":


### PR DESCRIPTION
### Description

Declare support for `react-native-macos`@0.79

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.79
yarn clean
yarn
cd example
rm macos/Podfile.lock
pod install --project-directory=macos
yarn macos

# In a separate terminal
yarn start
```

### Screenshots

| JSC | Hermes |
| :-: | :-: |
| <img width="592" height="800" alt="Screenshot 2025-09-02 at 06 38 04" src="https://github.com/user-attachments/assets/c125aa75-fd3e-45a5-8a19-b1e21de8c67a" /> | <img width="592" height="800" alt="Screenshot 2025-09-02 at 06 42 03" src="https://github.com/user-attachments/assets/6f6322e4-770f-4550-901e-b73533e4f7eb" /> |