### PR TITLE
chore: tighten `Manifest` type

### DIFF
--- a/packages/app/example/test/specs/app.spec.mjs
+++ b/packages/app/example/test/specs/app.spec.mjs
@@ -45,7 +45,7 @@ describe("App", () => {
       throw new Error("Could not find 'react-native'");
     }
 
-    /** @type {Required<Pick<Manifest, "version">>} */
+    /** @type {Manifest} */
     const { version } = readJSONFile(rnPath);
     return version.replace("-nightly-", "-nightly\n");
   })();

--- a/packages/app/ios/app.mjs
+++ b/packages/app/ios/app.mjs
@@ -133,7 +133,7 @@ function findReactNativePath(
  * @returns {number}
  */
 function readPackageVersion(p, fs = nodefs) {
-  /** @type {Required<Pick<Manifest, "version">>} */
+  /** @type {Manifest} */
   const manifest = readJSONFile(path.join(p, "package.json"), fs);
   return toVersionNumber(manifest["version"]);
 }

--- a/packages/app/scripts/internal/set-react-version.mts
+++ b/packages/app/scripts/internal/set-react-version.mts
@@ -77,8 +77,8 @@ function fetchPackageInfo(pkg: string, version: string): Promise<Manifest> {
       return fetch(npmRegistryBaseURL + pkg + "/" + foundVersion);
     })
     .then((res) => res?.json() ?? ({} as Manifest))
-    .then(({ version, dependencies = {}, peerDependencies = {} }) => {
-      return { version, dependencies, peerDependencies };
+    .then(({ name, version, dependencies = {}, peerDependencies = {} }) => {
+      return { name, version, dependencies, peerDependencies };
     });
 }
 
@@ -244,22 +244,23 @@ async function getProfile(
     }
 
     default: {
+      const remove = { name: undefined, version: undefined };
       const versions = {
         core: fetchPackageInfo("react-native", v),
         macos: coreOnly
-          ? Promise.resolve({ version: undefined })
+          ? Promise.resolve(remove)
           : fetchPackageInfo("react-native-macos", v),
         visionos: coreOnly
-          ? Promise.resolve({ version: undefined })
+          ? Promise.resolve(remove)
           : fetchPackageInfo(visionos.id, v),
         windows: coreOnly
-          ? Promise.resolve({ version: undefined })
+          ? Promise.resolve(remove)
           : fetchPackageInfo("react-native-windows", v),
       };
       const reactNative = await versions.core;
       const commonDeps = await resolveCommonDependencies(v, reactNative);
 
-      const getVersion = ({ version }: Manifest) => version;
+      const getVersion = ({ version }: Partial<Manifest>) => version;
       return {
         ...commonDeps,
         "react-native": reactNative.version,

--- a/packages/app/scripts/types.ts
+++ b/packages/app/scripts/types.ts
@@ -331,22 +331,25 @@ export type Docs = {
  * set-react-version.mjs *
  *************************/
 
-export type Manifest = Partial<{
+export type Manifest = {
   name: string;
   version: string;
-  repository: {
-    type: "git";
-    url: string;
-  };
-  dependencies: Record<string, string>;
-  peerDependencies: Record<string, string>;
-  devDependencies: Record<string, string | undefined>;
-  resolutions: Record<string, string | undefined>;
-  defaultPlatformPackages: Record<
+  repository?:
+    | string
+    | {
+        type: "git";
+        url: string;
+        directory?: string;
+      };
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  devDependencies?: Record<string, string | undefined>;
+  resolutions?: Record<string, string | undefined>;
+  defaultPlatformPackages?: Record<
     string,
     { id: PlatformPackage; template: string }
   >;
-}>;
+};
 
 /***************************
  * testing/test-matrix.mts *


### PR DESCRIPTION
### Description

Tightens the `Manifest` type so we can avoid casting

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a