### PR TITLE
ci: use `macos-26` runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       pull-requests: write # create code reviews (suggestion-bot)
     strategy:
       matrix:
-        runner: [macos-15, windows-2025]
+        runner: [macos-26, windows-2025]
     runs-on: ${{ matrix.runner }}
     if: ${{ github.event_name != 'schedule' }}
     steps:
@@ -157,7 +157,7 @@ jobs:
   ios:
     name: "iOS"
     permissions: {}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -170,7 +170,6 @@ jobs:
           platform: ios
           project-root: packages/app/example
           cache-key-prefix: example
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -212,7 +211,7 @@ jobs:
   ios-template:
     name: "iOS [template]"
     permissions: {}
-    runs-on: macos-15
+    runs-on: macos-26
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
@@ -226,7 +225,6 @@ jobs:
           platform: ios
           project-root: packages/app/example
           cache-key-prefix: template-${{ matrix.template }}
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -359,7 +357,6 @@ jobs:
           platform: macos
           project-root: packages/example-macos
           cache-key-prefix: example
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@canary
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -415,7 +412,6 @@ jobs:
           platform: macos
           project-root: packages/app/example
           cache-key-prefix: template-${{ matrix.template }}
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:
@@ -458,7 +454,6 @@ jobs:
           platform: visionos
           project-root: packages/app/example
           cache-key-prefix: example
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Set up react-native@nightly
         if: ${{ github.event_name == 'schedule' }}
         uses: ./.github/actions/setup-react-native
@@ -509,7 +504,6 @@ jobs:
           platform: visionos
           project-root: packages/app/example
           cache-key-prefix: template-${{ matrix.template }}
-          xcode-developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
       - name: Initialize test app
         uses: ./.github/actions/init-test-app
         with:

--- a/packages/app/example/ios/Podfile.lock
+++ b/packages/app/example/ios/Podfile.lock
@@ -1365,7 +1365,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-safe-area-context (5.6.2):
+  - react-native-safe-area-context (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1377,8 +1377,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.2)
-    - react-native-safe-area-context/fabric (= 5.6.2)
+    - react-native-safe-area-context/common (= 5.8.0)
+    - react-native-safe-area-context/fabric (= 5.8.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1389,7 +1389,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/common (5.6.2):
+  - react-native-safe-area-context/common (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1411,7 +1411,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.2):
+  - react-native-safe-area-context/fabric (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2154,7 +2154,7 @@ SPEC CHECKSUMS:
   React-logger: 4e7583fb51ef2aa76b298c88e1b9a5cff83e03f7
   React-Mapbuffer: 820bc13d35de93c05aacefb3ab43f061b247c64e
   React-microtasksnativemodule: d8115c4d1035b8671c036a47d82fe75d1ca44e44
-  react-native-safe-area-context: 91a90d98c310adcc90a511e5aeb6046d7c19d885
+  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
   React-NativeModulesApple: 647d3ab78e02b3a40fedffd856744215219ff0a6
   React-networking: 8d40769c4823a7e26ae98ca5cd691edc87828743
   React-oscompat: 934d246490699f24fb70bbc5ca0da7e6808ab80c

--- a/packages/example-macos/macos/Podfile.lock
+++ b/packages/example-macos/macos/Podfile.lock
@@ -1752,7 +1752,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-safe-area-context (5.6.2):
+  - react-native-safe-area-context (5.8.0):
     - React-Core
   - React-NativeModulesApple (0.81.5):
     - boost
@@ -2607,7 +2607,7 @@ SPEC CHECKSUMS:
   React-logger: 9442588f7670879b2230ab687eb84a65fabdf3ad
   React-Mapbuffer: 269c4f1441f8504198d0539481040213b54d18bc
   React-microtasksnativemodule: 6edd5d6c59121753a066cc0de179088ac07ba453
-  react-native-safe-area-context: 6c8805194166a9d6b3e53ba69ca76756c9bfb052
+  react-native-safe-area-context: 700f3e707470d3cef056231541c77df29a5f0d9e
   React-NativeModulesApple: c458b7ad1d4bd52fec401d4f571a765441a19adf
   React-oscompat: fae6f20685a2116163b0086b28191f8df2d1e5b8
   React-perflogger: 93c7f304c7243e276bcb165ec143a659ac41b7bc


### PR DESCRIPTION
### Description

Trying out `macos-26` runners

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a