### PR TITLE
fix(template): use locally installed schema for `app.json`

### DIFF
--- a/packages/app/example/app.json
+++ b/packages/app/example/app.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
+  "$schema": "./node_modules/react-native-test-app/schema.json",
   "name": "Example",
   "displayName": "Example",
   "components": [

--- a/packages/app/test/embed-manifest/fixtures.mts
+++ b/packages/app/test/embed-manifest/fixtures.mts
@@ -1,6 +1,5 @@
 export const simple = {
-  $schema:
-    "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
+  $schema: "./node_modules/react-native-test-app/schema.json",
   name: "Example",
   displayName: "Template",
   version: "1.0",

--- a/packages/example-macos/app.json
+++ b/packages/example-macos/app.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
+  "$schema": "./node_modules/react-native-test-app/schema.json",
   "name": "Example",
   "displayName": "Example",
   "components": [

--- a/packages/example-windows/app.json
+++ b/packages/example-windows/app.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
+  "$schema": "./node_modules/react-native-test-app/schema.json",
   "name": "Example",
   "displayName": "Example",
   "components": [


### PR DESCRIPTION
### Description

Use locally installed schema for `app.json`. The URL has been invalid ever since we migrated to a monorepo.

Switching to the locally installed one to avoid confusion if users are on an older version, and because editors (e.g. VS Code) no longer read random schemas from the web.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a