### PR TITLE
fix(windows): ensure target platform version match

### DIFF
--- a/packages/app/windows/Win32/ReactApp.Package.wapproj
+++ b/packages/app/windows/Win32/ReactApp.Package.wapproj
@@ -3,6 +3,7 @@
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <PropertyGroup>
     <ProjectGuid>{b44cead7-fbff-4a17-95eb-ff5434bbd79d}</ProjectGuid>
+    <TargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'!=''">$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <EntryPointProjectUniqueName>ReactApp.vcxproj</EntryPointProjectUniqueName>
     <DebuggerType>NativeOnly</DebuggerType>

--- a/packages/app/windows/Win32/ReactApp.vcxproj
+++ b/packages/app/windows/Win32/ReactApp.vcxproj
@@ -8,7 +8,6 @@
     <ProjectName>ReactApp</ProjectName>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ReactApp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <AppxPackage>false</AppxPackage>


### PR DESCRIPTION
### Description

Ensure `TargetPlatformVersion` matches whatever `WindowsTargetPlatformVersion` is set to.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

See https://github.com/microsoft/react-native-test-app/pull/2645