### PR TITLE
feat: load template config from external packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ".",
     "packages/app",
     "packages/app/example",
-    "packages/example-*"
+    "packages/example-*",
+    "packages/platform-*"
   ],
   "scripts": {
     "format": "nx run-many --target format:c,format:js,format:swift",
@@ -25,7 +26,7 @@
     "lint:commit": "git log --format='%s' origin/trunk..HEAD | tail -1 | npx @rnx-kit/commitlint-lite@2.0.0",
     "lint:js": "oxlint $(git ls-files 'scripts/*.[cm][jt]s' 'scripts/*.[jt]s')",
     "release-notes": "node scripts/release-notes.mts",
-    "rnx-align-deps": "rnx-align-deps --exclude-packages @microsoft/root,react-native-test-app",
+    "rnx-align-deps": "rnx-align-deps --exclude-packages @microsoft/root,@rnx-kit/react-native-template-web,react-native-test-app",
     "show-affected": "node scripts/affected.mts"
   },
   "devDependencies": {

--- a/packages/app/android/template.config.mjs
+++ b/packages/app/android/template.config.mjs
@@ -177,7 +177,7 @@ export function configure(
 }
 
 /**
- * @param {ConfigureParams}  params
+ * @param {ConfigureParams} params
  * @returns {Configuration}
  */
 export function getTemplate({ name, testAppPath, targetVersion }) {

--- a/packages/app/example/package.json
+++ b/packages/app/example/package.json
@@ -35,6 +35,7 @@
     "@rnx-kit/cli": "catalog:",
     "@rnx-kit/metro-config": "catalog:",
     "@rnx-kit/polyfills": "catalog:",
+    "@rnx-kit/react-native-template-web": "workspace:*",
     "@rnx-kit/tsconfig": "catalog:",
     "@types/react": "~19.2.0",
     "@wdio/types": "^9.20.0",

--- a/packages/app/ios/app.mjs
+++ b/packages/app/ios/app.mjs
@@ -115,7 +115,7 @@ function findReactNativePath(
 
   const manifestURL = new URL("../package.json", import.meta.url);
   const manifest = JSON.parse(readTextFile(fileURLToPath(manifestURL), fs));
-  const npmPackageName = manifest.defaultPlatformPackages[targetPlatform];
+  const npmPackageName = manifest.defaultPlatformPackages[targetPlatform]?.id;
   if (!npmPackageName) {
     throw new Error(`Unsupported target platform: ${targetPlatform}`);
   }

--- a/packages/app/ios/template.config.mjs
+++ b/packages/app/ios/template.config.mjs
@@ -48,7 +48,7 @@ export function configure(_projectRoot, config, _fs = nodefs) {
 }
 
 /**
- * @param {ConfigureParams}  params
+ * @param {ConfigureParams} params
  * @returns {Configuration}
  */
 export function getTemplate({ name, targetVersion }) {

--- a/packages/app/macos/template.config.mjs
+++ b/packages/app/macos/template.config.mjs
@@ -15,7 +15,7 @@ export function configure(_projectRoot, _config, _fs = nodefs) {
 }
 
 /**
- * @param {ConfigureParams}  params
+ * @param {ConfigureParams} params
  * @returns {Configuration}
  */
 export function getTemplate({ name, targetVersion }) {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -146,10 +146,25 @@
     "node": ">=20.19.4"
   },
   "defaultPlatformPackages": {
-    "android": "react-native",
-    "ios": "react-native",
-    "macos": "react-native-macos",
-    "visionos": "@callstack/react-native-visionos",
-    "windows": "react-native-windows"
+    "android": {
+      "id": "react-native",
+      "template": "./android/template.config.mjs"
+    },
+    "ios": {
+      "id": "react-native",
+      "template": "./ios/template.config.mjs"
+    },
+    "macos": {
+      "id": "react-native-macos",
+      "template": "./macos/template.config.mjs"
+    },
+    "visionos": {
+      "id": "@callstack/react-native-visionos",
+      "template": "./visionos/template.config.mjs"
+    },
+    "windows": {
+      "id": "react-native-windows",
+      "template": "./windows/template.config.mjs"
+    }
   }
 }

--- a/packages/app/scripts/configure.mjs
+++ b/packages/app/scripts/configure.mjs
@@ -11,17 +11,13 @@
  *   PlatformPackage,
  * } from "./types.js";
  */
+import { loadContext } from "@rnx-kit/tools-react-native/context";
 import * as nodefs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { URL, fileURLToPath } from "node:url";
 import semverCoerce from "semver/functions/coerce.js";
 import semverSatisfies from "semver/functions/satisfies.js";
-import { getTemplate as getAndroidTemplate } from "../android/template.config.mjs";
-import { getTemplate as getIOSTemplate } from "../ios/template.config.mjs";
-import { getTemplate as getMacOSTemplate } from "../macos/template.config.mjs";
-import { getTemplate as getVisionOSTemplate } from "../visionos/template.config.mjs";
-import { getTemplate as getWindowsTemplate } from "../windows/template.config.mjs";
 import {
   getPackageVersion,
   isMain,
@@ -104,6 +100,17 @@ export function mergeConfig(lhs, rhs) {
 }
 
 /**
+ * @param {string} root
+ * @param {string} subpath
+ * @returns {string | false}
+ */
+function resolvePath(root, subpath) {
+  const resolved = path.resolve(root, subpath);
+  const rel = path.relative(root, resolved);
+  return !path.isAbsolute(rel) && !rel.startsWith("..") && resolved;
+}
+
+/**
  * Sort the keys in specified object.
  * @param {Record<string, unknown>} obj
  */
@@ -140,9 +147,6 @@ export function validatePlatforms(input) {
       case "android":
       case "windows":
         break;
-
-      default:
-        throw new Error(`Unknown platform: ${p}`);
     }
   }
 
@@ -176,12 +180,8 @@ export function getDefaultPlatformPackageName(platform) {
   }
 
   const { defaultPlatformPackages } = readManifest();
-  const pkgName = defaultPlatformPackages[platform];
-  if (!pkgName) {
-    throw new Error(`Unsupported platform: ${platform}`);
-  }
-
-  return pkgName;
+  const pkg = defaultPlatformPackages[platform];
+  return pkg?.id;
 }
 
 /**
@@ -192,7 +192,7 @@ export function getDefaultPlatformPackageName(platform) {
  */
 export function getPlatformPackage(platform, targetVersion) {
   const packageName = getDefaultPlatformPackageName(platform);
-  if (packageName === "react-native") {
+  if (!packageName || packageName === "react-native") {
     return {};
   }
 
@@ -221,6 +221,50 @@ export function getPlatformPackage(platform, targetVersion) {
 export function reactNativeConfig({ name, testAppPath }, fs = nodefs) {
   const config = path.join(testAppPath, "example", "react-native.config.js");
   return readTextFile(config, fs).replaceAll("Example", name);
+}
+
+/**
+ * @param {ConfigureParams} params
+ * @param {NodeJS.Require} require
+ * @param {PlatformConfiguration} configuration
+ * @returns {PlatformConfiguration}
+ */
+function loadPlatformTemplates(params, require, configuration, fs = nodefs) {
+  const { packagePath, testAppPath } = params;
+  const { defaultPlatformPackages } = readManifest();
+  const platformPackages = { ...defaultPlatformPackages };
+
+  try {
+    const config = loadContext(packagePath);
+    for (const [, { root }] of Object.entries(config.dependencies)) {
+      const manifest = readJSONFile(path.join(root, "package.json"), fs);
+      const { reactNativeTemplateConfig: config } = manifest;
+      if (config && typeof config === "object" && !Array.isArray(config)) {
+        console.log(
+          "Loading template config:",
+          path.relative(packagePath, root)
+        );
+        for (const [key, { template, ...rest }] of Object.entries(config)) {
+          const resolved = resolvePath(root, template);
+          if (resolved) {
+            platformPackages[key] = { ...rest, template: resolved };
+          }
+        }
+      }
+    }
+  } catch (_) {
+    // If this was executed outside any projects, `@react-native-community/cli`
+    // will not be available and error here.
+  }
+
+  for (const [platform, { template }] of Object.entries(platformPackages)) {
+    const { getTemplate } = require(
+      template.startsWith(".") ? path.join(testAppPath + template) : template
+    );
+    configuration[platform] = getTemplate(params, fs);
+  }
+
+  return configuration;
 }
 
 /**
@@ -259,7 +303,7 @@ export const getConfig = (() => {
           path.dirname(require.resolve("react-native/template/package.json"))
         );
 
-      configuration = {
+      configuration = loadPlatformTemplates(params, require, {
         common: {
           files: {
             ".gitignore": findGitIgnore(path.join(testAppPath, "example"), fs),
@@ -292,12 +336,7 @@ export const getConfig = (() => {
           },
           dependencies: {},
         },
-        android: getAndroidTemplate(params),
-        ios: getIOSTemplate(params),
-        macos: getMacOSTemplate(params),
-        visionos: getVisionOSTemplate(params),
-        windows: getWindowsTemplate(params, fs),
-      };
+      });
     }
     return configuration[platform];
   };
@@ -322,7 +361,6 @@ export function gatherConfig(params, disableCache = false) {
 
         return mergeConfig(config, {
           ...platformConfig,
-          dependencies,
           files: Object.fromEntries(
             // Map each file into its platform specific folder, e.g.
             // `Podfile` -> `ios/Podfile`
@@ -334,13 +372,17 @@ export function gatherConfig(params, disableCache = false) {
           oldFiles: platformConfig.oldFiles.map((file) => {
             return path.join(platform, file);
           }),
+          dependencies: {
+            ...dependencies,
+            ...platformConfig.dependencies,
+          },
         });
       },
       /** @type {Configuration} */ ({
-        scripts: {},
-        dependencies: {},
         files: {},
         oldFiles: [],
+        scripts: {},
+        dependencies: {},
       })
     );
   })();

--- a/packages/app/scripts/internal/set-react-version.mts
+++ b/packages/app/scripts/internal/set-react-version.mts
@@ -214,7 +214,7 @@ async function getProfile(
         "react-native": coreVersion,
         "react-native-macos": "canary",
         "react-native-windows": undefined,
-        [visionos]: undefined,
+        [visionos.id]: undefined,
       };
     }
 
@@ -227,7 +227,7 @@ async function getProfile(
         "react-native": coreVersion,
         "react-native-macos": undefined,
         "react-native-windows": info.version,
-        [visionos]: undefined,
+        [visionos.id]: undefined,
       };
     }
 
@@ -239,7 +239,7 @@ async function getProfile(
         "react-native": "nightly",
         "react-native-macos": undefined,
         "react-native-windows": undefined,
-        [visionos]: undefined,
+        [visionos.id]: undefined,
       };
     }
 
@@ -251,7 +251,7 @@ async function getProfile(
           : fetchPackageInfo("react-native-macos", v),
         visionos: coreOnly
           ? Promise.resolve({ version: undefined })
-          : fetchPackageInfo(visionos, v),
+          : fetchPackageInfo(visionos.id, v),
         windows: coreOnly
           ? Promise.resolve({ version: undefined })
           : fetchPackageInfo("react-native-windows", v),
@@ -265,7 +265,7 @@ async function getProfile(
         "react-native": reactNative.version,
         "react-native-macos": await versions.macos.then(getVersion),
         "react-native-windows": await versions.windows.then(getVersion),
-        [visionos]: await versions.visionos.then(getVersion),
+        [visionos.id]: await versions.visionos.then(getVersion),
       };
     }
   }

--- a/packages/app/scripts/schema.mjs
+++ b/packages/app/scripts/schema.mjs
@@ -321,7 +321,7 @@ export function generateSchema(docs = {}) {
         type: "object",
         properties: {
           reactNativePath: {
-            description: `Sets a custom path to React Native. Useful for when \`require("${defaultPlatformPackages.ios}")\` does not return the desired path.`,
+            description: `Sets a custom path to React Native. Useful for when \`require("${defaultPlatformPackages.ios.id}")\` does not return the desired path.`,
             type: "string",
           },
         },
@@ -342,7 +342,7 @@ export function generateSchema(docs = {}) {
             type: "string",
           },
           reactNativePath: {
-            description: `Sets a custom path to React Native for macOS. Useful for when \`require("${defaultPlatformPackages.macos}")\` does not return the desired path.`,
+            description: `Sets a custom path to React Native for macOS. Useful for when \`require("${defaultPlatformPackages.macos.id}")\` does not return the desired path.`,
             type: "string",
           },
         },
@@ -353,7 +353,7 @@ export function generateSchema(docs = {}) {
         type: "object",
         properties: {
           reactNativePath: {
-            description: `Sets a custom path to React Native for visionOS. Useful for when \`require("${defaultPlatformPackages.visionos}")\` does not return the desired path.`,
+            description: `Sets a custom path to React Native for visionOS. Useful for when \`require("${defaultPlatformPackages.visionos.id}")\` does not return the desired path.`,
             type: "string",
           },
         },

--- a/packages/app/scripts/types.ts
+++ b/packages/app/scripts/types.ts
@@ -95,11 +95,7 @@ export type Configuration = {
 
 export type PlatformConfiguration = {
   common: Configuration;
-  android: Configuration;
-  ios: Configuration;
-  macos: Configuration;
-  visionos: Configuration;
-  windows: Configuration;
+  [platform: string]: Configuration;
 };
 
 export type PlatformPackage =
@@ -108,7 +104,13 @@ export type PlatformPackage =
   | "react-native-windows"
   | "@callstack/react-native-visionos";
 
-export type Platform = keyof PlatformConfiguration;
+export type Platform =
+  | "common"
+  | "android"
+  | "ios"
+  | "macos"
+  | "visionos"
+  | "windows";
 
 export type ConfigureParams = {
   name: string;
@@ -330,7 +332,10 @@ export type Manifest = Partial<{
   peerDependencies: Record<string, string>;
   devDependencies: Record<string, string | undefined>;
   resolutions: Record<string, string | undefined>;
-  defaultPlatformPackages: Record<string, PlatformPackage | undefined>;
+  defaultPlatformPackages: Record<
+    string,
+    { id: PlatformPackage; template: string }
+  >;
 }>;
 
 /***************************

--- a/packages/app/test/android/gradle.mts
+++ b/packages/app/test/android/gradle.mts
@@ -79,6 +79,8 @@ async function makeProject(
   try {
     const target = new URL("../../example/node_modules", import.meta.url);
     const nodeModulesDir = path.join(packagePath, "node_modules");
+    // `gatherConfig` writes to cache so we need to remove it first
+    rm_r(nodeModulesDir);
     fs.symlinkSync(fileURLToPath(target), nodeModulesDir, "dir");
   } catch (e) {
     if (e && typeof e === "object" && "code" in e && e.code !== "EEXIST") {

--- a/packages/app/test/configure/getConfig.test.mts
+++ b/packages/app/test/configure/getConfig.test.mts
@@ -1,4 +1,4 @@
-import { deepEqual } from "node:assert/strict";
+import { deepEqual, ok } from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
@@ -123,5 +123,16 @@ describe("getConfig()", () => {
       "Test.vcxproj",
       path.join("Test", "Test.vcxproj"),
     ]);
+  });
+
+  it("returns external platform specific scripts and additional files", () => {
+    const params = mockParams({ packagePath: "example" });
+    // @ts-expect-error unsupported platform
+    const config = getConfig(params, "web");
+
+    ok(config.files["index.html"]);
+    deepEqual(config.oldFiles, ["webpack.config.js"]);
+    ok(config.scripts["build:web"]);
+    ok(config.dependencies["react-native-web"]);
   });
 });

--- a/packages/app/test/configure/getPlatformPackage.test.mts
+++ b/packages/app/test/configure/getPlatformPackage.test.mts
@@ -56,7 +56,19 @@ describe("getPlatformPackage()", () => {
   });
 
   it("throws if target version is invalid", () => {
-    // @ts-expect-error intentional use of empty string to elicit an exception
-    throws(() => getPlatformPackage("", "version"));
+    throws(() => getPlatformPackage("macos", "version"));
+  });
+
+  it("returns an empty record for Android and iOS", () => {
+    for (const platform of ["common", "android", "ios"] as const) {
+      deepEqual(getPlatformPackage(platform, "version"), {});
+    }
+  });
+
+  it("returns an empty record for unsupported platforms", () => {
+    for (const platform of ["linux", "win32"] as const) {
+      // @ts-expect-error intentional use of unsupported platforms
+      deepEqual(getPlatformPackage(platform, "version"), {});
+    }
   });
 });

--- a/packages/app/visionos/template.config.mjs
+++ b/packages/app/visionos/template.config.mjs
@@ -15,7 +15,7 @@ export function configure(_projectRoot, _config, _fs = nodefs) {
 }
 
 /**
- * @param {ConfigureParams}  params
+ * @param {ConfigureParams} params
  * @returns {Configuration}
  */
 export function getTemplate({ name, targetVersion }) {

--- a/packages/app/windows/template.config.mjs
+++ b/packages/app/windows/template.config.mjs
@@ -45,7 +45,7 @@ export function configure(
 }
 
 /**
- * @param {ConfigureParams}  params
+ * @param {ConfigureParams} params
  * @returns {Configuration}
  */
 export function getTemplate({ name, testAppPath }, fs = nodefs) {

--- a/packages/platform-web/package.json
+++ b/packages/platform-web/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@rnx-kit/react-native-template-web",
+  "version": "0.0.1-dev",
+  "private": true,
+  "description": "Dummy package \"providing\" web support (used only for testing purposes)",
+  "keywords": [
+    "app",
+    "react",
+    "react-native",
+    "template",
+    "test-app",
+    "web"
+  ],
+  "homepage": "https://github.com/microsoft/react-native-test-app",
+  "license": "MIT",
+  "author": {
+    "name": "Microsoft Open Source",
+    "email": "microsoftopensource@users.noreply.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-test-app.git",
+    "directory": "packages/platform-web"
+  },
+  "files": [
+    "template.config.js",
+    "web"
+  ],
+  "type": "module",
+  "main": "template.config.js",
+  "engines": {
+    "node": ">=20.19.4"
+  },
+  "reactNativeTemplateConfig": {
+    "web": {
+      "template": "./template.config.js"
+    }
+  }
+}

--- a/packages/platform-web/template.config.js
+++ b/packages/platform-web/template.config.js
@@ -1,0 +1,33 @@
+// @ts-check
+import * as nodefs from "node:fs";
+
+/** @import { Configuration, ConfigureParams } from "../app/scripts/types.js"; */
+
+/**
+ * @param {string} _projectRoot
+ * @param {unknown} _config
+ * @returns {Record<string, unknown>}
+ */
+export function configure(_projectRoot, _config, _fs = nodefs) {
+  return { "@rnx-kit/react-native-template-web": true };
+}
+
+/**
+ * @param {ConfigureParams} _params
+ * @returns {Configuration}
+ */
+export function getTemplate(_params) {
+  return {
+    files: {
+      "index.html": "<!doctype html><html></html>",
+    },
+    oldFiles: ["webpack.config.js"],
+    scripts: {
+      "build:web":
+        "react-native bundle --entry-file index.js --platform web --dev true --bundle-output dist/main.web.jsbundle --assets-dest dist",
+    },
+    dependencies: {
+      "react-native-web": "^0.21.2",
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,6 +4477,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rnx-kit/react-native-template-web@workspace:*, @rnx-kit/react-native-template-web@workspace:packages/platform-web":
+  version: 0.0.0-use.local
+  resolution: "@rnx-kit/react-native-template-web@workspace:packages/platform-web"
+  languageName: unknown
+  linkType: soft
+
 "@rnx-kit/third-party-notices@npm:^3.0.0":
   version: 3.0.0
   resolution: "@rnx-kit/third-party-notices@npm:3.0.0"
@@ -8323,6 +8329,7 @@ __metadata:
     "@rnx-kit/cli": "catalog:"
     "@rnx-kit/metro-config": "catalog:"
     "@rnx-kit/polyfills": "catalog:"
+    "@rnx-kit/react-native-template-web": "workspace:*"
     "@rnx-kit/tsconfig": "catalog:"
     "@types/react": "npm:~19.2.0"
     "@wdio/types": "npm:^9.20.0"


### PR DESCRIPTION
### Description

Allows initializing and configuring existing apps to support additional platforms provided by external packages.

Part of #2211.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Configure example app to add web support:

```sh
cd packages/app/example
node ../scripts/configure.mjs -p web --force
```

Verify that:

- A `build:web` script was added to `package.json`
- `react-native-web` was added under `dependencies`
- `web/index.html` was created 