### PR TITLE
fix: declare support for 0.87

### DIFF
--- a/packages/app/example/package.json
+++ b/packages/app/example/package.json
@@ -39,7 +39,7 @@
     "@types/node": "catalog:",
     "@types/react": "~19.2.0",
     "@wdio/types": "^9.20.0",
-    "appium": "^3.5.2",
+    "appium": "^3.6.0",
     "appium-uiautomator2-driver": "^8.1.0",
     "appium-xcuitest-driver": "^11.0.0",
     "react-native-test-app": "workspace:*",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -120,7 +120,7 @@
     "@callstack/react-native-visionos": "0.76 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.2 - 19.2",
-    "react-native": "0.76 - 0.86 || >=0.86.0-0 <0.87.0",
+    "react-native": "0.76 - 0.87 || >=0.88.0-0 <0.88.0",
     "react-native-macos": "^0.0.0-0 || 0.76 - 0.81",
     "react-native-windows": "^0.0.0-0 || 0.76 - 0.83"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,41 +5,41 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@appium/base-driver@npm:10.7.1, @appium/base-driver@npm:^10.0.0-rc.1, @appium/base-driver@npm:^10.0.0-rc.2, @appium/base-driver@npm:^10.3.0":
-  version: 10.7.1
-  resolution: "@appium/base-driver@npm:10.7.1"
+"@appium/base-driver@npm:10.7.2, @appium/base-driver@npm:^10.0.0-rc.1, @appium/base-driver@npm:^10.0.0-rc.2, @appium/base-driver@npm:^10.3.0":
+  version: 10.7.2
+  resolution: "@appium/base-driver@npm:10.7.2"
   dependencies:
-    "@appium/support": "npm:7.2.5"
-    "@appium/types": "npm:1.5.1"
+    "@appium/support": "npm:7.2.6"
+    "@appium/types": "npm:1.6.0"
     async-lock: "npm:1.4.1"
-    asyncbox: "npm:6.3.0"
-    axios: "npm:1.18.0"
-    body-parser: "npm:2.2.2"
+    asyncbox: "npm:6.3.5"
+    axios: "npm:1.18.1"
+    body-parser: "npm:2.3.0"
     express: "npm:5.2.1"
     fastest-levenshtein: "npm:1.0.16"
     http-status-codes: "npm:2.3.0"
-    lru-cache: "npm:11.5.1"
+    lru-cache: "npm:11.5.2"
     method-override: "npm:3.0.0"
     morgan: "npm:1.11.0"
     path-to-regexp: "npm:8.4.2"
     serve-favicon: "npm:2.5.1"
     spdy: "npm:4.0.2"
-    type-fest: "npm:5.7.0"
+    type-fest: "npm:5.8.0"
   dependenciesMeta:
     spdy:
       optional: true
-  checksum: 10c0/fe91e3d4a79abccefaaab8f2ed236b13fdc61a784fd62d86b4211ebefcebbfdd8ac7decfe99860b2acef7ad433c37263a7c158551d33b9f44059e431e551d9a4
+  checksum: 10c0/f7217ab570a2ce9680096b08461fdc3da78c8cd55482f64a13ab63b09a2792e9c9ff19abc06ec0a493a7f25844f3e9bf0608676439173146ddf518caaa2e06d3
   languageName: node
   linkType: hard
 
-"@appium/base-plugin@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@appium/base-plugin@npm:3.3.2"
+"@appium/base-plugin@npm:3.3.3":
+  version: 3.3.3
+  resolution: "@appium/base-plugin@npm:3.3.3"
   dependencies:
-    "@appium/base-driver": "npm:10.7.1"
-    "@appium/support": "npm:7.2.5"
-    "@appium/types": "npm:1.5.1"
-  checksum: 10c0/269933e90106b2447d664ed2fa234c872d8dc6bdf93e833862b604f7ff2b7216d19094fef12b7c3c1f2cab24421d76180aa494aefd6785b09ad29367afabd714
+    "@appium/base-driver": "npm:10.7.2"
+    "@appium/support": "npm:7.2.6"
+    "@appium/types": "npm:1.6.0"
+  checksum: 10c0/46d6380a5a83b5435f5b6e54b2bd77679802fed45600ae2aedcdbf63915cae7787603e431f885e833627ac127ea8e7d8a9ff7f565ea21fc3b2590f9be3641591
   languageName: node
   linkType: hard
 
@@ -58,21 +58,21 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@appium/logger@npm:2.0.9, @appium/logger@npm:^2.0.0-rc.1":
-  version: 2.0.9
-  resolution: "@appium/logger@npm:2.0.9"
+"@appium/logger@npm:2.0.10, @appium/logger@npm:^2.0.0-rc.1":
+  version: 2.0.10
+  resolution: "@appium/logger@npm:2.0.10"
   dependencies:
-    lru-cache: "npm:11.5.1"
-  checksum: 10c0/07cd8133e26881d26b8a6c6c642544a0a028bb59e1c2f6a53d86fde9159919e44dc3ecdb9406133f99b35d8d0518cf5ed24f63a44305aff5cdd66ec2d0b93577
+    lru-cache: "npm:11.5.2"
+  checksum: 10c0/e44fb5c2dace2e88d9d76d1f00ebe46b966ce06dd073ad3ca4f8177cacfddce254caa71c236aa45c6d2594d28a6afbc1c82809cdea3e62e094b1ed2a411fcf1f
   languageName: node
   linkType: hard
 
-"@appium/schema@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@appium/schema@npm:1.2.1"
+"@appium/schema@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@appium/schema@npm:1.3.0"
   dependencies:
     json-schema: "npm:0.4.0"
-  checksum: 10c0/6b29289db9670c7093d14b201acbc5eb67911eff789ababef9c45175b0d2cacbf2a3820cd61ad9c19ad287cc1dc2e3181a50a974cd72f6ee47b85baa1d704ebf
+  checksum: 10c0/8ef7d4d3d31cebe30360acda990145fa4ef4c16090c0a81475a8b93ba730277c0b1dc33334d9fe3fe12d9ef670321ac8a06ffc21ae1182534202726c4a9331d4
   languageName: node
   linkType: hard
 
@@ -85,15 +85,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appium/support@npm:7.2.5, @appium/support@npm:^7.2.0, @appium/support@npm:^7.2.1, @appium/support@npm:^7.2.2":
-  version: 7.2.5
-  resolution: "@appium/support@npm:7.2.5"
+"@appium/support@npm:7.2.6, @appium/support@npm:^7.2.0, @appium/support@npm:^7.2.1, @appium/support@npm:^7.2.2":
+  version: 7.2.6
+  resolution: "@appium/support@npm:7.2.6"
   dependencies:
-    "@appium/logger": "npm:2.0.9"
-    "@appium/types": "npm:1.5.1"
+    "@appium/logger": "npm:2.0.10"
+    "@appium/types": "npm:1.6.0"
     archiver: "npm:8.0.0"
-    asyncbox: "npm:6.3.0"
-    axios: "npm:1.18.0"
+    asyncbox: "npm:6.3.5"
+    axios: "npm:1.18.1"
     bluebird: "npm:3.7.2"
     bplist-creator: "npm:0.1.1"
     bplist-parser: "npm:0.3.2"
@@ -106,30 +106,30 @@ __metadata:
     plist: "npm:4.0.0"
     pluralize: "npm:8.0.0"
     sanitize-filename: "npm:1.6.4"
-    semver: "npm:7.8.4"
-    sharp: "npm:0.35.1"
-    shell-quote: "npm:1.8.4"
-    teen_process: "npm:4.1.3"
-    type-fest: "npm:5.7.0"
-    uuid: "npm:14.0.0"
+    semver: "npm:7.8.5"
+    sharp: "npm:0.35.3"
+    shell-quote: "npm:1.10.0"
+    teen_process: "npm:4.1.9"
+    type-fest: "npm:5.8.0"
+    uuid: "npm:14.0.1"
     which: "npm:6.0.1"
     yauzl: "npm:3.4.0"
   dependenciesMeta:
     sharp:
       optional: true
-  checksum: 10c0/76e20744bf85a24b371843bba0db8ae4271dc8c04dfd441f5dde1d0b798a7ab72e55ba855064b0f3335bcc22ee1581dd854ffc6e56a857b1b27db503b3401c7d
+  checksum: 10c0/7fb9a0ccf29d8f6bef6b86da46ddcf8dc8be3a7479eabaf662a4ebf1ee0a8ca82bbb5b4ea1798e3726cde071c3177661ea085c2aa6cb882ed379306115256ed8
   languageName: node
   linkType: hard
 
-"@appium/types@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@appium/types@npm:1.5.1"
+"@appium/types@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@appium/types@npm:1.6.0"
   dependencies:
-    "@appium/schema": "npm:1.2.1"
-    type-fest: "npm:5.7.0"
+    "@appium/schema": "npm:1.3.0"
+    type-fest: "npm:5.8.0"
   peerDependencies:
     "@appium/logger": ^2.0.0
-  checksum: 10c0/e6c48dfa1494f4e5073b6a6efcf42ac8142ad8c4b400b628b84f36ce9cb0f8acd9841c4760dec8f3c4bdefeffed5efb4649400a0082ba83e14afa9a6810f04a1
+  checksum: 10c0/312b704f4269474119ef748332cbb6987cfadf3f35b7e371536a14e1252d858f748c19d7d79798b455ca428e441e2e1f9686ff2a657ca8d72435240899c68841
   languageName: node
   linkType: hard
 
@@ -6237,35 +6237,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"appium@npm:^3.5.2":
-  version: 3.5.2
-  resolution: "appium@npm:3.5.2"
+"appium@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "appium@npm:3.6.0"
   dependencies:
-    "@appium/base-driver": "npm:10.7.1"
-    "@appium/base-plugin": "npm:3.3.2"
-    "@appium/docutils": "npm:2.5.1"
-    "@appium/logger": "npm:2.0.9"
-    "@appium/schema": "npm:1.2.1"
-    "@appium/support": "npm:7.2.5"
-    "@appium/types": "npm:1.5.1"
+    "@appium/base-driver": "npm:10.7.2"
+    "@appium/base-plugin": "npm:3.3.3"
+    "@appium/docutils": "npm:2.5.2"
+    "@appium/logger": "npm:2.0.10"
+    "@appium/schema": "npm:1.3.0"
+    "@appium/support": "npm:7.2.6"
+    "@appium/types": "npm:1.6.0"
     "@sidvind/better-ajv-errors": "npm:5.0.0"
     ajv: "npm:8.20.0"
     ajv-formats: "npm:3.0.1"
-    argparse: "npm:2.0.1"
-    asyncbox: "npm:6.3.0"
-    axios: "npm:1.18.0"
+    argparse: "npm:3.0.0"
+    asyncbox: "npm:6.3.5"
+    axios: "npm:1.18.1"
     lilconfig: "npm:3.1.3"
-    lru-cache: "npm:11.5.1"
+    lru-cache: "npm:11.5.2"
     ora: "npm:5.4.1"
-    semver: "npm:7.8.4"
-    teen_process: "npm:4.1.3"
-    type-fest: "npm:5.7.0"
+    semver: "npm:7.8.5"
+    teen_process: "npm:4.1.9"
+    type-fest: "npm:5.8.0"
     winston: "npm:3.19.0"
-    ws: "npm:8.21.0"
+    ws: "npm:8.21.1"
     yaml: "npm:2.9.0"
   bin:
     appium: index.js
-  checksum: 10c0/885022203e29e2e2ce14d499adfe9550c0c0f6e908ac9ea3cf34d1117f91487b38e0e52342e51dd015fc0125d5c5202f459cfa0fa913c9109d73869698f583eb
+  checksum: 10c0/0cc05a751d63beee409e4f0b965b206bf909e7c681e62578fa725301ca91d8000cf5cc033ced2c50644af71e97b1f8278ce691ea5a57ff53f5be61e11f95b273
   languageName: node
   linkType: hard
 
@@ -6320,6 +6320,13 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "argparse@npm:3.0.0"
+  checksum: 10c0/76219209d7a4642f063278d93b37602df8a39c9e810e69b1b650b0bd6b847b5e880f216e4e2c2fa08116436de9ecd8d7026b3cddfc5668a8a4e69348ed03bcc8
   languageName: node
   linkType: hard
 
@@ -6514,12 +6521,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asyncbox@npm:^6.0.1, asyncbox@npm:^6.1.0, asyncbox@npm:^6.3.0":
-  version: 6.3.4
-  resolution: "asyncbox@npm:6.3.4"
+"asyncbox@npm:^6.0.1, asyncbox@npm:^6.1.0, asyncbox@npm:^6.3.0, asyncbox@npm:^6.3.5":
+  version: 6.4.1
+  resolution: "asyncbox@npm:6.4.1"
   dependencies:
     p-limit: "npm:^7.2.0"
-  checksum: 10c0/09ef7ae4588651849063cdd153b3a31c4b3cd5b71ab86cac0b9cbd55f7218563dc09b91de8677b725f018fd6d8d703c64c57c1742dd5cc81ad07beec2e7a94a9
+  checksum: 10c0/806f365961997d55f3d510be0f1b6613314ae5656211b8afd17fcc62a3abd5db98c175bb1f38e734d78132009c73b6d4b2ec8cabfc3489ec163f0ed414701b4c
   languageName: node
   linkType: hard
 
@@ -6539,7 +6546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.1, axios@npm:^1.16.0, axios@npm:^1.18.0, axios@npm:^1.4.0":
+"axios@npm:^1.15.1, axios@npm:^1.16.0, axios@npm:^1.18.1, axios@npm:^1.4.0":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
   dependencies:
@@ -6816,7 +6823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^2.2.1, body-parser@npm:^2.2.2":
+"body-parser@npm:^2.2.1, body-parser@npm:^2.2.2, body-parser@npm:^2.3.0":
   version: 2.3.0
   resolution: "body-parser@npm:2.3.0"
   dependencies:
@@ -8702,7 +8709,7 @@ __metadata:
     "@types/node": "catalog:"
     "@types/react": "npm:~19.2.0"
     "@wdio/types": "npm:^9.20.0"
-    appium: "npm:^3.5.2"
+    appium: "npm:^3.6.0"
     appium-uiautomator2-driver: "npm:^8.1.0"
     appium-xcuitest-driver: "npm:^11.0.0"
     react: "npm:19.2.3"
@@ -10983,10 +10990,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.5.1":
-  version: 11.5.1
-  resolution: "lru-cache@npm:11.5.1"
-  checksum: 10c0/7b341cea79a8efe9c6a6f20c8757a77eca5b25d7ff983ccf4e11e547b81f6787824baa1c84705251dff84ab4ffac85717ac354b9d02e465f86a9f8b166409979
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.5.2":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: 10c0/ece1ad731f5b655e85d67047d04bfc13823dc77aa61c5454924a9869ba600a0104e39cc33d726021feef812bc347ca34a5608a5eb1972a5dd0870b7ecd42c3f2
   languageName: node
   linkType: hard
 
@@ -13417,7 +13424,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.2 - 19.2
-    react-native: 0.76 - 0.86 || >=0.86.0-0 <0.87.0
+    react-native: 0.76 - 0.87 || >=0.88.0-0 <0.88.0
     react-native-macos: ^0.0.0-0 || 0.76 - 0.81
     react-native-windows: ^0.0.0-0 || 0.76 - 0.83
   peerDependenciesMeta:
@@ -14166,7 +14173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.4, semver@npm:^7.8.5":
+"semver@npm:^7.0.0, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -14326,7 +14333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.35.1":
+"sharp@npm:^0.35.3":
   version: 0.35.3
   resolution: "sharp@npm:0.35.3"
   dependencies:
@@ -14448,7 +14455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.10.0, shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.4":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
@@ -15108,12 +15115,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teen_process@npm:^4.0.4, teen_process@npm:^4.0.7, teen_process@npm:^4.1.0, teen_process@npm:^4.1.3":
-  version: 4.1.9
-  resolution: "teen_process@npm:4.1.9"
+"teen_process@npm:^4.0.4, teen_process@npm:^4.0.7, teen_process@npm:^4.1.0, teen_process@npm:^4.1.9":
+  version: 4.2.1
+  resolution: "teen_process@npm:4.2.1"
   dependencies:
     shell-quote: "npm:^1.8.1"
-  checksum: 10c0/4a5774fedb61c0d74ce5fc45c5d59fa26ef49b769011fff08894836bf827522091292aa48220e1de4ba8a3072e7d763bab1ca5e07d955bb2c3682d6bc84caa3c
+  checksum: 10c0/93631aa8c7ced7e81d2876695324735e5165036b5305e48df119b7eb7a92c2d852d9f638e54badd166fdc97eb3fb6a760ee1b62bdcd9fe3a4e48f589db68e335
   languageName: node
   linkType: hard
 
@@ -15317,12 +15324,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:5.7.0":
-  version: 5.7.0
-  resolution: "type-fest@npm:5.7.0"
+"type-fest@npm:5.8.0, type-fest@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "type-fest@npm:5.8.0"
   dependencies:
     tagged-tag: "npm:^1.0.0"
-  checksum: 10c0/f71ed17b753649421e419db8cc2e140f930333a1467b1d9cca2e0e4052900fd442f2360bae73f3a6bf9340d949ac46d9a1598c709b4c8089272e7624df9c8716
+  checksum: 10c0/c8aae118a763d550a9552a511dff6b71840a23dab4edf693cf1c4df22596942794e6f6723389bd9036a90182249d915158bacf0815a1ae87f05f901b1d5f574e
   languageName: node
   linkType: hard
 
@@ -15337,15 +15344,6 @@ __metadata:
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^5.7.0":
-  version: 5.8.0
-  resolution: "type-fest@npm:5.8.0"
-  dependencies:
-    tagged-tag: "npm:^1.0.0"
-  checksum: 10c0/c8aae118a763d550a9552a511dff6b71840a23dab4edf693cf1c4df22596942794e6f6723389bd9036a90182249d915158bacf0815a1ae87f05f901b1d5f574e
   languageName: node
   linkType: hard
 
@@ -15701,7 +15699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^14.0.0, uuid@npm:~14.0.0":
+"uuid@npm:^14.0.1, uuid@npm:~14.0.0":
   version: 14.0.1
   resolution: "uuid@npm:14.0.1"
   bin:
@@ -16129,7 +16127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.0.0, ws@npm:^8.13.0, ws@npm:^8.21.0, ws@npm:^8.8.0":
+"ws@npm:^8.0.0, ws@npm:^8.13.0, ws@npm:^8.21.1, ws@npm:^8.8.0":
   version: 8.21.1
   resolution: "ws@npm:8.21.1"
   peerDependencies:


### PR DESCRIPTION
### Description

Resolves #2776.

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd packages/app
node --run test:matrix -- 0.87
```

### Screenshots

| Android | iOS  |
| :-----: | :--: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/6ad2aae5-d58c-40a7-8e2d-3ebddcf2f6e9" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/30fbf024-f238-43b8-aaad-fd2671568125" /> |