### PR TITLE
fix(security): avoid missing buffer bounds check in `uuid`

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -89,10 +89,9 @@
     "@rnx-kit/react-native-host": "^0.5.15",
     "@rnx-kit/tools-react-native": "^2.1.0",
     "ajv": "^8.0.0",
-    "fast-xml-parser": "^5.3.4",
+    "fast-xml-parser": "^5.7.0",
     "prompts": "^2.4.0",
-    "semver": "^7.3.5",
-    "uuid": "^11.0.0"
+    "semver": "^7.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/packages/app/windows/project.mjs
+++ b/packages/app/windows/project.mjs
@@ -1,10 +1,10 @@
 // @ts-check
 import { resolveCommunityCLI } from "@rnx-kit/tools-react-native/context";
 import { XMLParser } from "fast-xml-parser";
+import { randomUUID } from "node:crypto";
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { URL, fileURLToPath } from "node:url";
-import { v5 as uuidv5 } from "uuid";
 import {
   findNearest,
   getPackageVersion,
@@ -27,8 +27,6 @@ import * as colors from "../scripts/utils/colors.mjs";
  *   ProjectInfo,
  * } from "../scripts/types.js";
  */
-
-const uniqueFilterIdentifier = "e48dc53e-40b1-40cb-970a-f89935452892";
 
 /**
  * Returns whether specified object is Error-like.
@@ -152,10 +150,9 @@ function generateContentItems(
         normalizePath(
           source ? path.relative(source, resource) : path.basename(resource)
         );
-      const id = uuidv5(filter, uniqueFilterIdentifier);
       assetFilters.push(
         `<Filter Include="${filter}">`,
-        `  <UniqueIdentifier>{${id}}</UniqueIdentifier>`,
+        `  <UniqueIdentifier>{${randomUUID()}}</UniqueIdentifier>`,
         `</Filter>`
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,10 +2584,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodable/entities@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@nodable/entities@npm:1.1.0"
-  checksum: 10c0/ff9b8d515d08ff8a5b83f587bc4a2482508250ac051d0967a8c77da3813cc7aae23d8ce8654c97a948536ca73387300ede734ff7c8ae61461220dca09a2911ec
+"@nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
   languageName: node
   linkType: hard
 
@@ -5502,16 +5502,16 @@ __metadata:
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.12
-  resolution: "@xmldom/xmldom@npm:0.8.12"
-  checksum: 10c0/b733c84292d1bee32ef21a05aba8f9063456b51a54068d0b4a1abf5545156ee0b9894b7ae23775b5881b11c35a8a03871d1b514fb7e1b11654cdbee57e1c2707
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
   languageName: node
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.9.0, @xmldom/xmldom@npm:^0.9.8, @xmldom/xmldom@npm:^0.x":
-  version: 0.9.9
-  resolution: "@xmldom/xmldom@npm:0.9.9"
-  checksum: 10c0/f1ecf6cd6926651a752d578fe662c10c47b8f8d98abe646f3318998283ac4a0e591161f89c8d1fc1822ae2524b82f8ff3de4ab396fba7ad7988f508cd5118e89
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 10c0/38a9c9b95450d7fccebc61371c8e0b90ceaae992886484108333d29ccbd2640e3555b6af012f15ce1beb5067aeb40486659b6183fad38af179e82d28028bfc5d
   languageName: node
   linkType: hard
 
@@ -8627,26 +8627,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
     path-expression-matcher: "npm:^1.1.3"
-  checksum: 10c0/d5dfc0660f7f886b9f42747e6aa1d5e16c090c804b322652f65a5d7ffb93aa00153c3e1276cd053629f9f4c4f625131dc6886677394f7048e827e63b97b18927
+  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.0.8, fast-xml-parser@npm:^5.3.4, fast-xml-parser@npm:^5.3.6":
-  version: 5.6.0
-  resolution: "fast-xml-parser@npm:5.6.0"
+"fast-xml-parser@npm:^5.0.8, fast-xml-parser@npm:^5.3.4, fast-xml-parser@npm:^5.3.6, fast-xml-parser@npm:^5.7.0":
+  version: 5.7.1
+  resolution: "fast-xml-parser@npm:5.7.1"
   dependencies:
-    "@nodable/entities": "npm:^1.1.0"
-    fast-xml-builder: "npm:^1.1.4"
+    "@nodable/entities": "npm:^2.1.0"
+    fast-xml-builder: "npm:^1.1.5"
     path-expression-matcher: "npm:^1.5.0"
     strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/3c6c1084d5aab932d34549492e16ccf6ba1267daf21664933fb719fa86a20efc0a60a575720a314cd7b0a4a36b1842bd34b9a22240af98f63e98c83782d8bb2e
+  checksum: 10c0/b8b54e33060da5fc5ce26fdc73c4728f18415f9be9a774f1406b03265a5b411b742c39dba0127c3f0f31fad5b3ee11f51be79aa16df160f69fd5e4b902bfbb85
   languageName: node
   linkType: hard
 
@@ -13252,7 +13252,7 @@ __metadata:
     "@types/semver": "npm:^7.3.6"
     "@typescript/native-preview": "npm:^7.0.0-0"
     ajv: "npm:^8.0.0"
-    fast-xml-parser: "npm:^5.3.4"
+    fast-xml-parser: "npm:^5.7.0"
     js-yaml: "npm:^4.1.0"
     memfs: "npm:^4.0.0"
     minimatch: "npm:^10.0.0"
@@ -13261,9 +13261,8 @@ __metadata:
     prompts: "npm:^2.4.0"
     react: "npm:19.2.3"
     react-native: "npm:^0.85.0"
-    semver: "npm:^7.3.5"
+    semver: "npm:^7.5.2"
     suggestion-bot: "npm:^4.0.0"
-    uuid: "npm:^11.0.0"
   peerDependencies:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
@@ -15537,15 +15536,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

I don't think we actually need to use v5 so replacing `uuid` with `node:crypto` seems like an obvious improvement.

Also addresses the following vulnerabilities:

- CVE-2026-41650
- CVE-2026-41672
- CVE-2026-41673
- CVE-2026-41674
- CVE-2026-41675
- GHSA-w5hq-g745-h8pq

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a