### PR TITLE
Add 'android:resource' to meta-data attributes

### DIFF
--- a/packages/app/android/android-manifest.js
+++ b/packages/app/android/android-manifest.js
@@ -102,7 +102,7 @@ function generateAndroidManifest(appManifestPath, manifestOutput, fs = nodefs) {
   const metaData = android.metaData;
   if (Array.isArray(metaData)) {
     const names = ["android:name"];
-    const attributes = ["android:value"];
+    const attributes = ["android:value", "android:resource"];
     const entries = toXML(metaData, names, attributes, attributeNamePrefix);
     if (entries.length > 0) {
       manifest.application["meta-data"] = entries;

--- a/packages/app/scripts/types.ts
+++ b/packages/app/scripts/types.ts
@@ -28,6 +28,7 @@ export type AndroidConfig = {
     metaData?: {
       "android:name": string;
       "android:value": string;
+      "android:resource": string;
     }[];
   };
 };


### PR DESCRIPTION
### Description

android:resource is one of possible attributes https://developer.android.com/guide/topics/manifest/meta-data-element

<!--
  Thank you for taking the time to submit this pull request.

  Please describe it in detail here:
  - What issue are you trying to solve?
  - How does this change address the issue?
  - If applicable, can you attach screenshots of before and after your
    change?
-->

<!--
  If this change addresses an existing issue, please provide a reference
  as in the example below.

Resolves #244.
-->

### Platforms affected

- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

specify to `app.json`
```
"metaData": [
      {
        "android:name": "module.icon.color",
        "android:resource": "@color/notification_icon_color"
      },
```
and see the attribute in generated AndroidManifest

<!--
  Provide step-by-step instructions for how to:
  - Reproduce the issue that this change addresses or otherwise verify
    that your changes are working correctly.
  - Test any edge cases you can think of.

  If changes to the local checkout is required for testing your PR, e.g.
  bump `react-native` to a specific version, providing a diff your
  reviewers can apply will help a lot.
-->
