### PR TITLE
chore: fix `set-react-version` when run outside package

### DIFF
--- a/packages/app/example/package.json
+++ b/packages/app/example/package.json
@@ -10,7 +10,6 @@
     "build:visionos": "rnx-cli bundle --platform ios",
     "build:windows": "rnx-cli bundle --platform windows",
     "ci:windows": "rnx-cli run-windows --logging --no-packager --no-launch --no-deploy --msbuildprops UseBundle=false --no-telemetry",
-    "clean": "yarn workspace react-native-test-app clean",
     "ios": "rnx-cli run --platform ios",
     "macos": "rnx-cli run --platform macos",
     "set-react-version": "yarn workspace react-native-test-app set-react-version",

--- a/packages/app/scripts/internal/set-react-version.mts
+++ b/packages/app/scripts/internal/set-react-version.mts
@@ -290,8 +290,12 @@ export async function setReactVersion(
       "../../package.json",
     ];
     for (const manifestPath of manifests) {
+      if (!fs.existsSync(manifestPath)) {
+        continue;
+      }
+
       const manifest = readJSONFile<Manifest>(manifestPath);
-      const { dependencies, devDependencies, resolutions } = manifest;
+      const { dependencies = {}, devDependencies = {}, resolutions } = manifest;
       if (!devDependencies) {
         throw new Error("Expected 'devDependencies' to be declared");
       }
@@ -311,10 +315,12 @@ export async function setReactVersion(
         }
       } else {
         for (const packageName of keys(profile)) {
-          const deps = dependencies?.[packageName]
-            ? dependencies
-            : devDependencies;
-          deps[packageName] = profile[packageName];
+          if (Object.hasOwn(dependencies, packageName)) {
+            dependencies[packageName] = profile[packageName];
+          }
+          if (Object.hasOwn(devDependencies, packageName)) {
+            devDependencies[packageName] = profile[packageName];
+          }
         }
       }
 

--- a/packages/app/scripts/types.ts
+++ b/packages/app/scripts/types.ts
@@ -341,7 +341,7 @@ export type Manifest = {
         url: string;
         directory?: string;
       };
-  dependencies?: Record<string, string>;
+  dependencies?: Record<string, string | undefined>;
   peerDependencies?: Record<string, string>;
   devDependencies?: Record<string, string | undefined>;
   resolutions?: Record<string, string | undefined>;

--- a/packages/example-macos/package.json
+++ b/packages/example-macos/package.json
@@ -8,10 +8,9 @@
     "build:ios": "rnx-cli bundle --platform ios",
     "build:macos": "rnx-cli bundle --platform macos",
     "build:visionos": "rnx-cli bundle --platform ios",
-    "clean": "yarn workspace react-native-test-app clean",
     "ios": "rnx-cli run --platform ios",
     "macos": "rnx-cli run --platform macos",
-    "set-react-version": "yarn workspace react-native-test-app set-react-version",
+    "set-react-version": "node ../app/scripts/internal/set-react-version.mts",
     "start": "rnx-cli start",
     "visionos": "rnx-cli run --platform visionos"
   },

--- a/packages/example-windows/package.json
+++ b/packages/example-windows/package.json
@@ -8,10 +8,9 @@
     "build:ios": "rnx-cli bundle --platform ios",
     "build:windows": "rnx-cli bundle --platform windows",
     "ci:windows": "rnx-cli run-windows --logging --no-packager --no-launch --no-deploy --msbuildprops UseBundle=false --no-telemetry",
-    "clean": "yarn workspace react-native-test-app clean",
     "ios": "rnx-cli run --platform ios",
     "prebuild": "node ../app/windows/app.mjs",
-    "set-react-version": "yarn workspace react-native-test-app set-react-version",
+    "set-react-version": "node ../app/scripts/internal/set-react-version.mts",
     "start": "rnx-cli start",
     "windows": "rnx-cli run-windows --no-packager"
   },


### PR DESCRIPTION
### Description

`yarn workspace ...` changes the working directory so it only modified files inside the main package.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd packages/example-macos
node --run set-react-version 0.81
```

Verify that `packages/example-macos/package.json` is modified.