### PR TITLE
ci(nightly): disable minimum age gate

### DIFF
--- a/.github/actions/setup-react-native/action.yml
+++ b/.github/actions/setup-react-native/action.yml
@@ -7,6 +7,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Disable minimum age gate
+      run: |
+        yarn config unset npmMinimalAgeGate
+      shell: bash
     - name: Set up react-native@${{ inputs.version }}
       run: |
         rm example/ios/Podfile.lock


### PR DESCRIPTION
### Description

We need to disable the minimum age gate to build nightlies.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a