### PR TITLE
ci: partially prevent prototype pollution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
     - cron: 0 4 * * 1-5
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
+  NODE_OPTIONS: "--disable-proto=delete"
   VisualStudioVersion: "17.0"
 concurrency:
   # Ensure single build of a pull request. `trunk` should not be affected.


### PR DESCRIPTION
### Description

Partially addresses https://github.com/microsoft/react-native-test-app/security/dependabot/117.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.