### PR TITLE
chore(ios): remove unused `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`

### DIFF
--- a/packages/app/example/Example-Tests.podspec
+++ b/packages/app/example/Example-Tests.podspec
@@ -18,8 +18,7 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'ReactTestApp-DevSupport'
 
-  s.framework             = 'XCTest'
-  s.user_target_xcconfig  = { 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => '$(inherited)' }
+  s.framework = 'XCTest'
 
   s.source_files = 'ios/ExampleTests/**/*.{m,swift}'
 end

--- a/packages/app/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/packages/app/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -226,7 +226,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					19ECD0D1232ED425003D8557 = {
@@ -443,7 +443,6 @@
 		19ECD100232ED428003D8557 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppTests/Info.plist;
@@ -464,7 +463,6 @@
 		19ECD101232ED428003D8557 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppTests/Info.plist;
@@ -485,7 +483,6 @@
 		19ECD103232ED428003D8557 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -504,7 +501,6 @@
 		19ECD104232ED428003D8557 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/app/macos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/packages/app/macos/ReactTestApp.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					193EF05E247A736100BE8C79 = {
@@ -431,7 +431,6 @@
 		193EF089247A736300BE8C79 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -452,7 +451,6 @@
 		193EF08A247A736300BE8C79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -473,7 +471,6 @@
 		193EF08C247A736300BE8C79 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;
@@ -492,7 +489,6 @@
 		193EF08D247A736300BE8C79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;

--- a/packages/app/visionos/ReactTestApp.xcodeproj/project.pbxproj
+++ b/packages/app/visionos/ReactTestApp.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					19ECD0D1232ED425003D8557 = {
@@ -427,7 +427,6 @@
 		19ECD100232ED428003D8557 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppTests/Info.plist;
@@ -452,7 +451,6 @@
 		19ECD101232ED428003D8557 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppTests/Info.plist;
@@ -477,7 +475,6 @@
 		19ECD103232ED428003D8557 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -500,7 +497,6 @@
 		19ECD104232ED428003D8557 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ReactTestAppUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
### Description

Xcode no longer use `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a