### PR TITLE
ci(windows): disable nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -544,6 +544,7 @@ jobs:
     name: "Windows"
     permissions: {}
     runs-on: windows-2025
+    if: ${{ github.event_name != 'schedule' }}
     strategy:
       matrix:
         platform: [ARM64, x64]


### PR DESCRIPTION
### Description

`react-native-windows` canary builds have not been updated since 0.78.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a