### PR TITLE
fix: declare support for 0.88

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -118,7 +118,7 @@
     "@callstack/react-native-visionos": "0.76 - 0.79",
     "@expo/config-plugins": ">=5.0",
     "react": "18.2 - 19.2",
-    "react-native": "0.76 - 0.87 || >=0.88.0-0 <0.88.0",
+    "react-native": "0.76 - 0.88 || >=0.89.0-0 <0.89.0",
     "react-native-macos": "^0.0.0-0 || 0.76 - 0.81",
     "react-native-windows": "^0.0.0-0 || 0.76 - 0.83"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13373,7 +13373,7 @@ __metadata:
     "@callstack/react-native-visionos": 0.76 - 0.79
     "@expo/config-plugins": ">=5.0"
     react: 18.2 - 19.2
-    react-native: 0.76 - 0.87 || >=0.88.0-0 <0.88.0
+    react-native: 0.76 - 0.88 || >=0.89.0-0 <0.89.0
     react-native-macos: ^0.0.0-0 || 0.76 - 0.81
     react-native-windows: ^0.0.0-0 || 0.76 - 0.83
   peerDependenciesMeta:


### PR DESCRIPTION
### Description

Declare support for React Native 0.88.

Resolves #2922

### Platforms affected

- [x] Android
- [x] iOS
- [ ] macOS
- [ ] visionOS
- [ ] Windows

### Test plan

```
cd packages/app
node --run test:matrix -- 0.89
```

### Screenshots

| Android | iOS  |
| :-----: | :--: |
| <img width="1080" height="2400" alt="Screenshot-Android-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/58ee8819-6ccc-40d2-a62f-71a6a196620f" /> | <img width="1206" height="2622" alt="Screenshot-iOS-hermes-fabric-concurrent" src="https://github.com/user-attachments/assets/118b9f49-ceb2-4cb6-98cf-cc79020eb953" /> |