### PR TITLE
fix(apple): don't compile bridge code in bridgeless mode

### DIFF
--- a/packages/app/ReactTestApp-DevSupport.podspec
+++ b/packages/app/ReactTestApp-DevSupport.podspec
@@ -17,6 +17,7 @@ end
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 version = package['version']
+preprocessor_definitions = ENV['USE_BRIDGELESS'] == '1' ? ['USE_BRIDGELESS=1'] : []
 
 Pod::Spec.new do |s|
   s.name      = File.basename(__FILE__, '.podspec')
@@ -37,6 +38,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
     'DEFINES_MODULE' => 'YES',
+    'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
+    'CPP_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions,
     'SWIFT_OBJC_BRIDGING_HEADER' =>
       'ios/ReactTestApp/Public/ReactTestApp-DevSupport-Bridging-Header.h',
   }

--- a/packages/app/example/ios/Podfile.lock
+++ b/packages/app/example/ios/Podfile.lock
@@ -1819,7 +1819,7 @@ PODS:
     - React-utils (= 0.85.1)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.1)
-  - ReactNativeHost (0.5.16):
+  - ReactNativeHost (0.5.17):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2189,8 +2189,8 @@ SPEC CHECKSUMS:
   ReactCodegen: 1663f3db0221878329f993847de1c422d6af5e3c
   ReactCommon: 66763e5bd1b778828ff6cb82d771b7162a5215c2
   ReactNativeDependencies: 8cbd0fbc0255c3949672a00a81fc8d60a29dcfd9
-  ReactNativeHost: 60fee0812001bb7fe6b917c3bd75744c05034950
-  ReactTestApp-DevSupport: 356dd447fab548be5afb29613df2a18a1dfe7ec7
+  ReactNativeHost: bfc03f71af9ea8533b3f77493ca49d6c40093397
+  ReactTestApp-DevSupport: aeb3fe7bc1b2916413ac41309a70a0df7475f8a5
   ReactTestApp-Resources: 1bd9ff10e4c24f2ad87101a32023721ae923bccf
   RNWWebStorage: e01ec77abc9866d80b0c1b0d57914cce11ab747b
   Yoga: b1085f68c014785350a2afdc95eaef0d49f23ccb

--- a/packages/app/ios/ReactTestApp/AppRegistryModule.mm
+++ b/packages/app/ios/ReactTestApp/AppRegistryModule.mm
@@ -2,17 +2,21 @@
 
 #import <jsi/jsi.h>
 
+#if !USE_BRIDGELESS
 #import <React/RCTBridge.h>
+#endif  // !USE_BRIDGELESS
 
 #import "AppRegistry.h"
 #import "ReactTestApp-DevSupport.h"
 
 using facebook::jsi::Runtime;
 
+#if !USE_BRIDGELESS
 @interface RCTCxxBridge : RCTBridge
 @property (nonatomic, readonly) void *runtime;
 - (void)invokeAsync:(std::function<void()> &&)func;
 @end
+#endif  // !USE_BRIDGELESS
 
 void RTAPostDidRegisterAppsNotification(NSValue *value)
 {
@@ -32,6 +36,7 @@ void RTAPostDidRegisterAppsNotification(NSValue *value)
                                                     userInfo:@{@"appKeys": [array copy]}];
 }
 
+#if !USE_BRIDGELESS
 void RTAPostDidRegisterAppsNotificationWithBridge(id bridge)
 {
     if (![bridge isKindOfClass:[RCTCxxBridge class]] ||
@@ -50,3 +55,4 @@ void RTAPostDidRegisterAppsNotificationWithBridge(id bridge)
         RTAPostDidRegisterAppsNotification([NSValue valueWithPointer:runtime]);
     }];
 }
+#endif  // !USE_BRIDGELESS

--- a/packages/app/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
+++ b/packages/app/ios/ReactTestApp/Public/ReactTestApp-DevSupport.h
@@ -26,6 +26,9 @@ OBJC_EXTERN NSNotificationName const ReactTestAppSceneDidOpenURLNotification
 OBJC_EXTERN NSNotificationName const ReactInstanceDidLoadBundle;
 
 OBJC_EXTERN void RTAPostDidRegisterAppsNotification(NSValue *runtime);
+
+#if !USE_BRIDGELESS
 OBJC_EXTERN void RTAPostDidRegisterAppsNotificationWithBridge(id bridge);
+#endif  // !USE_BRIDGELESS
 
 NS_ASSUME_NONNULL_END

--- a/packages/app/ios/ReactTestApp/ReactInstance.swift
+++ b/packages/app/ios/ReactTestApp/ReactInstance.swift
@@ -219,9 +219,11 @@ final class ReactInstance: NSObject, RNXHostConfig {
             #endif
         }
 
+        #if !USE_BRIDGELESS
         if let bridge = notification.userInfo?["bridge"] {
             RTAPostDidRegisterAppsNotificationWithBridge(bridge)
         }
+        #endif // !USE_BRIDGELESS
     }
 
     @objc

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@isaacs/cliui": "^9.0.0",
-    "@rnx-kit/react-native-host": "^0.5.15",
+    "@rnx-kit/react-native-host": "^0.5.17",
     "@rnx-kit/tools-react-native": "^2.1.0",
     "ajv": "^8.0.0",
     "fast-xml-parser": "^5.7.0",

--- a/packages/example-macos/macos/Podfile.lock
+++ b/packages/example-macos/macos/Podfile.lock
@@ -2259,7 +2259,7 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
-  - ReactNativeHost (0.5.16):
+  - ReactNativeHost (0.5.17):
     - boost
     - DoubleConversion
     - fast_float
@@ -2636,10 +2636,10 @@ SPEC CHECKSUMS:
   React-timing: 6fa0e6755deb2a960c61e4589c28475e654d2c35
   React-utils: 88c9727bb85bc5a1a0630370a1ff9ba0b4da21ae
   ReactAppDependencyProvider: dddd83e92ff2e76331e033a983785f1f242e0485
-  ReactCodegen: 6ad42e680f38b7c2b12fc083db2a709e8e8c4643
+  ReactCodegen: b71171467ffb01846451b0fa0ac5b207741f1a96
   ReactCommon: 2024e8fc1841d1e289c5bc5b26aaf0e6ced45142
-  ReactNativeHost: ba9bdd449af5c793d28ff2610c1bec3015d014cc
-  ReactTestApp-DevSupport: 356dd447fab548be5afb29613df2a18a1dfe7ec7
+  ReactNativeHost: 66a23d7106b451f1a1087f565a45c839abef1e73
+  ReactTestApp-DevSupport: 4d0b86847c5f7fffa0f09479443be7a2420d19a4
   ReactTestApp-Resources: 71a3155bca10819738469de1f161410f43528209
   RNWWebStorage: 8ec03f8288c1e212518f662f44ec223603bbe74c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,12 +4496,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.5.15":
-  version: 0.5.16
-  resolution: "@rnx-kit/react-native-host@npm:0.5.16"
+"@rnx-kit/react-native-host@npm:^0.5.17":
+  version: 0.5.17
+  resolution: "@rnx-kit/react-native-host@npm:0.5.17"
   peerDependencies:
     react-native: ">=0.66"
-  checksum: 10c0/346aa558a9fbe1e36c544ddcd2e85b1f111dec1250700e3a2326d3c171f33fed1e7f4f7291bbc6bc0dcbb81c648261cb872ff334d7d970684ae05d92e84ba0d3
+  checksum: 10c0/e9ab5c489758274def1d910c1f6855aeb04b8b8c4e17d71ea195f252dc1416f7dc29e743797532f80ab65dd6f4c8c596fbccc29df820c093c658b104b8d52a1c
   languageName: node
   linkType: hard
 
@@ -12992,7 +12992,7 @@ __metadata:
     "@react-native-community/cli-types": "npm:^20.1.0"
     "@react-native-community/template": "npm:^0.85.0"
     "@rnx-kit/lint-lockfile": "npm:^0.1.0"
-    "@rnx-kit/react-native-host": "npm:^0.5.15"
+    "@rnx-kit/react-native-host": "npm:^0.5.17"
     "@rnx-kit/tools-react-native": "npm:^2.1.0"
     "@rnx-kit/tsconfig": "npm:^3.0.1"
     "@types/js-yaml": "npm:^4.0.5"


### PR DESCRIPTION
### Description

Don't include bridge code in bridgeless mode.

See build failure: https://github.com/microsoft/react-native-test-app/actions/runs/26077758296/job/76672204311

### Platforms affected

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd packages/app
node --run set-react-version -- nightly
yarn
cd example
pod install --directory=ios
yarn ios
```

### Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 15 48 18" src="https://github.com/user-attachments/assets/254b3e32-6973-43a9-93e5-0565db2e4309" />
