### PR TITLE
feat: bump minimum Node version to 20.19

### DIFF
--- a/packages/app/android/template.config.mjs
+++ b/packages/app/android/template.config.mjs
@@ -1,0 +1,49 @@
+// @ts-check
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import { findFile } from "../scripts/helpers.js";
+import { generateAndroidManifest } from "./android-manifest.js";
+import { configureGradleWrapper } from "./gradle-wrapper.js";
+
+/** @import { ProjectConfig, ProjectParams } from "../scripts/types.js"; */
+
+/**
+ * @returns {string | undefined}
+ */
+export function getAndroidPackageName() {
+  return "com.microsoft.reacttestapp";
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {Required<ProjectConfig>["android"]} config
+ * @returns {ProjectParams["android"] | undefined}
+ */
+export function configure(
+  projectRoot,
+  { packageName, sourceDir },
+  fs = nodefs
+) {
+  const manifestPath = path.join(
+    "app",
+    "build",
+    "generated",
+    "rnta",
+    "src",
+    "main",
+    "AndroidManifest.xml"
+  );
+  const appManifestPath = findFile("app.json", projectRoot, fs);
+  if (appManifestPath) {
+    const output = path.resolve(projectRoot, sourceDir, manifestPath);
+    generateAndroidManifest(appManifestPath, output, fs);
+  }
+
+  configureGradleWrapper(sourceDir, fs);
+
+  return {
+    sourceDir,
+    manifestPath,
+    packageName: packageName || getAndroidPackageName(),
+  };
+}

--- a/packages/app/ios/template.config.mjs
+++ b/packages/app/ios/template.config.mjs
@@ -1,0 +1,13 @@
+// @ts-check
+import * as nodefs from "node:fs";
+
+/** @import { ProjectConfig, ProjectParams } from "../scripts/types.js"; */
+
+/**
+ * @param {string} _projectRoot
+ * @param {Required<ProjectConfig>["ios"]} config
+ * @returns {ProjectParams["ios"] | undefined}
+ */
+export function configure(_projectRoot, config, _fs = nodefs) {
+  return config;
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,6 +42,7 @@
     "android/autolink.mjs",
     "android/gradle-wrapper.js",
     "android/support/src",
+    "android/template.config.mjs",
     "common",
     "example/_gitignore",
     "example/android/gradle",
@@ -141,7 +142,7 @@
     }
   },
   "engines": {
-    "node": ">=18.12"
+    "node": ">=20.19.4"
   },
   "defaultPlatformPackages": {
     "android": "react-native",

--- a/packages/app/scripts/configure-projects.js
+++ b/packages/app/scripts/configure-projects.js
@@ -9,9 +9,15 @@
  */
 const nodefs = require("node:fs");
 const path = require("node:path");
-const { generateAndroidManifest } = require("../android/android-manifest");
-const { configureGradleWrapper } = require("../android/gradle-wrapper");
-const { findFile, findNearest, readTextFile } = require("./helpers");
+const {
+  configure: configureAndroid,
+  getAndroidPackageName,
+} = require("../android/template.config.mjs");
+const { configure: configureIOS } = require("../ios/template.config.mjs");
+const {
+  configure: configureWindows,
+} = require("../windows/template.config.mjs");
+const { findNearest } = require("./helpers");
 
 /**
  * Finds `react-native.config.[ts,mjs,cjs,js]`.
@@ -70,25 +76,6 @@ function findReactNativeConfig(fs = nodefs) {
 }
 
 /**
- * @returns {string | undefined}
- */
-function getAndroidPackageName() {
-  return "com.microsoft.reacttestapp";
-}
-
-/**
- * @param {string} solutionFile
- * @returns {ProjectParams["windows"]["project"]}
- */
-function windowsProjectPath(solutionFile, fs = nodefs) {
-  const sln = readTextFile(solutionFile, fs);
-  const m = sln.match(
-    /([^"]*?node_modules[/\\].generated[/\\]windows[/\\].*?\.vcxproj)/
-  );
-  return { projectFile: m ? m[1] : `(Failed to parse '${solutionFile}')` };
-}
-
-/**
  * @param {ProjectConfig} configuration
  * @returns {Partial<ProjectParams>}
  */
@@ -98,47 +85,15 @@ function configureProjects({ android, ios, windows }, fs = nodefs) {
   /** @type {Partial<ProjectParams>} */
   const config = {};
 
+  const projectRoot = path.dirname(reactNativeConfig);
   if (android) {
-    const { packageName, sourceDir } = android;
-    const manifestPath = path.join(
-      "app",
-      "build",
-      "generated",
-      "rnta",
-      "src",
-      "main",
-      "AndroidManifest.xml"
-    );
-    const projectRoot = path.dirname(reactNativeConfig);
-    const appManifestPath = findFile("app.json", projectRoot, fs);
-    if (appManifestPath) {
-      generateAndroidManifest(
-        appManifestPath,
-        path.resolve(projectRoot, sourceDir, manifestPath),
-        fs
-      );
-    }
-
-    config.android = {
-      sourceDir,
-      manifestPath,
-      packageName: packageName || getAndroidPackageName(),
-    };
-
-    configureGradleWrapper(sourceDir, fs);
+    config.android = configureAndroid(projectRoot, android, fs);
   }
-
   if (ios) {
-    config.ios = ios;
+    config.ios = configureIOS(projectRoot, ios, fs);
   }
-
-  if (windows && fs.existsSync(windows.solutionFile)) {
-    const { sourceDir, solutionFile } = windows;
-    config.windows = {
-      sourceDir,
-      solutionFile: path.relative(sourceDir, solutionFile),
-      project: windowsProjectPath(solutionFile, fs),
-    };
+  if (windows) {
+    config.windows = configureWindows(projectRoot, windows, fs);
   }
 
   return config;

--- a/packages/app/test/pack.test.mts
+++ b/packages/app/test/pack.test.mts
@@ -102,6 +102,7 @@ describe("npm pack", () => {
       "android/support/build.gradle",
       "android/support/src/main/AndroidManifest.xml",
       "android/support/src/main/java/com/microsoft/reacttestapp/support/ReactTestAppLifecycleEvents.java",
+      "android/template.config.mjs",
       "android/utils.gradle",
       "common/AppRegistry.cpp",
       "common/AppRegistry.h",
@@ -151,6 +152,7 @@ describe("npm pack", () => {
       "ios/localizations.mjs",
       "ios/pod_helpers.rb",
       "ios/privacyManifest.mjs",
+      "ios/template.config.mjs",
       "ios/test_app.rb",
       "ios/use_react_native-0.71.rb",
       "ios/utils.mjs",
@@ -317,6 +319,7 @@ describe("npm pack", () => {
       "windows/Win32/targetver.h",
       "windows/app.mjs",
       "windows/project.mjs",
+      "windows/template.config.mjs",
       "windows/uwp.mjs",
       "windows/win32.mjs",
     ]);

--- a/packages/app/tsconfig.cjs.json
+++ b/packages/app/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
+  "extends": "@rnx-kit/tsconfig/tsconfig.nodenext.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rnx-kit/tsconfig/tsconfig.node.json",
+  "extends": "@rnx-kit/tsconfig/tsconfig.nodenext.json",
   "compilerOptions": {
     "target": "esnext",
     "allowImportingTsExtensions": true,

--- a/packages/app/windows/template.config.mjs
+++ b/packages/app/windows/template.config.mjs
@@ -1,0 +1,37 @@
+// @ts-check
+import * as nodefs from "node:fs";
+import * as path from "node:path";
+import { readTextFile } from "../scripts/helpers.js";
+
+/** @import { ProjectConfig, ProjectParams } from "../scripts/types.js"; */
+
+/**
+ * @param {string} solutionFile
+ * @returns {ProjectParams["windows"]["project"]}
+ */
+function windowsProjectPath(solutionFile, fs = nodefs) {
+  const sln = readTextFile(solutionFile, fs);
+  const m = sln.match(
+    /([^"]*?node_modules[/\\].generated[/\\]windows[/\\].*?\.vcxproj)/
+  );
+  return { projectFile: m ? m[1] : `(Failed to parse '${solutionFile}')` };
+}
+
+/**
+ * @param {string} _projectRoot
+ * @param {Required<ProjectConfig>["windows"]} config
+ * @returns {ProjectParams["windows"] | undefined}
+ */
+export function configure(
+  _projectRoot,
+  { sourceDir, solutionFile },
+  fs = nodefs
+) {
+  return fs.existsSync(solutionFile)
+    ? {
+        sourceDir,
+        solutionFile: path.relative(sourceDir, solutionFile),
+        project: windowsProjectPath(solutionFile, fs),
+      }
+    : undefined;
+}


### PR DESCRIPTION
### Description

Moves platform specific configuration to a `template.config.mjs` under their respective folders.

This change bumps minimum Node version to 20.19 for require(esm). I'm making this a minor bump because I believe we should stop considering Node bumps as major breaking changes.

Part of #2211

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.