### PR TITLE
ci(windows): document how to enable property tracking during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -573,6 +573,10 @@ jobs:
       - name: Build
         id: build
         if: ${{ steps.affected.outputs.windows != '' }}
+        env:
+          # Enable this when debugging Windows builds:
+          # https://github.com/dotnet/msbuild/blob/main/documentation/Property-tracking-capabilities.md
+          MSBuildLogPropertyTracking: 0
         run: |
           if ("${{ matrix.configuration }}" -eq "Release") {
             yarn ci:windows --release --arch ${{ matrix.platform }}


### PR DESCRIPTION
### Description

Document how to enable property tracking during build. This is just for future reference. For performance reasons, we don't enable it by default.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [x] Windows

### Test plan

n/a