### PR TITLE
fix(android): update to match `ReactNativeHost` migration to Kotlin

### DIFF
--- a/packages/app/android/app/src/reacthost-0.76/java/com/microsoft/reacttetapp/react/MainReactNativeHost.kt
+++ b/packages/app/android/app/src/reacthost-0.76/java/com/microsoft/reacttetapp/react/MainReactNativeHost.kt
@@ -26,7 +26,7 @@ class MainReactNativeHost(
     private val reactBundleNameProvider: ReactBundleNameProvider
 ) : com.microsoft.reacttestapp.compat.ReactNativeHostCompat(application) {
     val jsExecutorName: String
-        get() = javaScriptExecutorFactory.toString()
+        get() = getJavaScriptExecutorFactory().toString()
 
     var source: BundleSource =
         if (reactBundleNameProvider.bundleName == null || isPackagerRunning(application)) {
@@ -36,6 +36,9 @@ class MainReactNativeHost(
         }
 
     var onBundleSourceChanged: ((newSource: BundleSource) -> Unit)? = null
+
+    private val application
+        get() = getApplication() as TestApp
 
     private var currentActivityTracker = CurrentActivityTracker()
 
@@ -54,7 +57,7 @@ class MainReactNativeHost(
         beforeReactNativeInit()
 
         if (BuildConfig.REACTAPP_USE_BRIDGELESS) {
-            val reactHost = (application as TestApp).reactHost
+            val reactHost = application.reactHost
             reactHost.addReactInstanceEventListener(object : ReactInstanceEventListener {
                 override fun onReactContextInitialized(context: ReactContext) {
                     // proactively removing the listener to avoid leaking memory


### PR DESCRIPTION
### Description


Updated to match `ReactNativeHost` migration to Kotlin: https://github.com/facebook/react-native/commit/7eb11331b670b83fa7b7a7ae194313848d72d0e6

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

These changes are backwards compatible. To test nightly, cherry-pick #2791 and run:

```
cd packages/app
node --run set-react-version -- nightly
yarn
cd example/android
./gradlew assembleDebug
```