### PR TITLE
chore(release): skip empty categories in release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,8 +359,9 @@ the template we currently use:
 > - Fix #2
 
 Make sure you're on latest `trunk`, then run
-`yarn release-notes <last version> <this version>` to get a list of user-facing
-changes. You will likely need to prune and rewrite some of these entries.
+`node --run release-notes -- <last version> <this version>` to get a list of
+user-facing changes. You will likely need to prune and rewrite some of these
+entries.
 
 <!-- References -->
 

--- a/scripts/internal/release-notes.mts
+++ b/scripts/internal/release-notes.mts
@@ -19,7 +19,7 @@ type Group =
   | "visionos"
   | "windows";
 
-type Changes = Record<string, Record<Group, string[]>>;
+type Changes = Record<string, Partial<Record<Group, string[]>>>;
 
 function assertCategory(category: string): asserts category is "feat" | "fix" {
   if (category !== "feat" && category !== "fix") {
@@ -85,33 +85,16 @@ function sanitizeGroup(group: string): Group {
 }
 
 function parseCommits(commits: Commit[]): Changes {
-  const changes: Changes = {
-    feat: {
-      general: [],
-      android: [],
-      apple: [],
-      ios: [],
-      macos: [],
-      visionos: [],
-      windows: [],
-    },
-    fix: {
-      general: [],
-      android: [],
-      apple: [],
-      ios: [],
-      macos: [],
-      visionos: [],
-      windows: [],
-    },
-  };
+  const changes: Changes = { feat: {}, fix: {} };
 
   for (const { message } of commits) {
     const m = message.match(/^(feat|fix)(?:\((.*?)\))?: (.*)$/);
     if (m) {
       const [, cat, group, message] = m;
       assertCategory(cat);
-      changes[cat][sanitizeGroup(group)].push(message);
+      const g = sanitizeGroup(group);
+      changes[cat][g] ||= [];
+      changes[cat][g].push(message);
     }
   }
 


### PR DESCRIPTION
### Description

Skip empty categories when generating release notes

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

**Before:**

```
% node --run release-notes -- 4.4.12 5.0.0
📣 react-native-test-app 5.0.0

New features:

- Drop support for 0.75 and older (#2545)

Fixes since 4.4.12:

```

**After:**

```
% node --run release-notes -- 4.4.12 5.0.0
📣 react-native-test-app 5.0.0

New features:

- Drop support for 0.75 and older (#2545)
```