### PR TITLE
chore(yarn): make Yarn plugins support monorepos

### DIFF
--- a/.yarn/plugins/clean.cjs
+++ b/.yarn/plugins/clean.cjs
@@ -1,9 +1,6 @@
 // @ts-check
-const { spawnSync } = require("node:child_process");
-const fs = require("node:fs");
-const path = require("node:path");
 
-/** @type {{ name: string; factory: (require: NodeRequire) => unknown; }} */
+/** @type {{ name: string; factory: (require: NodeJS.Require) => unknown; }} */
 module.exports = {
   name: "plugin-clean",
   factory: (require) => {
@@ -14,20 +11,35 @@ module.exports = {
       static paths = [["clean"]];
 
       async execute() {
-        const projectRoot = path.dirname(path.dirname(__dirname));
+        // @ts-expect-error Yarn internal package
+        const { Configuration, Project } = require("@yarnpkg/core");
+        // @ts-expect-error Yarn internal package
+        const { npath } = require("@yarnpkg/fslib");
+        const { spawnSync } = require("node:child_process");
+        const fs = require("node:fs");
 
-        // Remove the symlink first. On Windows, `git clean` resolves/traverses
-        // the symlink, causing an infinite loop.
-        const symlink = path.join(
-          projectRoot,
-          "example",
-          "node_modules",
-          "react-native-test-app"
+        const configuration = await Configuration.find(
+          this.context.cwd,
+          this.context.plugins
         );
-        fs.rmSync(symlink, { force: true, maxRetries: 3, recursive: true });
+        const { project } = await Project.find(configuration, this.context.cwd);
+
+        // Remove symlinks first. On Windows, `git clean` resolves/traverses
+        // symlinks, causing an infinite loop.
+        for (const ws of project.workspaces) {
+          const rntaPath = npath.join(
+            npath.fromPortablePath(ws.cwd),
+            "node_modules",
+            "react-native-test-app"
+          );
+          const stats = fs.lstatSync(rntaPath, { throwIfNoEntry: false });
+          if (stats?.isSymbolicLink()) {
+            fs.rmSync(rntaPath);
+          }
+        }
 
         spawnSync("git", ["clean", "-dfqx", "--exclude=.yarn/cache"], {
-          cwd: projectRoot,
+          cwd: npath.fromPortablePath(project.cwd),
           stdio: "inherit",
         });
       }

--- a/.yarn/plugins/undo-bin-sorting.cjs
+++ b/.yarn/plugins/undo-bin-sorting.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 /**
  * @typedef {{ values: Map<string, unknown>; }} Configuration
- * @typedef {{ cwd: string; }} Workspace
+ * @typedef {{ cwd: string; manifest: { name: { scope?: string; name: string; } } }} Workspace
  * @typedef {{ configuration: Configuration; cwd: string; workspaces: Workspace[]; }} Project
  * @typedef {{ mode?: "skip-build" | "update-lockfile"; }} InstallOptions
  */
@@ -21,9 +21,9 @@
 module.exports = {
   name: "plugin-undo-bin-sorting",
   factory: (require) => {
+    // @ts-expect-error Yarn internal package
     const { npath } = require("@yarnpkg/fslib");
     const fs = require("node:fs");
-    const path = require("node:path");
 
     const asText = /** @type {const} */ ({ encoding: "utf-8" });
 
@@ -33,12 +33,21 @@ module.exports = {
       hooks: {
         /** @type {(project: Project) => void} */
         validateProject(project) {
-          const projectRoot = npath.fromPortablePath(project.cwd);
-          manifestPath = path.join(projectRoot, "package.json");
-          orig_rawManifest = fs.readFileSync(manifestPath, asText);
+          for (const ws of project.workspaces) {
+            if (ws.manifest.name.name === "react-native-test-app") {
+              const packagePath = npath.fromPortablePath(ws.cwd);
+              manifestPath = npath.join(packagePath, "package.json");
+              orig_rawManifest = fs.readFileSync(manifestPath, asText);
+              break;
+            }
+          }
         },
         /** @type {(project: Project, options: InstallOptions) => void} */
         afterAllInstalled() {
+          if (!manifestPath) {
+            return;
+          }
+
           const rawManifest = fs.readFileSync(manifestPath, asText);
           if (rawManifest === orig_rawManifest) {
             return;


### PR DESCRIPTION
### Description

Make Yarn plugins support monorepos

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a