### PR TITLE
fix(windows): workaround for MSB4006 circular dependency in CppWinRT

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,6 +64,7 @@
           - packages/app/scripts/init.mjs
           - packages/app/scripts/template.mjs
           - packages/app/scripts/build/xcodebuild.sh
+          - packages/example-macos/**/*
 "platform: visionOS":
   - changed-files:
       - any-glob-to-any-file:
@@ -103,3 +104,4 @@
           - packages/app/scripts/init.mjs
           - packages/app/scripts/template.mjs
           - packages/app/windows/**/*
+          - packages/example-windows/**/*

--- a/.yarn/plugins/undo-bin-sorting.cjs
+++ b/.yarn/plugins/undo-bin-sorting.cjs
@@ -24,6 +24,7 @@ module.exports = {
     // @ts-expect-error Yarn internal package
     const { npath } = require("@yarnpkg/fslib");
     const fs = require("node:fs");
+    const { EOL } = require("node:os");
 
     const asText = /** @type {const} */ ({ encoding: "utf-8" });
 
@@ -67,10 +68,9 @@ module.exports = {
           for (let i = 0; i < length; ++i) {
             if (bin[i] !== orig_bin[i]) {
               manifest.bin = orig_manifest.bin;
-              const fd = fs.openSync(manifestPath, "w", 0o644);
-              fs.writeSync(fd, JSON.stringify(manifest, undefined, 2));
-              fs.writeSync(fd, "\n");
-              fs.closeSync(fd);
+              const serialized = JSON.stringify(manifest, undefined, 2);
+              const reverted = serialized.replace(/\r?\n/g, EOL) + EOL;
+              fs.writeFileSync(manifestPath, reverted, asText);
               break;
             }
           }

--- a/packages/app/windows/Win32/ReactApp.Package.wapproj
+++ b/packages/app/windows/Win32/ReactApp.Package.wapproj
@@ -10,7 +10,7 @@
     <BackgroundTaskDebugEngines>NativeOnly</BackgroundTaskDebugEngines>
   </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" />
   <PropertyGroup>

--- a/packages/app/windows/Win32/ReactApp.vcxproj
+++ b/packages/app/windows/Win32/ReactApp.vcxproj
@@ -3,6 +3,8 @@
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
+    <!-- Prevent MSB4006 circular dependency in CppWinRT during parallel builds (https://github.com/microsoft/cppwinrt/issues/950) -->
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{B44CEAD7-FBFF-4A17-95EA-FF5434BBD79D}</ProjectGuid>
     <ProjectName>ReactApp</ProjectName>


### PR DESCRIPTION
### Description

Adds the workaround for MSB4006 circular dependency in CppWinRT introduced in latest RNW templates.

Also ensures `app/package.json` is written with the correct newlines so Git doesn't think the file has changed.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a