### PR TITLE
fix(macos): show React menu on right-click of Fabric root views

### DIFF
--- a/macos/ReactTestApp/AppDelegate.swift
+++ b/macos/ReactTestApp/AppDelegate.swift
@@ -214,7 +214,7 @@ extension AppDelegate {
                 return viewController
             }
 
-            let viewController = NSViewController(nibName: nil, bundle: nil)
+            let viewController = HostingViewController(nibName: nil, bundle: nil)
             viewController.title = title
             viewController.view = host.view(
                 moduleName: component.appKey,

--- a/macos/ReactTestApp/ViewController.swift
+++ b/macos/ReactTestApp/ViewController.swift
@@ -33,6 +33,8 @@ final class ViewController: NSViewController {
         )
     }
 
+    #endif // !ENABLE_SINGLE_APP_MODE
+
     override func mouseDown(with event: NSEvent) {
         NSMenu.popUpReactMenu(with: event, for: view)
     }
@@ -40,11 +42,20 @@ final class ViewController: NSViewController {
     override func rightMouseDown(with event: NSEvent) {
         NSMenu.popUpReactMenu(with: event, for: view)
     }
-
-    #endif // !ENABLE_SINGLE_APP_MODE
 }
 
-#if !ENABLE_SINGLE_APP_MODE
+// Hosts a React Native root view. The Fabric root view does not implement
+// `menuForEvent:`, so right-click events propagate up the responder chain to
+// this controller, which presents the React menu as a context menu.
+final class HostingViewController: NSViewController {
+    override func mouseDown(with event: NSEvent) {
+        NSMenu.popUpReactMenu(with: event, for: view)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        NSMenu.popUpReactMenu(with: event, for: view)
+    }
+}
 
 extension NSMenu {
     static func popUpReactMenu(with event: NSEvent, for view: NSView) {
@@ -55,6 +66,8 @@ extension NSMenu {
         popUpContextMenu(reactMenu, with: event, for: view)
     }
 }
+
+#if !ENABLE_SINGLE_APP_MODE
 
 final class Label: NSTextView {
     init(text: String) {


### PR DESCRIPTION
## Summary

On the new architecture, right-clicking inside the React content of the macOS test app shows nothing. On the old architecture, `RCTRootView.menuForEvent:` returns the dev menu, but the Fabric root view (`RCTSurfaceHostingProxyRootView`) does not override `menuForEvent:`, so the menu never appears.

This adds a small `HostingViewController` that overrides `mouseDown` / `rightMouseDown` to pop up the React menu, and:

- Uses it as the wrapper view controller in `AppDelegate.present()` (multi-app mode, after a component is presented).
- Ungates the existing handlers on `ViewController` so they also fire in `ENABLE_SINGLE_APP_MODE`, where the storyboard-instantiated `ViewController` is in the responder chain above the React root view.

The `popUpReactMenu` helper is moved out of the `#if !ENABLE_SINGLE_APP_MODE` guard so it is available in single-app mode too.

## Relationship to microsoft/rnx-kit#4114

This is the **self-contained workaround** of a pair. The underlying root cause — that consumers of `host.viewWithModuleName:` bypass `RCTRootViewFactory` and so the upstream `devMenu` wiring on `RCTSurfaceHostingView` (react-native-macos 0.81+) never runs — is fixed properly in microsoft/rnx-kit#4114. That PR makes `@rnx-kit/react-native-host` set `devMenu` on 0.81+ and installs a fallback gesture recognizer on older versions, so the upstream **React Native** dev menu (Reload, Open Debugger, …) shows on secondary-click without the test app needing to do anything.

The two PRs differ in what menu they show:

- **This PR** shows the test app's own React menu (component picker + Load From Dev Server + …).
- **microsoft/rnx-kit#4114** shows the standard RN dev menu.

Once microsoft/rnx-kit#4114 lands, is published, and the test app bumps `@rnx-kit/react-native-host`, this workaround can be removed in favor of the upstream behavior — or kept if we prefer the test app's richer React menu over the bare RN dev menu. They will conflict if both are active, since the rnx-kit gesture recognizer fires before the responder chain reaches `HostingViewController`, so this should be removed at the same commit that picks up the new rnx-kit version.

## Test plan

- [ ] Right-click the React content on macOS, new architecture, single-app mode → React menu pops up.
- [ ] Right-click the React content on macOS, new architecture, multi-app mode (after a component is presented) → React menu pops up.
- [ ] Empty initial state in multi-app mode still shows the React menu on click as before.
- [ ] Old architecture continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)