### PR TITLE
chore: bump `@rnx-kit/react-native-host` to 0.5.21

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_react-native_version.yml
+++ b/.github/ISSUE_TEMPLATE/new_react-native_version.yml
@@ -44,7 +44,6 @@ body:
       options:
         - label: Verify that the Gradle version used is the same or higher ([see context](https://github.com/microsoft/react-native-test-app/pull/1935))
         - label: Ensure React Native Gradle Plugin autolinking code are in sync ([see context](https://github.com/microsoft/react-native-test-app/pull/2075))
-        - label: Ensure feature flags are in sync ([see context](https://github.com/microsoft/rnx-kit/pull/3196))
   - type: checkboxes
     id: checklist
     attributes:

--- a/packages/app/example/ios/Podfile.lock
+++ b/packages/app/example/ios/Podfile.lock
@@ -1819,7 +1819,7 @@ PODS:
     - React-utils (= 0.85.1)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.1)
-  - ReactNativeHost (0.5.19):
+  - ReactNativeHost (0.5.21):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1847,7 +1847,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.4.5):
+  - RNWWebStorage (0.4.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2189,10 +2189,10 @@ SPEC CHECKSUMS:
   ReactCodegen: 1663f3db0221878329f993847de1c422d6af5e3c
   ReactCommon: 66763e5bd1b778828ff6cb82d771b7162a5215c2
   ReactNativeDependencies: 8cbd0fbc0255c3949672a00a81fc8d60a29dcfd9
-  ReactNativeHost: f5cd5ffbfb7c6eda04b5b40d3de4e09ccec2c108
+  ReactNativeHost: c49183895850a534a9d58049bf02b3c80a3ebb0c
   ReactTestApp-DevSupport: aeb3fe7bc1b2916413ac41309a70a0df7475f8a5
   ReactTestApp-Resources: 1bd9ff10e4c24f2ad87101a32023721ae923bccf
-  RNWWebStorage: e01ec77abc9866d80b0c1b0d57914cce11ab747b
+  RNWWebStorage: a3612eab23117c5bf9d18faa213565409a376ef1
   Yoga: b1085f68c014785350a2afdc95eaef0d49f23ccb
 
 PODFILE CHECKSUM: c9e179d1d59e47eaa6fef9316a7e039dbb9b0c0b

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@isaacs/cliui": "^9.0.0",
-    "@rnx-kit/react-native-host": "^0.5.19",
+    "@rnx-kit/react-native-host": "^0.5.21",
     "@rnx-kit/tools-react-native": "^2.1.0",
     "ajv": "^8.0.0",
     "fast-xml-builder": "^1.2.0",

--- a/packages/example-macos/macos/Podfile.lock
+++ b/packages/example-macos/macos/Podfile.lock
@@ -2259,7 +2259,7 @@ PODS:
     - React-perflogger (= 0.81.8)
     - React-utils (= 0.81.8)
     - SocketRocket
-  - ReactNativeHost (0.5.19):
+  - ReactNativeHost (0.5.21):
     - boost
     - DoubleConversion
     - fast_float
@@ -2292,7 +2292,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNWWebStorage (0.4.5):
+  - RNWWebStorage (0.4.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2638,10 +2638,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 3a4b47b0501d4d1068eef3c457c9ebef0b6ae49b
   ReactCodegen: 5a676a29f556095ce9f87f1f39e273ca0ad9586f
   ReactCommon: ef913092a4501cf30c176155312c30abc82dbd34
-  ReactNativeHost: 8680b5bbc3afdbfeccc206ed0f3230d7c3df691b
+  ReactNativeHost: c8a7476a8bed6ba32f07207ee095837c8f7456e9
   ReactTestApp-DevSupport: 4d0b86847c5f7fffa0f09479443be7a2420d19a4
   ReactTestApp-Resources: 71a3155bca10819738469de1f161410f43528209
-  RNWWebStorage: 8ec03f8288c1e212518f662f44ec223603bbe74c
+  RNWWebStorage: 8bc155b048a2d1ee1db5f63b1b9c5705434d48db
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 9f9bacf26f441fa32d25c32e5583ff72f6d2806d
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,12 +4653,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.5.19":
-  version: 0.5.19
-  resolution: "@rnx-kit/react-native-host@npm:0.5.19"
+"@rnx-kit/react-native-host@npm:^0.5.21":
+  version: 0.5.21
+  resolution: "@rnx-kit/react-native-host@npm:0.5.21"
   peerDependencies:
     react-native: ">=0.66"
-  checksum: 10c0/6dbf12788c7ebff0813288343dcaa4b7c18b4a2fa048a6bdcb65019c92234beabbe8b9a52701dc7cd6845f9c621e93969fe58db3409093c7443053aa8646cc21
+  checksum: 10c0/f48bfe6fa991becee8783909a1668309b994aa8cd1dcdb8294aaf0685810cc8cec708b3e5ba87cb44ac4b9c2d41495dc027d6ebb8720a1d4476d6de477d15a0c
   languageName: node
   linkType: hard
 
@@ -13332,7 +13332,7 @@ __metadata:
     "@react-native-community/cli": "npm:^20.1.0"
     "@react-native-community/cli-types": "npm:^20.1.0"
     "@react-native-community/template": "npm:^0.85.0"
-    "@rnx-kit/react-native-host": "npm:^0.5.19"
+    "@rnx-kit/react-native-host": "npm:^0.5.21"
     "@rnx-kit/tools-react-native": "npm:^2.1.0"
     "@rnx-kit/tsconfig": "npm:^3.0.1"
     "@types/mustache": "npm:^4.0.0"


### PR DESCRIPTION
### Description

Since we're now using `ReactNativeFeatureFlagsOverridesOSSStable` when it's available, we no longer need to keep feature flags in sync with upstream.

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a