### PR TITLE
fix: declare support for 0.84

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -99,7 +99,7 @@
     "@callstack/react-native-visionos": "0.76 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.2 - 19.2",
-    "react-native": "0.76 - 0.83 || >=0.83.0-0 <0.84.0",
+    "react-native": "0.76 - 0.84 || >=0.84.0-0 <0.85.0",
     "react-native-macos": "^0.0.0-0 || 0.76 - 0.81",
     "react-native-windows": "^0.0.0-0 || 0.76 - 0.81"
   },

--- a/packages/app/scripts/testing/test-apple.mts
+++ b/packages/app/scripts/testing/test-apple.mts
@@ -32,7 +32,7 @@ export const getIOSSimulatorName = memo(() => {
       "An error occurred while trying to evaluate 'wdio.config.mjs'"
     );
   }
-  return stdout.trim();
+  return `'${stdout.trim()}'`;
 });
 
 /**

--- a/packages/app/scripts/testing/test-e2e.mts
+++ b/packages/app/scripts/testing/test-e2e.mts
@@ -6,14 +6,16 @@ import { spawnSync } from "node:child_process";
 import { Socket } from "node:net";
 import { isMain } from "../helpers.js";
 
+export const DEFAULT_SPAWN_OPTIONS = {
+  stdio: "inherit",
+  shell: true, // Yarn won't be able to find commands otherwise
+} as const;
+
 /**
  * Invokes a shell command with optional arguments.
  */
 export function $(command: string, ...args: string[]) {
-  const { status } = spawnSync(command, args, {
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  });
+  const { status } = spawnSync(command, args, DEFAULT_SPAWN_OPTIONS);
   if (status !== 0) {
     throw new Error(
       `An error occurred while executing: ${command} ${args.join(" ")}`

--- a/packages/app/scripts/testing/test-matrix.mts
+++ b/packages/app/scripts/testing/test-matrix.mts
@@ -13,7 +13,7 @@ import type { BuildConfig, TargetPlatform } from "../types.js";
 import { green, red, yellow } from "../utils/colors.mjs";
 import { rm_r } from "../utils/filesystem.mjs";
 import { getIOSSimulatorName, installPods } from "./test-apple.mts";
-import { $, $$, test } from "./test-e2e.mts";
+import { $, $$, DEFAULT_SPAWN_OPTIONS, test } from "./test-e2e.mts";
 
 type PlatformConfig = {
   name: string;
@@ -364,8 +364,8 @@ if (platforms.length === 0) {
     .then(() => {
       showBanner("Initialize new app");
       $(
-        PACKAGE_MANAGER,
-        "init-test-app",
+        process.argv0,
+        "../scripts/init.mjs",
         "--destination",
         "template-example",
         "--name",
@@ -379,7 +379,7 @@ if (platforms.length === 0) {
     .then(() => {
       showBanner("Reconfigure existing app");
       const args = [
-        "configure-test-app",
+        "../scripts/configure.mjs",
         "-p",
         "android",
         "-p",
@@ -391,10 +391,7 @@ if (platforms.length === 0) {
         "-p",
         "windows",
       ];
-      const { status } = spawnSync(PACKAGE_MANAGER, args, {
-        stdio: "inherit",
-        shell: process.platform === "win32",
-      });
+      const { status } = spawnSync(process.argv0, args, DEFAULT_SPAWN_OPTIONS);
       if (status !== 1) {
         throw new Error("Expected an error");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12262,7 +12262,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.2 - 19.2
-    react-native: 0.76 - 0.83 || >=0.83.0-0 <0.84.0
+    react-native: 0.76 - 0.84 || >=0.84.0-0 <0.85.0
     react-native-macos: ^0.0.0-0 || 0.76 - 0.81
     react-native-windows: ^0.0.0-0 || 0.76 - 0.81
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for 0.84.

Resolves #2624.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
node --run test:matrix -- 0.84
```

### Screenshots

| Android | iOS  |
| :-----: | :--: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/89918b53-f32f-45da-ae39-d8cdf9e97f54" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/90e7e752-137e-4ce9-93ab-4b920c5223f2" /> |