### PR TITLE
fix(apple): support Ruby JSON 3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,8 @@ jobs:
       - name: Install Pods
         if: ${{ steps.affected.outputs.ios != '' }}
         run: |
-          pod install --project-directory=ios
+          bundle install
+          bundle exec pod install --project-directory=ios --verbose
         working-directory: template-example
       - name: Build
         if: ${{ steps.affected.outputs.ios != '' }}

--- a/packages/app/ios/test_app.rb
+++ b/packages/app/ios/test_app.rb
@@ -92,7 +92,7 @@ def resources_pod(project_root, platforms, resources)
   File.open(podspec_path, 'w') do |f|
     # Under certain conditions, the file doesn't get written to disk before it
     # is read by CocoaPods.
-    f.write(spec.to_json)
+    f.write(JSON.generate(spec))
     f.fsync
     ObjectSpace.define_finalizer(self, Remover.new(f))
   end
@@ -122,7 +122,7 @@ end
 
 def make_project!(project_root, target_platform, options)
   generate_project = File.join(__dir__, 'app.mjs')
-  options_json = JSON.fast_generate(options.transform_keys { |key| key.to_s.camelize(:lower) })
+  options_json = JSON.generate(options.transform_keys { |key| key.to_s.camelize(:lower) })
   result = `node "#{generate_project}" "#{project_root}" #{target_platform} '#{options_json}'`
   project = JSON.parse(result)
 


### PR DESCRIPTION
### Description

`JSON.fast_generate` was removed in 3.x: https://github.com/ruby/json/releases/tag/v3.0.0

See build failure: https://github.com/microsoft/react-native-test-app/actions/runs/34485411010/job/102898313895?pr=2921

### Platforms affected

- [ ] Android
- [x] iOS
- [x] macOS
- [x] visionOS
- [ ] Windows

### Test plan

n/a