### PR TITLE
ci: disable npm cache to ensure build consistency

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Prefix to add to the cache key
   cache-npm-dependencies:
     description: Caches npm dependencies (supports npm, yarn, pnpm v6.10+)
-    default: yarn
+    default: ""
   java-version:
     description: Desired Java version
     default: "17"
@@ -54,13 +54,13 @@ runs:
       shell: bash
     - name: Set up JDK
       if: ${{ inputs.platform == 'android' || inputs.platform == 'node' }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Set up Gradle
       if: ${{ inputs.platform == 'android' || inputs.platform == 'node' }}
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
       with:
         gradle-version: wrapper
         gradle-home-cache-excludes: |
@@ -77,7 +77,7 @@ runs:
         bundler: Gemfile.lock
         bundler-cache: true
     - name: Set up Node.js
-      uses: actions/setup-node@v4.4.0
+      uses: actions/setup-node@v6.2.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache-npm-dependencies }}
@@ -98,7 +98,7 @@ runs:
       shell: bash
     - name: Cache /.ccache
       if: ${{ steps.setup-ccache.outputs.cache-key }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .ccache
         key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-ccache-${{ steps.setup-ccache.outputs.cache-key }}-1

--- a/packages/app/example/package.json
+++ b/packages/app/example/package.json
@@ -36,7 +36,7 @@
     "@react-native/babel-preset": "^0.79.0",
     "@react-native/metro-config": "^0.79.0",
     "@rnx-kit/cli": "^0.18.11",
-    "@rnx-kit/metro-config": "^2.1.0",
+    "@rnx-kit/metro-config": "^2.2.3",
     "@rnx-kit/polyfills": "^0.2.0",
     "@rnx-kit/tsconfig": "^2.0.0",
     "@types/react": "~19.0.0",

--- a/packages/app/scripts/configure.mjs
+++ b/packages/app/scripts/configure.mjs
@@ -570,7 +570,7 @@ export function updatePackageManifest(
 
   const { name: rntaName, version: rntaVersion } = readManifest();
   manifest["devDependencies"] = mergeObjects(manifest["devDependencies"], {
-    "@rnx-kit/metro-config": "^2.1.0",
+    "@rnx-kit/metro-config": "^2.2.3",
     [rntaName]: `^${rntaVersion}`,
   });
 

--- a/packages/app/windows/Win32/ReactApp.Package.wapproj
+++ b/packages/app/windows/Win32/ReactApp.Package.wapproj
@@ -10,7 +10,7 @@
     <BackgroundTaskDebugEngines>NativeOnly</BackgroundTaskDebugEngines>
   </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" />
   <PropertyGroup>

--- a/packages/app/windows/Win32/ReactApp.Package.wapproj
+++ b/packages/app/windows/Win32/ReactApp.Package.wapproj
@@ -10,7 +10,7 @@
     <BackgroundTaskDebugEngines>NativeOnly</BackgroundTaskDebugEngines>
   </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" />
   <PropertyGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,9 +3807,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/metro-config@npm:^2.1.0":
-  version: 2.2.2
-  resolution: "@rnx-kit/metro-config@npm:2.2.2"
+"@rnx-kit/metro-config@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@rnx-kit/metro-config@npm:2.2.3"
   dependencies:
     "@rnx-kit/tools-node": "npm:^3.0.0"
     "@rnx-kit/tools-react-native": "npm:^2.3.1"
@@ -3821,7 +3821,7 @@ __metadata:
   peerDependenciesMeta:
     "@react-native/metro-config":
       optional: true
-  checksum: 10c0/0209a089ed9e4a8ed41454d508d48ccb6bed42dcb4679dcc1d99d007676195c1a758a1207842f605ead909a15e50de45933f894140e54e5ea76661651c9f17c3
+  checksum: 10c0/82e2bfaa0af95764de4ed9aaede77179f99c33ca675aba68129bc7d619f201b3eadd3ffd39844a6f33cbbb619460e403f0488da4b40f11eaadd5538fd1c3707c
   languageName: node
   linkType: hard
 
@@ -7845,7 +7845,7 @@ __metadata:
     "@react-native/babel-preset": "npm:^0.79.0"
     "@react-native/metro-config": "npm:^0.79.0"
     "@rnx-kit/cli": "npm:^0.18.11"
-    "@rnx-kit/metro-config": "npm:^2.1.0"
+    "@rnx-kit/metro-config": "npm:^2.2.3"
     "@rnx-kit/polyfills": "npm:^0.2.0"
     "@rnx-kit/tsconfig": "npm:^2.0.0"
     "@types/react": "npm:~19.0.0"


### PR DESCRIPTION
### Description

Ensure `react-native-windows` path can be found

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

CI should pass