### PR TITLE
fix(windows): resolve `react-native-windows` path before using it

### DIFF
--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,5 @@
 import { equal, fail, notEqual } from "node:assert/strict";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { URL, fileURLToPath } from "node:url";
@@ -72,7 +73,7 @@ describe("requireTransitive()", () => {
 
     const mustache = requireTransitive<typeof import("mustache")>(
       ["@react-native-windows/cli", "mustache"],
-      rnwDir
+      fs.realpathSync(rnwDir)
     );
     notEqual(mustache, null);
     equal(typeof mustache.parse, "function");

--- a/windows/app.mjs
+++ b/windows/app.mjs
@@ -203,7 +203,7 @@ export async function generateSolution(destPath, options, fs = nodefs) {
   /** @type {typeof import("mustache")} */
   const mustache = requireTransitive(
     ["@react-native-windows/cli", "mustache"],
-    rnWindowsPath
+    fs.realpathSync(rnWindowsPath)
   );
   const slnPath = path.join(destPath, `${info.bundle.appName}.sln`);
   const vcxprojPath = path.join(projectFilesDestPath, projectFileName);


### PR DESCRIPTION
### Description

Resolve `react-native-windows` path before using it

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a