### PR TITLE
fix: declare support for 0.86

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -123,7 +123,7 @@
     "@callstack/react-native-visionos": "0.76 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.2 - 19.2",
-    "react-native": "0.76 - 0.85 || >=0.85.0-0 <0.86.0",
+    "react-native": "0.76 - 0.86 || >=0.86.0-0 <0.87.0",
     "react-native-macos": "^0.0.0-0 || 0.76 - 0.81",
     "react-native-windows": "^0.0.0-0 || 0.76 - 0.82"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13028,7 +13028,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.2 - 19.2
-    react-native: 0.76 - 0.85 || >=0.85.0-0 <0.86.0
+    react-native: 0.76 - 0.86 || >=0.86.0-0 <0.87.0
     react-native-macos: ^0.0.0-0 || 0.76 - 0.81
     react-native-windows: ^0.0.0-0 || 0.76 - 0.82
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declares support for React Native 0.86

Resolves #2751.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```sh
cd packages/app
node --run test:matrix -- 0.86
```

| Android | iOS  |
| :-----: | :--: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/32bdf412-43b8-461f-b0d3-2f6328498677" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/16f44108-d02d-4950-b067-9e8e484723c3" /> |