### PR TITLE
fix(android): allow passing `CMAKE_MAKE_PROGRAM` to underlying CMake call

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,12 +100,21 @@ android {
         resValue("string", "app_name", project.ext.react.appName)
 
         def cppStd = "-std=c++20"
+        def cmakeMakeProgram = System.getenv("CMAKE_MAKE_PROGRAM")
+
         if (enableNewArchitecture) {
+            def cmakeArgs = [
+                "-DANDROID_STL=c++_shared",
+                "-DPROJECT_BUILD_DIR=${buildDir}",
+                "-DREACT_ANDROID_DIR=${reactNativePath}/ReactAndroid",
+            ]
+            if (cmakeMakeProgram != null) {
+                cmakeArgs.add("-DCMAKE_MAKE_PROGRAM=${cmakeMakeProgram}")
+            }
+
             externalNativeBuild {
                 cmake {
-                    arguments("-DANDROID_STL=c++_shared",
-                              "-DPROJECT_BUILD_DIR=${buildDir}",
-                              "-DREACT_ANDROID_DIR=${reactNativePath}/ReactAndroid")
+                    arguments(*cmakeArgs)
                     cppFlags(cppStd, "-frtti", "-fexceptions", "-DWITH_INSPECTOR=1")
                 }
             }
@@ -115,11 +124,18 @@ android {
                 }
             }
         } else {
+            def cmakeArgs = [
+                "-DANDROID_STL=c++_shared",
+                "-DREACT_COMMON_DIR=${reactNativePath}/ReactCommon",
+                "-DREACT_JNILIBS_DIR=${buildDir}/outputs/jniLibs",
+            ]
+            if (cmakeMakeProgram != null) {
+                cmakeArgs.add("-DCMAKE_MAKE_PROGRAM=${cmakeMakeProgram}")
+            }
+
             externalNativeBuild {
                 cmake {
-                    arguments("-DANDROID_STL=c++_shared",
-                              "-DREACT_COMMON_DIR=${reactNativePath}/ReactCommon",
-                              "-DREACT_JNILIBS_DIR=${buildDir}/outputs/jniLibs")
+                    arguments(*cmakeArgs)
                     cppFlags(cppStd, "-Wall", "-Werror", "-frtti", "-fexceptions", "-DWITH_INSPECTOR=1")
                 }
             }

--- a/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
+++ b/android/app/src/camera/java/com/microsoft/reacttestapp/camera/MainActivityExtensions.kt
@@ -33,6 +33,7 @@ fun MainActivity.scanForQrCode() {
             }
             fragment.show(supportFragmentManager, QRCodeScannerFragment.TAG)
         }
+
         shouldShowRequestPermissionRationale(Manifest.permission.CAMERA) -> {
             Snackbar
                 .make(
@@ -49,6 +50,7 @@ fun MainActivity.scanForQrCode() {
                 }
                 .show()
         }
+
         else -> {
             ActivityCompat.requestPermissions(
                 this,

--- a/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
+++ b/android/app/src/main/java/com/microsoft/reacttestapp/MainActivity.kt
@@ -201,21 +201,25 @@ class MainActivity : ReactActivity() {
                     reload(BundleSource.Disk)
                     true
                 }
+
                 R.id.load_from_dev_server -> {
                     PackagerConnectionSettings(this).debugServerHost = ""
                     reload(BundleSource.Server)
                     true
                 }
+
                 R.id.remember_last_component -> {
                     val enable = !menuItem.isChecked
                     menuItem.isChecked = enable
                     session.shouldRememberLastComponent = enable
                     true
                 }
+
                 R.id.scan_qr_code -> {
                     scanForQrCode()
                     true
                 }
+
                 R.id.show_dev_options -> {
                     val devSupportManager = if (BuildConfig.REACTAPP_USE_BRIDGELESS) {
                         (application as TestApp).reactHost.devSupportManager
@@ -225,6 +229,7 @@ class MainActivity : ReactActivity() {
                     devSupportManager?.showDevOptionsDialog()
                     true
                 }
+
                 else -> false
             }
         }
@@ -254,6 +259,7 @@ class MainActivity : ReactActivity() {
                     .newInstance(component)
                     .show(supportFragmentManager, ComponentBottomSheetDialogFragment.TAG)
             }
+
             else -> {
                 findActivityClass(component.name)?.let {
                     startActivity(Intent(this, it))

--- a/android/app/src/reacthost-0.76/java/com/microsoft/reacttetapp/react/MainReactNativeHost.kt
+++ b/android/app/src/reacthost-0.76/java/com/microsoft/reacttetapp/react/MainReactNativeHost.kt
@@ -108,6 +108,7 @@ class MainReactNativeHost(
             BundleSource.Action.RELOAD -> {
                 reactInstanceManager.devSupportManager.handleReloadJS()
             }
+
             BundleSource.Action.RESTART -> {
                 if (activity !is MainActivity) {
                     activity.navigateUpTo(Intent(application, MainActivity.Companion::class.java))


### PR DESCRIPTION
### Description

Allow passing `CMAKE_MAKE_PROGRAM` to underlying CMake call

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.