### PR TITLE
chore: use `@rnx-kit/tools-git`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@rnx-kit/align-deps": "^3.4.5",
     "@rnx-kit/lint-lockfile": "^0.1.0",
     "@rnx-kit/oxlint-config": "^1.0.3",
+    "@rnx-kit/tools-git": "^0.1.1",
     "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.8",
     "@types/js-yaml": "^4.0.5",

--- a/scripts/affected.mts
+++ b/scripts/affected.mts
@@ -1,6 +1,6 @@
+import { getBaseCommit, getChangedFiles, git } from "@rnx-kit/tools-git";
 import yaml from "js-yaml";
 import { Minimatch } from "minimatch";
-import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 
 type MatchChangedFiles = { "any-glob-to-any-file": string[] };
@@ -11,63 +11,6 @@ type Match = { "changed-files": MatchChangedFiles[] };
  */
 function clean(platforms: string[]): string[] {
   return platforms.map((p) => p.toLowerCase()).sort();
-}
-
-/**
- * Executes a Git command.
- */
-function git(...args: string[]): string {
-  const { stderr, stdout } = spawnSync("git", args);
-  const message = stderr.toString().trim();
-  if (message) {
-    console.error(message);
-  }
-  return stdout.toString().trim();
-}
-
-/**
- * Returns the default Git branch.
- */
-function getDefaultBranch(): string {
-  if (process.env["CI"]) {
-    // CIs don't clone the repo, but use a different way to checkout a branch.
-    // This means that `origin/HEAD` is never created, which in turn means that
-    // we don't have a reliable way to get the default branch. For now, just
-    // return a hard-coded value.
-    return "origin/trunk";
-  }
-
-  const defaultBranch = git("rev-parse", "--abbrev-ref", "origin/HEAD");
-  if (!defaultBranch) {
-    throw new Error("Failed to determine default branch");
-  }
-  return defaultBranch;
-}
-
-/**
- * Returns the commit from which this branch was forked.
- */
-function getBaseCommit(targetBranch: string | undefined): string {
-  targetBranch =
-    !targetBranch || targetBranch.endsWith("/")
-      ? getDefaultBranch()
-      : targetBranch;
-  const base = git("merge-base", "--fork-point", targetBranch);
-  if (!base) {
-    console.error("❌", "Failed to determine base commit");
-  }
-  return base;
-}
-
-/**
- * Returns changed files since fork point.
- */
-function getChangedFiles(since: string): string[] {
-  const changedFiles = git("diff", "--name-only", since);
-  if (!changedFiles) {
-    return [];
-  }
-  return changedFiles.split("\n");
 }
 
 /**
@@ -105,7 +48,7 @@ function makeMatchers(): Record<string, Minimatch[]> {
 function getAffectedPlatforms(targetBranch: string | undefined): string[] {
   const platformMatchers = makeMatchers();
 
-  const baseCommit = getBaseCommit(targetBranch);
+  const baseCommit = getBaseCommit(targetBranch, "origin/trunk");
   if (!baseCommit) {
     // Match all platforms if we cannot find base commit
     return clean(Object.keys(platformMatchers));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,7 @@ __metadata:
     "@rnx-kit/align-deps": "npm:^3.4.5"
     "@rnx-kit/lint-lockfile": "npm:^0.1.0"
     "@rnx-kit/oxlint-config": "npm:^1.0.3"
+    "@rnx-kit/tools-git": "npm:^0.1.1"
     "@swc-node/register": "npm:^1.11.1"
     "@swc/core": "npm:^1.15.8"
     "@types/js-yaml": "npm:^4.0.5"
@@ -4547,6 +4548,13 @@ __metadata:
     memfs:
       optional: true
   checksum: 10c0/397f3e521b581da733aba81b59f2a084766904f52c063e4f1d153f9972861d6061eae3ddab3b340ffa2ce8971df9a8483e9a8e3cc9d50d7e33ab64f212fe91ac
+  languageName: node
+  linkType: hard
+
+"@rnx-kit/tools-git@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@rnx-kit/tools-git@npm:0.1.1"
+  checksum: 10c0/d672aa911d212a200cd593cf680fa316adc9cd221a26feac5f5fb055d5a4857d6c1f9356d8b027ea2a124eb7d24ba53416ccd373b0707a14f96f6586056658d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Git convenience helpers have been extracted to `@rnx-kit/tools-git`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a