### PR TITLE
fix(android): only apply Kotlin plugin if not using built-in

### DIFF
--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -7,7 +7,15 @@ buildscript {
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.android") apply false
+}
+
+// Only apply Kotlin plugin if `android.builtInKotlin=false`
+// https://developer.android.com/build/migrate-to-built-in-kotlin#enable-built-in-kotlin
+def useBuiltInKotlin = toVersionNumber(gradle.gradleVersion) >= v(9, 4, 0) &&
+                       project.findProperty("android.builtInKotlin") != false
+if (!useBuiltInKotlin) {
+    apply(plugin: "org.jetbrains.kotlin.android")
 }
 
 // `react-native run-android` is hard-coded to look for the output APK at a very
@@ -76,8 +84,10 @@ android {
         prefab = true
     }
 
-    kotlinOptions {
-        allWarningsAsErrors = true
+    if (!useBuiltInKotlin) {
+        kotlinOptions {
+            allWarningsAsErrors = true
+        }
     }
 
     defaultConfig {
@@ -201,6 +211,14 @@ android {
             enable = project.ext.react.abiSplit
             universalApk = false
             include(*project.ext.react.architectures)
+        }
+    }
+}
+
+if (useBuiltInKotlin) {
+    kotlin {
+        compilerOptions {
+            allWarningsAsErrors = true
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15226,9 +15226,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.19.5, undici@npm:^6.21.3":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Nightly builds are failing with the following error:

```
An exception occurred applying plugin request [id: 'org.jetbrains.kotlin.android']
> Failed to apply plugin 'org.jetbrains.kotlin.android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```

-- https://github.com/microsoft/react-native-test-app/actions/runs/28003974492/job/82881903173

### Platforms affected

- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

Build will still fail but on `react-native-safe-area-context` instead:

```
cd packages/app
node --run set-react-version -- nightly
yarn
cd example
yarn android
```