### PR TITLE
fix(visionos): declare support for 0.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "uuid": "^11.0.0"
   },
   "peerDependencies": {
-    "@callstack/react-native-visionos": "0.73 - 0.78",
+    "@callstack/react-native-visionos": "0.73 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.1",
     "react-native": "0.70 - 0.81 || >=0.82.0-0 <0.82.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12455,7 +12455,7 @@ __metadata:
     typescript: "npm:^5.0.0"
     uuid: "npm:^11.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": 0.73 - 0.78
+    "@callstack/react-native-visionos": 0.73 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.1
     react-native: 0.70 - 0.81 || >=0.82.0-0 <0.82.0


### PR DESCRIPTION
### Description

Declare support for `@callstack/react-native-visionos`@0.79

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] visionOS
- [ ] Windows

### Test plan

```
npm run set-react-version 0.79
yarn clean
yarn
cd example
rm visionos/Podfile.lock
pod install --project-directory=visionos
yarn visionos

# In a separate terminal
yarn start
```

### Screenshots

<img width="1442" height="1161" alt="image" src="https://github.com/user-attachments/assets/6e2368cf-ee4d-46cc-b315-d42827e7b559" />