### PR TITLE
chore: extend test script to support all platforms

### DIFF
--- a/scripts/testing/test-e2e.mts
+++ b/scripts/testing/test-e2e.mts
@@ -10,7 +10,10 @@ import { isMain } from "../helpers.js";
  * Invokes a shell command with optional arguments.
  */
 export function $(command: string, ...args: string[]) {
-  const { status } = spawnSync(command, args, { stdio: "inherit" });
+  const { status } = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
   if (status !== 0) {
     throw new Error(
       `An error occurred while executing: ${command} ${args.join(" ")}`
@@ -25,6 +28,7 @@ export function $(command: string, ...args: string[]) {
 export function $$(command: string, ...args: string[]): string {
   const { status, stderr, stdout } = spawnSync(command, args, {
     stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
     encoding: "utf-8",
   });
   if (status !== 0) {


### PR DESCRIPTION
### Description

Extends test script to support all platforms

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [x] visionOS
- [x] Windows

### Test plan

```
npm run test:matrix 0.79 -- --macos
```