### PR TITLE
ci: bump Node.js to 24

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: "17"
   node-version:
     description: Desired Node version
-    default: "22"
+    default: "24"
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
 runs:


### PR DESCRIPTION
### Description

Bumps Node.js to 24

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a