### PR TITLE
chore(publish): fix GH release not containing change logs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,6 @@
   "defaultBase": "trunk",
   "release": {
     "projects": ["react-native-test-app"],
-    "projectsRelationship": "independent",
     "changelog": {
       "workspaceChangelog": false,
       "projectChangelogs": {


### PR DESCRIPTION
### Description

Fixed GH release not containing change logs

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

**Before:**

```
% yarn nx release --dry-run

 NX   Running release version for project: react-native-test-app

react-native-test-app 🏷️  Resolved the current version as 4.4.10 from git tag "4.4.10", based on releaseTagPattern "{version}"
react-native-test-app 📄 Resolved the specifier as "patch" using git history and the conventional commits standard
react-native-test-app ❓ Applied semver relative bump "patch", derived from conventional commits data, to get new version 4.4.11
react-native-test-app ✍️  New version 4.4.11 written to manifest: package.json

UPDATE package.json [dry-run]

    "name": "react-native-test-app",
-   "version": "0.0.1-dev",
+   "version": "4.4.11",
    "description": "react-native-test-app provides a test app for all supported platforms as a package",


 NX   Tagging commit with git


 NX   Pushing to git remote "origin"


 NX   Creating GitHub Release

CREATE https://github.com/microsoft/react-native-test-app/releases/tag/4.4.11 [dry-run]

+ ## 4.4.11 (2025-09-11)
+
+ This was a version bump only for react-native-test-app to align it with other projects, there were no code changes.


 NX   Skipped publishing packages.


NOTE: The "dryRun" flag means no changes were made.
```

**After:**

```
% yarn nx release --dry-run

 NX   Running release version for project: react-native-test-app

react-native-test-app 🏷️  Resolved the current version as 4.4.10 from git tag "4.4.10", based on releaseTagPattern "{version}"
react-native-test-app 📄 Resolved the specifier as "patch" using git history and the conventional commits standard
react-native-test-app ❓ Applied semver relative bump "patch", derived from conventional commits data, to get new version 4.4.11
react-native-test-app ✍️  New version 4.4.11 written to manifest: package.json

UPDATE package.json [dry-run]

    "name": "react-native-test-app",
-   "version": "0.0.1-dev",
+   "version": "4.4.11",
    "description": "react-native-test-app provides a test app for all supported platforms as a package",


 NX   Tagging commit with git


 NX   Pushing to git remote "origin"


 NX   Creating GitHub Release

CREATE https://github.com/microsoft/react-native-test-app/releases/tag/4.4.11 [dry-run]

+ ## 4.4.11 (2025-09-11)
+
+ ### 🩹 Fixes
+
+ - **windows:** include New Arch build in `test:matrix` ([827bbcfe](https://github.com/microsoft/react-native-test-app/commit/827bbcfe))


 NX   Skipped publishing packages.


NOTE: The "dryRun" flag means no changes were made.
```