### PR TITLE
chore: bump `typescript` to 7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "nx": "^22.0.0",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.51.0",
-    "typescript": "^7.0.1-0"
+    "typescript": "^7.0.2"
   },
   "resolutions": {
     "@appium/base-driver/asyncbox": "^6.3.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -114,7 +114,7 @@
     "react": "19.2.3",
     "react-native": "^0.85.0",
     "suggestion-bot": "^4.0.0",
-    "typescript": "^7.0.1-0"
+    "typescript": "^7.0.2"
   },
   "peerDependencies": {
     "@callstack/react-native-visionos": "0.76 - 0.79",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ __metadata:
     nx: "npm:^22.0.0"
     oxfmt: "npm:^0.57.0"
     oxlint: "npm:^1.51.0"
-    typescript: "npm:^7.0.1-0"
+    typescript: "npm:^7.0.2"
   languageName: unknown
   linkType: soft
 
@@ -5454,142 +5454,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/typescript-aix-ppc64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.1-rc"
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-darwin-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.1-rc"
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-darwin-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-darwin-x64@npm:7.0.1-rc"
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-freebsd-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.1-rc"
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-freebsd-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.1-rc"
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-arm64@npm:7.0.1-rc"
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-arm@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-arm@npm:7.0.1-rc"
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-loong64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-loong64@npm:7.0.1-rc"
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-mips64el@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.1-rc"
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-ppc64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.1-rc"
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-riscv64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.1-rc"
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-s390x@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-s390x@npm:7.0.1-rc"
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@typescript/typescript-linux-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-linux-x64@npm:7.0.1-rc"
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-netbsd-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.1-rc"
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-netbsd-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.1-rc"
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-openbsd-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.1-rc"
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-openbsd-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.1-rc"
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-sunos-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-sunos-x64@npm:7.0.1-rc"
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-win32-arm64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-win32-arm64@npm:7.0.1-rc"
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/typescript-win32-x64@npm:7.0.1-rc":
-  version: 7.0.1-rc
-  resolution: "@typescript/typescript-win32-x64@npm:7.0.1-rc"
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -13273,7 +13273,7 @@ __metadata:
     react-native: "npm:^0.85.0"
     semver: "npm:^7.5.2"
     suggestion-bot: "npm:^4.0.0"
-    typescript: "npm:^7.0.1-0"
+    typescript: "npm:^7.0.2"
   peerDependencies:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
@@ -15329,30 +15329,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^7.0.1-0":
-  version: 7.0.1-rc
-  resolution: "typescript@npm:7.0.1-rc"
+"typescript@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
   dependencies:
-    "@typescript/typescript-aix-ppc64": "npm:7.0.1-rc"
-    "@typescript/typescript-darwin-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-darwin-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-freebsd-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-freebsd-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-arm": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-loong64": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-mips64el": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-ppc64": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-riscv64": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-s390x": "npm:7.0.1-rc"
-    "@typescript/typescript-linux-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-netbsd-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-netbsd-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-openbsd-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-openbsd-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-sunos-x64": "npm:7.0.1-rc"
-    "@typescript/typescript-win32-arm64": "npm:7.0.1-rc"
-    "@typescript/typescript-win32-x64": "npm:7.0.1-rc"
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
   dependenciesMeta:
     "@typescript/typescript-aix-ppc64":
       optional: true
@@ -15396,7 +15396,7 @@ __metadata:
       optional: true
   bin:
     tsc: bin/tsc
-  checksum: 10c0/f83e3c85823b5b76d131a985fad2112d01006bce2ad752f4b92ee4794c53a760acd5f6c760ec4d9f105baa848f4ffe0f8107a5c80b8abd504a1c906bef34e29f
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bumps TypeScript to 7.0.2

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a