### PR TITLE
refactor: use built-in `Error.isError`

### DIFF
--- a/packages/app/scripts/testing/test-matrix.mts
+++ b/packages/app/scripts/testing/test-matrix.mts
@@ -404,7 +404,7 @@ if (platforms.length === 0) {
         process.exitCode = e;
       } else {
         process.exitCode = 1;
-        showBanner(`❌ ${(e instanceof Error && e.stack) || e}`);
+        showBanner(`❌ ${(Error.isError(e) && e.stack) || e}`);
       }
     });
 }

--- a/packages/app/test/windows/copyAndReplace.test.mts
+++ b/packages/app/test/windows/copyAndReplace.test.mts
@@ -48,14 +48,14 @@ describe("copyAndReplace()", () => {
 
   it("throws on error", async () => {
     await rejects(copyAndReplace("ReactTestApp.png", "", {}), (err) => {
-      if (!(err instanceof Error)) {
+      if (!Error.isError(err)) {
         fail("Expected an Error");
       }
       match(err.message, /ENOENT/);
       return true;
     });
     await rejects(copyAndReplace("ReactTestApp.sln", "", {}), (err) => {
-      if (!(err instanceof Error)) {
+      if (!Error.isError(err)) {
         fail("Expected an Error");
       }
       match(err.message, /ENOENT/);

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "esnext",
     "allowImportingTsExtensions": true,
     "noEmit": true,
-    "lib": ["ES2022", "DOM"]
+    "lib": ["esnext", "dom"]
   },
   "include": [
     "**/*.mjs",


### PR DESCRIPTION
### Description

Use built-in [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) instead of `instanceof`.

Note that this was recently introduced in Node 24.3. We cannot use it in public-facing code.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a