### PR TITLE
chore: use internal `JSONObject` type

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -99,7 +99,6 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@expo/config-plugins": "^57.0.0",
-    "@expo/json-file": "^11.0.0",
     "@react-native-community/cli": "^20.1.0",
     "@react-native-community/cli-types": "^20.1.0",
     "@react-native-community/template": "^0.85.0",

--- a/packages/app/scripts/config-plugins/provider.mjs
+++ b/packages/app/scripts/config-plugins/provider.mjs
@@ -4,8 +4,7 @@ import { findFile } from "../helpers.js";
 import { BaseMods } from "./ExpoConfigPlugins.mjs";
 
 /**
- * @import { JSONObject } from "@expo/json-file";
- * @import { CustomModProvider } from "./types.ts";
+ * @import { CustomModProvider, JSONObject } from "./types.ts";
  */
 
 /**

--- a/packages/app/scripts/config-plugins/types.ts
+++ b/packages/app/scripts/config-plugins/types.ts
@@ -18,6 +18,17 @@ export type IosModFileProviders = ReturnType<
   // oxlint-disable-next-line typescript/no-explicit-any
   Record<string, BaseModProviderMethods<any, any>>;
 
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | JSONArray
+  | JSONObject
+  | null;
+
+export type JSONArray = JSONValue[];
+export type JSONObject = { [key: string]: JSONValue | undefined };
+
 export type ProjectInfo = {
   projectRoot: string;
   platforms: ModPlatform[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,7 +1730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/json-file@npm:^11.0.0, @expo/json-file@npm:~11.0.1":
+"@expo/json-file@npm:~11.0.1":
   version: 11.0.1
   resolution: "@expo/json-file@npm:11.0.1"
   dependencies:
@@ -13396,7 +13396,6 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@expo/config-plugins": "npm:^57.0.0"
-    "@expo/json-file": "npm:^11.0.0"
     "@isaacs/cliui": "npm:^9.0.0"
     "@react-native-community/cli": "npm:^20.1.0"
     "@react-native-community/cli-types": "npm:^20.1.0"


### PR DESCRIPTION
### Description

It's exactly the same as the type exported in `@expo/json-file`.

### Platforms affected

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

n/a