### PR TITLE
fix(windows): do not enable NuGet by default when New Arch is

### DIFF
--- a/packages/app/ios/ReactTestApp/ReactInstance.swift
+++ b/packages/app/ios/ReactTestApp/ReactInstance.swift
@@ -155,7 +155,7 @@ final class ReactInstance: NSObject, RNXHostConfig {
         #if swift(>=5.9)
 
         #if os(visionOS)
-        // Fallback to iOS extensions if visionOS is not present
+        /// Fallback to iOS extensions if visionOS is not present
         let extensions = [".visionos", ".ios", ".mobile", ".native", ""]
         #elseif os(iOS)
         let extensions = [".ios", ".mobile", ".native", ""]

--- a/packages/app/ios/ReactTestApp/Session.swift
+++ b/packages/app/ios/ReactTestApp/Session.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// `UserDefaults` can be misused for fingerprinting and developers are now
-/// required to provide a reason for using it. This was announced at WWDC 2023
-/// (see https://developer.apple.com/videos/play/wwdc2023/10060/?time=457). By
-/// excluding unused modules when in single app mode, we also conveniently
-/// remove all uses of it.
+// `UserDefaults` can be misused for fingerprinting and developers are now
+// required to provide a reason for using it. This was announced at WWDC 2023
+// (see https://developer.apple.com/videos/play/wwdc2023/10060/?time=457). By
+// excluding unused modules when in single app mode, we also conveniently
+// remove all uses of it.
 #if !ENABLE_SINGLE_APP_MODE
 
 enum Session {

--- a/packages/app/windows/Win32/ReactApp.vcxproj
+++ b/packages/app/windows/Win32/ReactApp.vcxproj
@@ -13,6 +13,7 @@
     <AppxPackage>false</AppxPackage>
   </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
+    <ProjectRootDir Condition="'$(ProjectRootDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'app.json'))</ProjectRootDir>
     <ReactAppWinDir Condition="'$(ReactAppWinDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-test-app\package.json'))\node_modules\react-native-test-app\windows</ReactAppWinDir>
     <ReactAppSharedDir Condition="'$(ReactAppSharedDir)'==''">$(ReactAppWinDir)\Shared</ReactAppSharedDir>
     <ReactAppWin32Dir Condition="'$(ReactAppWin32Dir)'==''">$(ReactAppWinDir)\Win32</ReactAppWin32Dir>
@@ -78,6 +79,14 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <DisableSpecificWarnings></DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>
+        $(ReactAppWin32Dir);
+        $(ReactAppSharedDir);
+        $(ReactAppGeneratedDir);
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>ENABLE_SINGLE_APP_MODE=0;REACT_NATIVE_VERSION=1000000000;USE_FABRIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shell32.lib;user32.lib;windowsapp.lib;%(AdditionalDependenices)</AdditionalDependencies>
@@ -93,13 +102,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <PreprocessorDefinitions>ENABLE_SINGLE_APP_MODE=0;REACT_NATIVE_VERSION=1000000000;USE_FABRIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactAppWin32Dir);$(ReactAppSharedDir);$(ReactAppGeneratedDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />

--- a/packages/app/windows/app.mjs
+++ b/packages/app/windows/app.mjs
@@ -216,6 +216,7 @@ export async function generateSolution(destPath, options, fs = nodefs) {
           ...templateView,
           name: path.basename(projectFileName, path.extname(projectFileName)),
           useExperimentalNuget: info.useExperimentalNuGet,
+          useNuGets: info.useExperimentalNuGet,
           rnwPathFromProjectRoot: path.relative(
             path.dirname(projectManifest),
             rnWindowsPath
@@ -228,7 +229,6 @@ export async function generateSolution(destPath, options, fs = nodefs) {
           /"\.\.\\node_modules\\react-native-windows\\/g,
           `"${path.relative(destPath, rnWindowsPath)}\\`
         )
-        .replace("ReactApp\\ReactApp.vcxproj", vcxprojLocalPath) // Win32
         .replace(
           "ReactApp.Package\\ReactApp.Package.wapproj", // Win32
           vcxprojLocalPath.replace(
@@ -236,6 +236,7 @@ export async function generateSolution(destPath, options, fs = nodefs) {
             "ReactApp.Package.wapproj"
           )
         )
+        .replace("ReactApp\\ReactApp.vcxproj", vcxprojLocalPath) // Win32
         .replace("ReactTestApp\\ReactTestApp.vcxproj", vcxprojLocalPath) // UWP
         .replace(
           /EndProject\r?\nGlobal/,

--- a/packages/app/windows/project.mjs
+++ b/packages/app/windows/project.mjs
@@ -421,7 +421,7 @@ export async function projectInfo(
     versionNumber,
     bundle: getBundleResources(findNearest("app.json", destPath, fs), fs),
     nugetDependencies: await getNuGetDependencies(rnWindowsPath),
-    useExperimentalNuGet: newArch || useNuGet,
+    useExperimentalNuGet: useNuGet,
     useFabric: newArch,
   };
 }


### PR DESCRIPTION
### Description

Do not enable NuGet by default when New Arch is

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a