### PR TITLE
chore(security): address CVE-2026-34601

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "@nx/devkit/minimatch": "^10.2.4",
     "@nx/js/picomatch": "^4.0.2",
     "@nx/workspace/picomatch": "^4.0.2",
+    "@react-native-windows/cli/@xmldom/xmldom": "^0.8.12",
+    "@react-native-windows/telemetry/@xmldom/xmldom": "^0.8.12",
     "appium/ajv": "~8.18.0",
     "appium/axios": "^1.13.6",
     "appium/lodash": "^4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,14 +5494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.7.7":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: 10c0/cb02e4e8d986acf18578a5f25d1bce5e18d08718f40d8a0cdd922a4c112c8e00daf94de4e43f9556ed147c696b135f2ab81fa9a2a8a0416f60af15d156b60e40
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:^0.8.8":
+"@xmldom/xmldom@npm:^0.8.12, @xmldom/xmldom@npm:^0.8.8":
   version: 0.8.12
   resolution: "@xmldom/xmldom@npm:0.8.12"
   checksum: 10c0/b733c84292d1bee32ef21a05aba8f9063456b51a54068d0b4a1abf5545156ee0b9894b7ae23775b5881b11c35a8a03871d1b514fb7e1b11654cdbee57e1c2707


### PR DESCRIPTION
### Description

Addresses CVE-2026-34601

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a