### PR TITLE
fix(windows): re-enable NuGet by default when building New Arch

### DIFF
--- a/packages/app/windows/project.mjs
+++ b/packages/app/windows/project.mjs
@@ -421,7 +421,7 @@ export async function projectInfo(
     versionNumber,
     bundle: getBundleResources(findNearest("app.json", destPath, fs), fs),
     nugetDependencies: await getNuGetDependencies(rnWindowsPath),
-    useExperimentalNuGet: useNuGet,
+    useExperimentalNuGet: newArch || useNuGet,
     useFabric: newArch,
   };
 }


### PR DESCRIPTION
### Description

Re-enables NuGet by default when building New Arch

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a