### PR TITLE
ci(windows): downgrade runnders to `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,7 +529,7 @@ jobs:
   windows:
     name: "Windows"
     permissions: {}
-    runs-on: windows-2025
+    runs-on: windows-2022
     if: ${{ github.event_name != 'schedule' }}
     strategy:
       matrix:
@@ -598,7 +598,7 @@ jobs:
   windows-template:
     name: "Windows [template]"
     permissions: {}
-    runs-on: windows-2025
+    runs-on: windows-2022
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

GH decided to remove Visual Studio 2022 and replaced it with 2026 without any announcement and are asking people to downgrade their pipelines to 2022.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a