### PR TITLE
chore: bump `clang-format` and update `.yarnrc` copy script to exclude plugins

### DIFF
--- a/scripts/build/clang-format-diff.sh
+++ b/scripts/build/clang-format-diff.sh
@@ -3,8 +3,8 @@ set -eo pipefail
 
 if [[ -z $DEBUG ]]; then
   brew install clang-format
-  curl --silent --show-error --remote-name https://raw.githubusercontent.com/llvm/llvm-project/release/18.x/clang/tools/clang-format/clang-format-diff.py
+  curl --silent --show-error --remote-name https://raw.githubusercontent.com/llvm/llvm-project/release/21.x/clang/tools/clang-format/clang-format-diff.py
 fi
 git diff --unified=0 --no-color @^ \
-  | python clang-format-diff.py -p1 -regex '.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hh|hpp|m|mm|inc)' -sort-includes \
+  | python3 clang-format-diff.py -p1 -regex '.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hh|hpp|m|mm|inc)' -sort-includes \
   | npx suggestion-bot

--- a/scripts/build/copy-yarnrc.mjs
+++ b/scripts/build/copy-yarnrc.mjs
@@ -16,13 +16,19 @@ function main(src, dst) {
   });
 
   const yml = fs.readFileSync(src, { encoding: "utf-8" });
-  const rc = /** @type {Record<string, string | undefined>} */ (yaml.load(yml));
+  const rc = /** @type {Record<string, string | string[] | undefined>} */ (
+    yaml.load(yml)
+  );
 
   rc["nmHoistingLimits"] = undefined;
-  rc["plugins"] = undefined;
+  rc["plugins"] = [];
 
+  if (rc.globalFolder) {
+    const globalFolder = rc.globalFolder.toString();
+    rc["globalFolder"] = path.join(path.dirname(src), globalFolder);
+  }
   if (rc.yarnPath) {
-    rc["yarnPath"] = path.join(path.dirname(src), rc.yarnPath);
+    rc["yarnPath"] = path.join(path.dirname(src), rc.yarnPath.toString());
   }
 
   fs.writeFileSync(dst, yaml.dump(rc));


### PR DESCRIPTION
### Description

Bump `clang-format` and update `.yarnrc` copy script to exclude plugins

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a