### PR TITLE
chore: set minimum npm package age to 7 days

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,7 @@ logFilters:
   - code: YN0069 # This rule seems redundant when applied on the original package
     level: error
 nodeLinker: node-modules
+npmMinimalAgeGate: 7d
 npmRegistryServer: "https://registry.npmjs.org"
 packageExtensions:
   appium@3:


### PR DESCRIPTION
### Description

Set minimum npm package age to 7 days

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a