### PR TITLE
fix(macos): add Xcode project configuration

### DIFF
--- a/packages/app/example/react-native.config.js
+++ b/packages/app/example/react-native.config.js
@@ -8,6 +8,9 @@ const project = (() => {
       ios: {
         sourceDir: "ios",
       },
+      macos: {
+        sourceDir: "macos",
+      },
       windows: {
         sourceDir: "windows",
         solutionFile: "windows/Example.sln",

--- a/packages/app/macos/template.config.mjs
+++ b/packages/app/macos/template.config.mjs
@@ -3,15 +3,22 @@ import * as nodefs from "node:fs";
 import { podfile } from "../ios/template.config.mjs";
 import { toVersionNumber } from "../scripts/helpers.js";
 
-/** @import { Configuration, ConfigureParams } from "../scripts/types.js"; */
+/**
+ * @import {
+ *   Configuration,
+ *   ConfigureParams,
+ *   ProjectConfig,
+ *   ProjectParams,
+ * } from "../scripts/types.js";
+ */
 
 /**
  * @param {string} _projectRoot
- * @param {unknown} _config
- * @returns {undefined}
+ * @param {Required<ProjectConfig>["macos"]} config
+ * @returns {ProjectParams["macos"] | undefined}
  */
-export function configure(_projectRoot, _config, _fs = nodefs) {
-  return undefined;
+export function configure(_projectRoot, config, _fs = nodefs) {
+  return config;
 }
 
 /**

--- a/packages/app/scripts/types.ts
+++ b/packages/app/scripts/types.ts
@@ -133,6 +133,10 @@ export type ProjectParams = {
     sourceDir?: string;
     project?: string;
   };
+  macos: {
+    sourceDir?: string;
+    project?: string;
+  };
   windows: {
     sourceDir: string;
     solutionFile: string;
@@ -147,6 +151,7 @@ export type ProjectParams = {
 export type ProjectConfig = {
   android?: Pick<ProjectParams["android"], "sourceDir" | "packageName">;
   ios?: Pick<ProjectParams["ios"], "sourceDir">;
+  macos?: Pick<ProjectParams["macos"], "sourceDir">;
   windows?: Pick<ProjectParams["windows"], "sourceDir" | "solutionFile">;
   [platform: string]: unknown;
 };

--- a/packages/app/test/configure/gatherConfig.test.mts.snapshot
+++ b/packages/app/test/configure/gatherConfig.test.mts.snapshot
@@ -13,7 +13,7 @@ exports[`gatherConfig() > returns common configuration 1`] = `
     "metro.config.js": {
       "source": "example/metro.config.js"
     },
-    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
+    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      macos: {\\n        sourceDir: \\"macos\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
     "common/.gitignore": {
       "source": "example/.gitignore"
     },
@@ -26,7 +26,7 @@ exports[`gatherConfig() > returns common configuration 1`] = `
     "common/metro.config.js": {
       "source": "example/metro.config.js"
     },
-    "common/react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n"
+    "common/react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      macos: {\\n        sourceDir: \\"macos\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n"
   },
   "oldFiles": [],
   "scripts": {
@@ -51,7 +51,7 @@ exports[`gatherConfig() > returns configuration for a single platform 1`] = `
     "metro.config.js": {
       "source": "example/metro.config.js"
     },
-    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
+    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      macos: {\\n        sourceDir: \\"macos\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
     "ios/Podfile": "ws_dir = Pathname.new(__dir__)\\nws_dir = ws_dir.parent until\\n  File.exist?(\\"#{ws_dir}/node_modules/react-native-test-app/test_app.rb\\") ||\\n  ws_dir.expand_path.to_s == '/'\\nrequire \\"#{ws_dir}/node_modules/react-native-test-app/test_app.rb\\"\\n\\nworkspace 'Test.xcworkspace'\\n\\nuse_test_app! :hermes_enabled => true, :fabric_enabled => true\\n"
   },
   "oldFiles": [
@@ -84,7 +84,7 @@ exports[`gatherConfig() > returns configuration for all platforms 1`] = `
     "metro.config.js": {
       "source": "example/metro.config.js"
     },
-    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
+    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      macos: {\\n        sourceDir: \\"macos\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
     "android/build.gradle": "buildscript {\\n    apply(from: {\\n        def searchDir = rootDir.toPath()\\n        do {\\n            def p = searchDir.resolve(\\"node_modules/react-native-test-app/android/dependencies.gradle\\")\\n            if (p.toFile().exists()) {\\n                return p.toRealPath().toString()\\n            }\\n        } while (searchDir = searchDir.getParent())\\n        throw new GradleException(\\"Could not find \`react-native-test-app\`\\");\\n    }())\\n\\n    repositories {\\n        mavenCentral()\\n        google()\\n    }\\n\\n    dependencies {\\n        getReactNativeDependencies().each { dependency ->\\n            classpath(dependency)\\n        }\\n    }\\n}\\n",
     "android/gradle/wrapper/gradle-wrapper.jar": {
       "source": "example/android/gradle/wrapper/gradle-wrapper.jar"
@@ -152,7 +152,7 @@ exports[`gatherConfig() > returns configuration for arbitrary platforms 1`] = `
     "metro.config.js": {
       "source": "example/metro.config.js"
     },
-    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
+    "react-native.config.js": "const project = (() => {\\n  try {\\n    const { configureProjects } = require(\\"react-native-test-app\\");\\n    return configureProjects({\\n      android: {\\n        sourceDir: \\"android\\",\\n      },\\n      ios: {\\n        sourceDir: \\"ios\\",\\n      },\\n      macos: {\\n        sourceDir: \\"macos\\",\\n      },\\n      windows: {\\n        sourceDir: \\"windows\\",\\n        solutionFile: \\"windows/Test.sln\\",\\n      },\\n    });\\n  } catch (_) {\\n    return undefined;\\n  }\\n})();\\n\\nmodule.exports = {\\n  ...(project ? { project } : undefined),\\n};\\n",
     "android/build.gradle": "buildscript {\\n    apply(from: {\\n        def searchDir = rootDir.toPath()\\n        do {\\n            def p = searchDir.resolve(\\"node_modules/react-native-test-app/android/dependencies.gradle\\")\\n            if (p.toFile().exists()) {\\n                return p.toRealPath().toString()\\n            }\\n        } while (searchDir = searchDir.getParent())\\n        throw new GradleException(\\"Could not find \`react-native-test-app\`\\");\\n    }())\\n\\n    repositories {\\n        mavenCentral()\\n        google()\\n    }\\n\\n    dependencies {\\n        getReactNativeDependencies().each { dependency ->\\n            classpath(dependency)\\n        }\\n    }\\n}\\n",
     "android/gradle/wrapper/gradle-wrapper.jar": {
       "source": "example/android/gradle/wrapper/gradle-wrapper.jar"


### PR DESCRIPTION
### Description

This is currently unused by `react-native-macos` but will be used in the future: https://github.com/microsoft/react-native-macos/pull/2995

### Platforms affected

- [ ] Android
- [ ] iOS
- [x] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a