### PR TITLE
fix(windows): fix cannot find `@react-native-windows/cli/package.json`

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -95,11 +95,15 @@ function readJSONFile(path, fs = nodefs) {
  * @param {string=} startDir
  * @returns {T}
  */
-function requireTransitive(dependencyChain, startDir = process.cwd()) {
+function requireTransitive(
+  dependencyChain,
+  startDir = process.cwd(),
+  fs = nodefs
+) {
   const p = dependencyChain.reduce((curr, next) => {
     const p = require.resolve(next + "/package.json", { paths: [curr] });
     return path.dirname(p);
-  }, startDir);
+  }, fs.realpathSync(startDir));
   return require(p);
 }
 


### PR DESCRIPTION
### Description

`Cannot find module '@react-native-windows/cli/package.json'` occurs when running `install-windows-test-app` in a pnpm repo.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a