### PR TITLE
fix: declare support for 0.83

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@callstack/react-native-visionos": "0.76 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.2 - 19.1",
-    "react-native": "0.76 - 0.82 || >=0.83.0-0 <0.83.0",
+    "react-native": "0.76 - 0.83 || >=0.83.0-0 <0.84.0",
     "react-native-macos": "^0.0.0-0 || 0.76 - 0.79",
     "react-native-windows": "^0.0.0-0 || 0.76 - 0.80"
   },

--- a/scripts/testing/test-matrix.mts
+++ b/scripts/testing/test-matrix.mts
@@ -338,20 +338,29 @@ if (platforms.length === 0) {
   process.exitCode = 1;
   showBanner(red("No valid platforms were specified"));
 } else {
-  TEST_VARIANTS.reduce(
-    (job, variant) => {
-      return job.then(() =>
-        withReactNativeVersion(version, async () => {
-          for (const platform of platforms) {
-            await buildRunTest({ version, platform, variant });
-          }
-        })
-      );
-    },
-    waitForUserInput(
-      `${TAG} Before continuing, make sure all emulators/simulators and Appium/Metro instances are closed.\n${TAG}\n${TAG} Press any key to continue...`
+  TEST_VARIANTS.filter((variant) =>
+    platforms.some((platform) =>
+      PLATFORM_CONFIG[platform].isAvailable({
+        version,
+        platform,
+        variant,
+        engine: "hermes",
+      })
     )
   )
+    .reduce(
+      (job, variant) =>
+        job.then(() =>
+          withReactNativeVersion(version, async () => {
+            for (const platform of platforms) {
+              await buildRunTest({ version, platform, variant });
+            }
+          })
+        ),
+      waitForUserInput(
+        `${TAG} Before continuing, make sure all emulators/simulators and Appium/Metro instances are closed.\n${TAG}\n${TAG} Press any key to continue...`
+      )
+    )
     .then(() => {
       showBanner("Initialize new app");
       $(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12349,7 +12349,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.2 - 19.1
-    react-native: 0.76 - 0.82 || >=0.83.0-0 <0.83.0
+    react-native: 0.76 - 0.83 || >=0.83.0-0 <0.84.0
     react-native-macos: ^0.0.0-0 || 0.76 - 0.79
     react-native-windows: ^0.0.0-0 || 0.76 - 0.80
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for React Native 0.83.

Resolves #2594.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
node --run test:matrix -- 0.83
```

### Screenshots

| Android | iOS  |
| :-----: | :--: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/81046c6d-5c35-4222-a21c-71f1601a2d84" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/b910a875-afeb-4926-aa8d-0a90a15ad134" /> |