### PR TITLE
chore: use modern JS syntax introduced in Node 20

### DIFF
--- a/packages/app/example/test/specs/app.spec.mjs
+++ b/packages/app/example/test/specs/app.spec.mjs
@@ -2,12 +2,13 @@
 import { equal, match } from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { remote } from "webdriverio";
-import { findNearest, readTextFile } from "../../../scripts/helpers.js";
+import { findNearest, readJSONFile } from "../../../scripts/helpers.js";
 import { config } from "./wdio.config.mjs";
 
 /**
  * @typedef {Awaited<ReturnType<typeof import("webdriverio").remote>>} Browser
  * @typedef {keyof typeof config.capabilities} Capability
+ * @typedef {import("../../../scripts/types.ts").Manifest} Manifest
  */
 
 /**
@@ -44,8 +45,8 @@ describe("App", () => {
       throw new Error("Could not find 'react-native'");
     }
 
-    const manifest = readTextFile(rnPath);
-    const { version } = JSON.parse(manifest);
+    /** @type {Required<Pick<Manifest, "version">>} */
+    const { version } = readJSONFile(rnPath);
     return version.replace("-nightly-", "-nightly\n");
   })();
 

--- a/packages/app/ios/app.mjs
+++ b/packages/app/ios/app.mjs
@@ -2,11 +2,12 @@
 import * as nodefs from "node:fs";
 import * as path from "node:path";
 import { URL, fileURLToPath } from "node:url";
+import manifest from "../package.json" with { type: "json" };
 import { loadAppConfig } from "../scripts/appConfig.mjs";
 import {
   findFile,
   isMain,
-  readTextFile,
+  readJSONFile,
   toVersionNumber,
 } from "../scripts/helpers.js";
 import { cp_r, mkdir_p, rm_r } from "../scripts/utils/filesystem.mjs";
@@ -44,6 +45,7 @@ import {
  *   ApplePlatform,
  *   JSONObject,
  *   JSONValue,
+ *   Manifest,
  *   ProjectConfiguration,
  * } from "../scripts/types.ts";
  */
@@ -113,8 +115,6 @@ function findReactNativePath(
     }
   }
 
-  const manifestURL = new URL("../package.json", import.meta.url);
-  const manifest = JSON.parse(readTextFile(fileURLToPath(manifestURL), fs));
   const npmPackageName = manifest.defaultPlatformPackages[targetPlatform]?.id;
   if (!npmPackageName) {
     throw new Error(`Unsupported target platform: ${targetPlatform}`);
@@ -133,7 +133,8 @@ function findReactNativePath(
  * @returns {number}
  */
 function readPackageVersion(p, fs = nodefs) {
-  const manifest = JSON.parse(readTextFile(path.join(p, "package.json"), fs));
+  /** @type {Required<Pick<Manifest, "version">>} */
+  const manifest = readJSONFile(path.join(p, "package.json"), fs);
   return toVersionNumber(manifest["version"]);
 }
 

--- a/packages/app/scripts/apply-config-plugins.mjs
+++ b/packages/app/scripts/apply-config-plugins.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 // @ts-check
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
-import { findFile } from "./helpers.js";
+import { findFile, readTextFile } from "./helpers.js";
 
 /**
  * @typedef {import("./config-plugins/types.js").ProjectInfo["platforms"]} Platforms
@@ -17,7 +16,7 @@ async function main(projectRoot = process.cwd(), platforms) {
     throw new Error("Failed to find `package.json`");
   }
 
-  const content = fs.readFileSync(packageJsonPath, { encoding: "utf-8" });
+  const content = readTextFile(packageJsonPath);
   if (!content.includes('"@expo/config-plugins"')) {
     return;
   }

--- a/packages/app/scripts/configure.mjs
+++ b/packages/app/scripts/configure.mjs
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { URL, fileURLToPath } from "node:url";
 import semverCoerce from "semver/functions/coerce.js";
 import semverSatisfies from "semver/functions/satisfies.js";
+import rntaManifest from "../package.json" with { type: "json" };
 import {
   getPackageVersion,
   isMain,
@@ -28,7 +29,6 @@ import {
   copyFrom,
   findGitIgnore,
   loadPlatformTemplates,
-  readManifest,
   serialize,
 } from "./template.mjs";
 import * as colors from "./utils/colors.mjs";
@@ -162,9 +162,9 @@ export function getDefaultPlatformPackageName(platform) {
     return "react-native";
   }
 
-  const { defaultPlatformPackages } = readManifest();
+  const { defaultPlatformPackages } = rntaManifest;
   const pkg = defaultPlatformPackages[platform];
-  return pkg?.id;
+  return /** @type {PlatformPackage} */ (pkg?.id);
 }
 
 /**
@@ -184,7 +184,7 @@ export function getPlatformPackage(platform, targetVersion) {
     throw new Error(`Invalid ${packageName} version: ${targetVersion}`);
   }
 
-  const { peerDependencies } = readManifest();
+  const { peerDependencies } = rntaManifest;
   const versionRange = peerDependencies[packageName];
   if (!semverSatisfies(v.version, versionRange)) {
     warn(
@@ -434,7 +434,7 @@ export function updatePackageManifest(
     dependencies
   );
 
-  const { name: rntaName, version: rntaVersion } = readManifest();
+  const { name: rntaName, version: rntaVersion } = rntaManifest;
   manifest["devDependencies"] = mergeObjects(manifest["devDependencies"], {
     "@rnx-kit/metro-config": "^2.2.4",
     [rntaName]: `^${rntaVersion}`,

--- a/packages/app/scripts/internal/set-react-version.mts
+++ b/packages/app/scripts/internal/set-react-version.mts
@@ -5,6 +5,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as util from "node:util";
+import manifest from "../../package.json" with { type: "json" };
 import { isMain, readJSONFile } from "../helpers.js";
 import type { Manifest } from "../types.js";
 import { writeJSONFile } from "../utils/filesystem.mjs";
@@ -198,8 +199,7 @@ async function getProfile(
   v: string,
   coreOnly: boolean
 ): Promise<Record<string, string | undefined>> {
-  const manifest = readJSONFile<Manifest>("package.json");
-  const visionos = manifest.defaultPlatformPackages?.["visionos"];
+  const visionos = manifest.defaultPlatformPackages["visionos"];
   if (!visionos) {
     throw new Error("Missing platform package for visionOS");
   }

--- a/packages/app/scripts/schema.mjs
+++ b/packages/app/scripts/schema.mjs
@@ -1,6 +1,5 @@
 // @ts-check
-import { URL, fileURLToPath } from "node:url";
-import { readJSONFile } from "./helpers.js";
+import manifest from "../package.json" with { type: "json" };
 
 /** @import { Docs } from "./types.ts"; */
 
@@ -14,19 +13,12 @@ function extractBrief(content = "") {
   return brief.replace(/\r?\n/g, " ");
 }
 
-function readManifest() {
-  const manifest = fileURLToPath(new URL("../package.json", import.meta.url));
-  return /** @type {typeof import("../package.json")} */ (
-    readJSONFile(manifest)
-  );
-}
-
 /**
  * @param {Partial<Docs>=} docs App manifest documentation
  * @returns {import("ajv").SchemaObject}
  */
 export function generateSchema(docs = {}) {
-  const { defaultPlatformPackages } = readManifest();
+  const { defaultPlatformPackages } = manifest;
   return {
     $defs: {
       appIconSet: {

--- a/packages/app/scripts/template.mjs
+++ b/packages/app/scripts/template.mjs
@@ -2,11 +2,11 @@
 import * as nodefs from "node:fs";
 import { Module, createRequire } from "node:module";
 import * as path from "node:path";
-import { URL } from "node:url";
 import * as vm from "node:vm";
-import { memo, readJSONFile } from "./helpers.js";
+import manifest from "../package.json" with { type: "json" };
+import { readJSONFile } from "./helpers.js";
 
-/** @import { ConfigureParams, Manifest, Plugin } from "./types.js"; */
+/** @import { ConfigureParams, Plugin } from "./types.js"; */
 
 /**
  * @param {...string} paths
@@ -31,11 +31,6 @@ export function findGitIgnore(dir, fs = nodefs) {
 
   return "";
 }
-
-/** @type {() => Required<Manifest>} */
-export const readManifest = memo(() =>
-  readJSONFile(new URL("../package.json", import.meta.url))
-);
 
 /**
  * @param {string} root
@@ -153,8 +148,8 @@ export function loadPlatformTemplates(
   const require = createRequire(import.meta.url);
   const verbose = process.env["VERBOSE"];
 
-  const { defaultPlatformPackages } = readManifest();
-  const platformPackages = { ...defaultPlatformPackages };
+  /** @type {Record<string, typeof manifest.defaultPlatformPackages.ios>} */
+  const platformPackages = { ...manifest.defaultPlatformPackages };
 
   // We have to manually load project dependencies to avoid recursive calls
   const opts = { paths: [packagePath] };

--- a/packages/app/scripts/utils/colors.mjs
+++ b/packages/app/scripts/utils/colors.mjs
@@ -1,17 +1,21 @@
 // @ts-check
-import { WriteStream } from "node:tty";
+import { styleText } from "node:util";
 
-const hasColors =
-  WriteStream.prototype.hasColors() && process.env["NODE_ENV"] !== "test";
+/** @typedef {(text: string) => string} Color */
 
-/** @type {(start: number, end: number) => (s: string) => string} */
-const color = hasColors
-  ? (start, end) => (s) => "\u001B[" + start + "m" + s + "\u001B[" + end + "m"
-  : () => (s) => s;
+// Force disable colors in test environments
+if (process.env["NODE_TEST_CONTEXT"] || process.env["NODE_ENV"] === "test") {
+  process.env["FORCE_COLOR"] = "0";
+}
 
-export const bold = color(1, 22);
-export const dim = color(2, 22);
-export const red = color(31, 39);
-export const green = color(32, 39);
-export const yellow = color(33, 39);
-export const cyan = color(36, 39);
+export const infoTag = styleText(["cyan", "bold"], "info");
+export const warnTag = styleText(["yellow", "bold"], "warn");
+
+/** @type {Color} */
+export const bold = (text) => styleText("bold", text);
+/** @type {Color} */
+export const red = (text) => styleText("red", text);
+/** @type {Color} */
+export const green = (text) => styleText("green", text);
+/** @type {Color} */
+export const yellow = (text) => styleText("yellow", text);

--- a/packages/app/scripts/utils/parseargs.mjs
+++ b/packages/app/scripts/utils/parseargs.mjs
@@ -1,9 +1,8 @@
 // @ts-check
 import { cliui } from "@isaacs/cliui";
-import * as fs from "node:fs";
 import * as path from "node:path";
-import { URL, fileURLToPath } from "node:url";
 import * as util from "node:util";
+import manifest from "../../package.json" with { type: "json" };
 
 /** @import { Args, Options } from "../types.js"; */
 
@@ -94,9 +93,7 @@ export function parseArgs(description, options, callback) {
   if (values.help) {
     console.log(formatHelp(description, mergedOptions));
   } else if (typeof values.version === "boolean" && values.version) {
-    const file = fileURLToPath(new URL("../../package.json", import.meta.url));
-    const manifest = fs.readFileSync(file, { encoding: "utf-8" });
-    const { name, version } = JSON.parse(manifest);
+    const { name, version } = manifest;
     console.log(`${name} ${version}`);
   } else {
     values._ = positionals;

--- a/packages/app/test/ios/app.test.mts
+++ b/packages/app/test/ios/app.test.mts
@@ -1,9 +1,9 @@
 import { deepEqual, equal, fail, ok, throws } from "node:assert/strict";
 import * as fs from "node:fs";
 import { afterEach, before, describe, it } from "node:test";
-import { URL, fileURLToPath } from "node:url";
 import { generateProject as generateProjectActual } from "../../ios/app.mjs";
 import { USER_HEADER_SEARCH_PATHS } from "../../ios/xcode.mjs";
+import manifest from "../../package.json" with { type: "json" };
 import { readTextFile } from "../../scripts/helpers.js";
 import type {
   ApplePlatform,
@@ -27,9 +27,7 @@ describe("generateProject()", macosOnly, () => {
     overrides?: Record<string, unknown>,
     reactNativeVersion = "1000.0.0"
   ) {
-    const manifestURL = new URL("../../package.json", import.meta.url);
-    const manifest = readTextFile(fileURLToPath(manifestURL));
-    const { name, version, defaultPlatformPackages } = JSON.parse(manifest);
+    const { name, version, defaultPlatformPackages } = manifest;
     return {
       "app.json": JSON.stringify({
         name: "ContosoApp",

--- a/packages/app/windows/app.mjs
+++ b/packages/app/windows/app.mjs
@@ -254,7 +254,7 @@ export async function generateSolution(destPath, options, fs = nodefs) {
   );
   if (fs.existsSync(experimentalFeaturesPropsPath)) {
     const props = path.relative(process.cwd(), experimentalFeaturesPropsPath);
-    console.log(colors.cyan(colors.bold("info")), `'${props}' already exists`);
+    console.log(colors.infoTag, `'${props}' already exists`);
   } else {
     const { msbuildprops, useHermes } = options;
     const { useExperimentalNuGet, useFabric } = info;

--- a/packages/app/windows/project.mjs
+++ b/packages/app/windows/project.mjs
@@ -114,8 +114,7 @@ export const loadReactNativeConfig = memo((rnWindowsPath) => {
  * @param {string} message
  */
 function warn(message) {
-  const tag = colors.yellow(colors.bold("warn"));
-  console.warn(tag, message);
+  console.warn(colors.warnTag, message);
 }
 
 /**


### PR DESCRIPTION
### Description

- Use import attributes to import app manifest
- Use `node:util.styleText`

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

CI should pass.