### PR TITLE
chore: bump TypeScript to 7.0 RC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
             git diff --exit-code
             yarn lint:js
           fi
-          yarn tsgo
+          yarn tsc
           yarn test:js
         shell: bash
         working-directory: packages/app

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nx": "^22.0.0",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.51.0",
-    "typescript": "^6.0.0"
+    "typescript": "^7.0.1-0"
   },
   "resolutions": {
     "@appium/base-driver/axios": "^1.15.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
     "generate:code": "node scripts/internal/generate-manifest.mts",
     "generate:docs": "node scripts/internal/generate-manifest-docs.mts",
     "generate:schema": "node scripts/internal/generate-schema.mts",
-    "lint:js": "oxlint -c ../../oxlint.config.ts $(git ls-files '*.[cm][jt]s' '*.[jt]s' '*.tsx' ':!:*.config.js') && tsgo && tsgo --project tsconfig.cjs.json",
+    "lint:js": "oxlint -c ../../oxlint.config.ts $(git ls-files '*.[cm][jt]s' '*.[jt]s' '*.tsx' ':!:*.config.js') && tsc && tsc --project tsconfig.cjs.json",
     "lint:kt": "ktlint --relative 'android/app/src/**/*.kt'",
     "lint:rb": "bundle exec rubocop",
     "lint:swift": "swiftlint",
@@ -110,7 +110,6 @@
     "@types/prompts": "~2.4.0",
     "@types/react": "~19.2.0",
     "@types/semver": "^7.3.6",
-    "@typescript/native-preview": "^7.0.0-0",
     "js-yaml": "^4.1.0",
     "memfs": "^4.0.0",
     "minimatch": "^10.0.0",
@@ -118,7 +117,8 @@
     "oxlint": "^1.51.0",
     "react": "19.2.3",
     "react-native": "^0.85.0",
-    "suggestion-bot": "^4.0.0"
+    "suggestion-bot": "^4.0.0",
+    "typescript": "^7.0.1-0"
   },
   "peerDependencies": {
     "@callstack/react-native-visionos": "0.76 - 0.79",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,7 +2503,7 @@ __metadata:
     nx: "npm:^22.0.0"
     oxfmt: "npm:^0.41.0"
     oxlint: "npm:^1.51.0"
-    typescript: "npm:^6.0.0"
+    typescript: "npm:^7.0.1-0"
   languageName: unknown
   linkType: soft
 
@@ -5284,84 +5284,143 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-aix-ppc64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.1-rc"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.1-rc"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-darwin-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.1-rc"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-freebsd-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.1-rc"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.1-rc"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.1-rc"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-linux-arm@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.1-rc"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-linux-loong64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.1-rc"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.1-rc"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.1-rc"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.1-rc"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.1-rc"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.1-rc"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-netbsd-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.1-rc"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.1-rc"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.1-rc"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.1-rc"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.1-rc"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.1-rc"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260527.2":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260527.2"
+"@typescript/typescript-win32-x64@npm:7.0.1-rc":
+  version: 7.0.1-rc
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.1-rc"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@typescript/native-preview@npm:^7.0.0-0":
-  version: 7.0.0-dev.20260527.2
-  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260527.2"
-  dependencies:
-    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260527.2"
-    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260527.2"
-  dependenciesMeta:
-    "@typescript/native-preview-darwin-arm64":
-      optional: true
-    "@typescript/native-preview-darwin-x64":
-      optional: true
-    "@typescript/native-preview-linux-arm":
-      optional: true
-    "@typescript/native-preview-linux-arm64":
-      optional: true
-    "@typescript/native-preview-linux-x64":
-      optional: true
-    "@typescript/native-preview-win32-arm64":
-      optional: true
-    "@typescript/native-preview-win32-x64":
-      optional: true
-  bin:
-    tsgo: bin/tsgo.js
-  checksum: 10c0/7fe16e651816bddff00a2e2956144ec9d9f5e197040abb204f3ba5b9c1286aab959fbf45bc4b623cb54caebe52acf4607bcdae029f843c83c9ab64c43030fdc4
   languageName: node
   linkType: hard
 
@@ -12982,7 +13041,6 @@ __metadata:
     "@types/prompts": "npm:~2.4.0"
     "@types/react": "npm:~19.2.0"
     "@types/semver": "npm:^7.3.6"
-    "@typescript/native-preview": "npm:^7.0.0-0"
     ajv: "npm:^8.0.0"
     fast-xml-builder: "npm:^1.2.0"
     fast-xml-parser: "npm:^5.8.0"
@@ -12996,6 +13054,7 @@ __metadata:
     react-native: "npm:^0.85.0"
     semver: "npm:^7.5.2"
     suggestion-bot: "npm:^4.0.0"
+    typescript: "npm:^7.0.1-0"
   peerDependencies:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
@@ -15045,13 +15104,84 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=4.7.0, typescript@npm:^6.0.0, typescript@npm:^6.0.2":
+"typescript@npm:>=4.7.0, typescript@npm:^6.0.2":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^7.0.1-0":
+  version: 7.0.1-rc
+  resolution: "typescript@npm:7.0.1-rc"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.1-rc"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-darwin-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-arm": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-loong64": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-s390x": "npm:7.0.1-rc"
+    "@typescript/typescript-linux-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-sunos-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-win32-arm64": "npm:7.0.1-rc"
+    "@typescript/typescript-win32-x64": "npm:7.0.1-rc"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
+  bin:
+    tsc: bin/tsc
+  checksum: 10c0/f83e3c85823b5b76d131a985fad2112d01006bce2ad752f4b92ee4794c53a760acd5f6c760ec4d9f105baa848f4ffe0f8107a5c80b8abd504a1c906bef34e29f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bumps TypeScript to 7.0 RC

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a