### PR TITLE
ci: skip publishing if behind `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -670,9 +670,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
-          git config user.email 'github-actions[bot]'
-          git config user.name 'github-actions[bot]@users.noreply.github.com'
-          yarn nx release --yes
+          git fetch origin trunk
+          if git merge-base --is-ancestor origin/trunk HEAD; then
+            git config user.email 'github-actions[bot]'
+            git config user.name 'github-actions[bot]@users.noreply.github.com'
+            yarn nx release --yes
+          fi
   autobot:
     name: "Autobot"
     permissions:


### PR DESCRIPTION
### Description

Nx Release does not check whether it's behind `main` before performing Git operations.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Run the following command in a Bash shell:

```sh
if git merge-base --is-ancestor origin/trunk HEAD; then echo PUBLISH; fi
```

`PUBLISH` should only be printed if we're in sync with `origin/trunk`.