### PR TITLE
ci: remove npm update step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -719,13 +719,6 @@ jobs:
         if: ${{ github.ref != 'refs/heads/trunk' }}
         run: |
           yarn nx release --dry-run
-      - name: Update npm if <11.5.1
-        if: ${{ github.ref == 'refs/heads/trunk' }}
-        run: |
-          if [[ "$(echo -e "11.5.1\n$(npm --version)" | sort --version-sort | head -n 1)" != "11.5.1" ]]; then
-            npm install -g npm@11.5.2
-          fi
-          echo "npm version: $(npm --version)"
       - name: Release
         if: ${{ github.ref == 'refs/heads/trunk' }}
         env:


### PR DESCRIPTION
### Description

Runner images have npm 11.6.2 installed by default now.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a