### PR TITLE
fix: fix template config paths not being resolved correctly

### DIFF
--- a/packages/app/scripts/configure.mjs
+++ b/packages/app/scripts/configure.mjs
@@ -258,9 +258,10 @@ function loadPlatformTemplates(params, require, configuration, fs = nodefs) {
   }
 
   for (const [platform, { template }] of Object.entries(platformPackages)) {
-    const { getTemplate } = require(
-      template.startsWith(".") ? path.join(testAppPath + template) : template
-    );
+    const templatePath = template.startsWith(".")
+      ? path.resolve(testAppPath, template)
+      : template;
+    const { getTemplate } = require(templatePath);
     configuration[platform] = getTemplate(params, fs);
   }
 


### PR DESCRIPTION
### Description

Fixed template config paths not being resolved correctly

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a