### PR TITLE
fix: declare support for 0.82

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_react-native_version.yml
+++ b/.github/ISSUE_TEMPLATE/new_react-native_version.yml
@@ -49,14 +49,13 @@ body:
     id: checklist
     attributes:
       label: End-to-end tests
-      description: Leave these unchecked. Combinations of configurations that have been tested.
+      description: Leave these unchecked. Platforms that have been tested.
       options:
-        - label: "Android"
-        - label: "iOS"
-        - label: "macOS"
-        - label: "visionOS"
-        - label: "Windows - NuGet: disabled"
-        - label: "Windows - NuGet: **enabled**"
+        - label: Android
+        - label: iOS
+        - label: macOS
+        - label: visionOS
+        - label: Windows
   - type: checkboxes
     id: terms
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,13 +257,9 @@ If the test script succeeds, we are ready to open a PR:
   - The test script we ran should have generated screenshots for the table
 
 ```markdown
-| Configuration | JSC | Hermes | Fabric | Fabric + Hermes |
-| :------------ | :-: | :----: | :----: | :-------------: |
-| Android       | n/a |  TODO  |  n/a   |      TODO       |
-| iOS           | n/a |  TODO  |  n/a   |      TODO       |
-| macOS         | n/a |  TODO  |  n/a   |      TODO       |
-| visionOS      | n/a |  TODO  |  n/a   |      TODO       |
-| Windows       | n/a |  TODO  |  n/a   |      TODO       |
+| Android | iOS  | macOS | visionOS | Windows |
+| :-----: | :--: | :---: | :------: | :-----: |
+|  TODO   | TODO | TODO  |   TODO   |  TODO   |
 ```
 
 While the PR is open:

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@callstack/react-native-visionos": "0.73 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.1 - 19.1",
-    "react-native": "0.70 - 0.81 || >=0.82.0-0 <0.82.0",
+    "react-native": "0.70 - 0.82 || >=0.83.0-0 <0.83.0",
     "react-native-macos": "^0.0.0-0 || 0.71 - 0.79",
     "react-native-windows": "^0.0.0-0 || 0.70 - 0.79"
   },

--- a/scripts/testing/test-apple.mts
+++ b/scripts/testing/test-apple.mts
@@ -65,7 +65,6 @@ export function installPods({
   rm_r(`${platform}/Pods`);
   rm_r(`${platform}/build`);
 
-  process.env["RCT_USE_PREBUILT_RNCORE"] = "1";
   $("pod", "install", `--project-directory=${platform}`);
 
   return Promise.resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12502,7 +12502,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.73 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.1 - 19.1
-    react-native: 0.70 - 0.81 || >=0.82.0-0 <0.82.0
+    react-native: 0.70 - 0.82 || >=0.83.0-0 <0.83.0
     react-native-macos: ^0.0.0-0 || 0.71 - 0.79
     react-native-windows: ^0.0.0-0 || 0.70 - 0.79
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for React Native 0.82

Resolves #2529

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
npm run test:matrix 0.82
```

### Screenshots

| Android | iOS |
| :-----: | :-: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/098e5f77-2807-4af5-a97a-5dcf7bc6d85d" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/31448fec-b24a-4251-80fd-9e3f3d58cbea" /> |
